### PR TITLE
Refine content listing handling

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -296,7 +296,7 @@ function setContentTaxonomyTerms(int $content_id, int $taxonomy_id, array $term_
 function getContentList(int $content_type_id): array {
     $pdo = getPDO();
     // Fetch basic content
-    $stmt = $pdo->prepare('SELECT c.id, c.title, c.created_at, u.username FROM content c JOIN users u ON c.user_id = u.id WHERE c.content_type_id = ? ORDER BY c.id DESC');
+    $stmt = $pdo->prepare('SELECT c.id, c.title, c.created_at, u.username AS author_name FROM content c JOIN users u ON c.user_id = u.id WHERE c.content_type_id = ? ORDER BY c.id DESC');
     $stmt->execute([$content_type_id]);
     $contents = $stmt->fetchAll();
     // Preload fields definitions and taxonomy definitions
@@ -305,19 +305,13 @@ function getContentList(int $content_type_id): array {
     // For each content entry, fetch custom values and terms
     foreach ($contents as &$content) {
         // Fetch custom values
-        $cstmt = $pdo->prepare('SELECT cf.name, cv.value FROM custom_values cv JOIN custom_fields cf ON cv.field_id = cf.id WHERE cv.content_id = ?');
+        $cstmt = $pdo->prepare('SELECT cv.field_id, cv.value FROM custom_values cv WHERE cv.content_id = ?');
         $cstmt->execute([$content['id']]);
-        $content['fields'] = [];
-        while ($row = $cstmt->fetch()) {
-            $content['fields'][$row['name']] = $row['value'];
-        }
+        $content['fields'] = $cstmt->fetchAll();
         // Fetch taxonomy assignments
-        $content['taxonomies'] = [];
-        $tstmt = $pdo->prepare('SELECT t.name AS taxonomy_name, tt.term FROM content_taxonomy ct JOIN taxonomies t ON ct.taxonomy_id = t.id JOIN taxonomy_terms tt ON ct.term_id = tt.id WHERE ct.content_id = ?');
+        $tstmt = $pdo->prepare('SELECT ct.taxonomy_id, tt.term AS term_name FROM content_taxonomy ct JOIN taxonomy_terms tt ON ct.term_id = tt.id WHERE ct.content_id = ?');
         $tstmt->execute([$content['id']]);
-        while ($row = $tstmt->fetch()) {
-            $content['taxonomies'][$row['taxonomy_name']][] = $row['term'];
-        }
+        $content['taxonomies'] = $tstmt->fetchAll();
     }
     return $contents;
 }

--- a/list_content.php
+++ b/list_content.php
@@ -26,9 +26,10 @@ if (!$contentType) {
     exit;
 }
 
-// Get custom fields and content list
+// Get custom fields, taxonomies and content list
 $customFields = getCustomFields($typeId);
 $contents = getContentList($typeId);
+$allTaxonomies = getAllTaxonomies();
 
 ?>
 <!DOCTYPE html>
@@ -65,7 +66,7 @@ $contents = getContentList($typeId);
                                             <?php foreach ($customFields as $field): ?>
                                                 <th><?php echo htmlspecialchars($field['name']); ?></th>
                                             <?php endforeach; ?>
-                                            <?php foreach (getAllTaxonomies() as $tax): ?>
+                                            <?php foreach ($allTaxonomies as $tax): ?>
                                                 <th><?php echo htmlspecialchars($tax['name']); ?></th>
                                             <?php endforeach; ?>
                                         </tr>
@@ -89,7 +90,7 @@ $contents = getContentList($typeId);
                                                     ?>
                                                     <td><?php echo htmlspecialchars($fieldValue); ?></td>
                                                 <?php endforeach; ?>
-                                                <?php foreach (getAllTaxonomies() as $tax): ?>
+                                                <?php foreach ($allTaxonomies as $tax): ?>
                                                     <?php
                                                         $termsList = [];
                                                         foreach ($content['taxonomies'] as $assoc) {


### PR DESCRIPTION
## Summary
- Alias author username as `author_name` and return field/taxonomy IDs in `getContentList`
- Cache taxonomy list in `list_content.php` to avoid repeated queries

## Testing
- `php -l functions.php`
- `php -l list_content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b07dd307748320a9b57c3851d23442