### PR TITLE
Fix header CSS imports

### DIFF
--- a/header.php
+++ b/header.php
@@ -26,15 +26,9 @@ $user = currentUser();
     <!-- Bootstrap 5 CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Font Awesome Icons -->
-
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" integrity="sha512-dN3c8+Gl9FPT0IwwxDRf6b0yYmFjc7Nrg5oWlVm1DrF7kRquYnpHPgSlx2uP9duADy9OLdPzPU1jU5hTBdGdZg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <!-- Gentelella CSS -->
     <link rel="stylesheet" href="https://colorlibhq.github.io/gentelella/build/css/gentelella.min.css">
-
-
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" referrerpolicy="no-referrer" />
-    <!-- Gentelella CSS (Bootstrap 5 based) -->
-    <link rel="stylesheet" href="https://unpkg.com/gentelella@2.0.0/dist/css/gentelella.min.css">
 
     <!-- Custom styles for the CMS (optional) -->
     <style>


### PR DESCRIPTION
## Summary
- remove leftover merge conflict CSS links in `header.php`
- ensure `<head>` imports Bootstrap 5, Font Awesome, and Gentelella once each

## Testing
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b07dccaf548320b3a4afa43b15aa15