### PR TITLE
Include body field when creating content

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -238,12 +238,13 @@ function createTerm(int $taxonomy_id, string $term): int {
  * @param int $content_type_id
  * @param int $user_id
  * @param string $title
+ * @param string|null $body Optional body text
  * @return int
  */
-function createContent(int $content_type_id, int $user_id, string $title): int {
+function createContent(int $content_type_id, int $user_id, string $title, ?string $body = null): int {
     $pdo = getPDO();
-    $stmt = $pdo->prepare('INSERT INTO content (content_type_id, user_id, title, created_at, updated_at) VALUES (?, ?, ?, NOW(), NOW())');
-    $stmt->execute([$content_type_id, $user_id, $title]);
+    $stmt = $pdo->prepare('INSERT INTO content (content_type_id, user_id, title, body, created_at, updated_at) VALUES (?, ?, ?, ?, NOW(), NOW())');
+    $stmt->execute([$content_type_id, $user_id, $title, $body]);
     return (int)$pdo->lastInsertId();
 }
 


### PR DESCRIPTION
## Summary
- Allow `createContent` to receive optional body text and store it in the content table.

## Testing
- `php -l functions.php`
- `php -l add_content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b07dd1d2d48320a2d648e2630198d2