### PR TITLE
Expand layout to full width and unify templates

### DIFF
--- a/add_content.php
+++ b/add_content.php
@@ -8,9 +8,9 @@
  * After submitting the form, it saves the content, custom field values, and taxonomy
  * assignments using functions from functions.php.
  */
- 
-require_once 'db.php';
-require_once 'functions.php';
+
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/functions.php';
 
 startSession();
 requireLogin();
@@ -60,92 +60,74 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
+require_once __DIR__ . '/header.php';
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Add Content - <?php echo htmlspecialchars($contentType['name']); ?></title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
-    <!-- Gentelella v2.0 CSS -->
-    <link href="https://colorlibhq.github.io/gentelella/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://colorlibhq.github.io/gentelella/css/custom.min.css" rel="stylesheet">
-</head>
-<body class="nav-md">
-    <div class="container body">
-        <div class="main_container">
-            <div class="right_col" role="main">
-                <div class="page-title">
-                    <div class="title_left">
-                        <h3>Add <?php echo htmlspecialchars($contentType['name']); ?></h3>
-                    </div>
-                </div>
-                <div class="clearfix"></div>
-                <div class="row">
-                    <div class="col-md-12 col-sm-12 ">
-                        <div class="x_panel">
-                            <div class="x_content">
-                                <?php if (!empty($error)): ?>
-                                    <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
-                                <?php endif; ?>
-                                <form method="post">
-                                    <div class="mb-3">
-                                        <label for="title" class="form-label">Title</label>
-                                        <input type="text" id="title" name="title" class="form-control" required>
-                                    </div>
-                                    <div class="mb-3">
-                                        <label for="body" class="form-label">Body</label>
-                                        <textarea id="body" name="body" class="form-control" rows="4"></textarea>
-                                    </div>
-                                    <?php foreach ($customFields as $field): ?>
-                                        <?php
-                                            $inputName = 'field_' . $field['id'];
-                                            $options = $field['options'];
-                                        ?>
-                                        <div class="mb-3">
-                                            <label class="form-label"><?php echo htmlspecialchars($field['name']); ?></label>
-                                            <?php if ($field['field_type'] === 'text'): ?>
-                                                <input type="text" name="<?php echo htmlspecialchars($inputName); ?>" class="form-control">
-                                            <?php elseif ($field['field_type'] === 'textarea'): ?>
-                                                <textarea name="<?php echo htmlspecialchars($inputName); ?>" class="form-control"></textarea>
-                                            <?php elseif ($field['field_type'] === 'number'): ?>
-                                                <input type="number" name="<?php echo htmlspecialchars($inputName); ?>" class="form-control">
-                                            <?php elseif ($field['field_type'] === 'date'): ?>
-                                                <input type="date" name="<?php echo htmlspecialchars($inputName); ?>" class="form-control">
-                                            <?php elseif ($field['field_type'] === 'select'): ?>
-                                                <select name="<?php echo htmlspecialchars($inputName); ?>" class="form-select">
-                                                    <option value="">-- Select --</option>
-                                                    <?php foreach (explode(',', $options) as $opt): ?>
-                                                        <option value="<?php echo htmlspecialchars(trim($opt)); ?>">
-                                                            <?php echo htmlspecialchars(trim($opt)); ?>
-                                                        </option>
-                                                    <?php endforeach; ?>
-                                                </select>
-                                            <?php endif; ?>
-                                        </div>
-                                    <?php endforeach; ?>
-                                    <?php foreach ($allTaxonomies as $taxonomy): ?>
-                                        <div class="mb-3">
-                                            <label class="form-label">Select <?php echo htmlspecialchars($taxonomy['name']); ?></label>
-                                            <?php $terms = getTerms($taxonomy['id']); ?>
-                                            <select name="taxonomy_<?php echo htmlspecialchars($taxonomy['id']); ?>[]" class="form-select" multiple>
-                                                <?php foreach ($terms as $term): ?>
-                                                    <option value="<?php echo htmlspecialchars($term['id']); ?>">
-                                                        <?php echo htmlspecialchars($term['name']); ?>
-                                                    </option>
-                                                <?php endforeach; ?>
-                                            </select>
-                                        </div>
-                                    <?php endforeach; ?>
-                                    <button type="submit" class="btn btn-success">Save</button>
-                                    <a href="dashboard.php" class="btn btn-secondary">Cancel</a>
-                                </form>
-                            </div>
+<div class="container-fluid">
+    <div class="page-title">
+        <div class="title_left">
+            <h3>Add <?php echo htmlspecialchars($contentType['name']); ?></h3>
+        </div>
+    </div>
+    <div class="clearfix"></div>
+    <div class="row">
+        <div class="col-md-12 col-sm-12">
+            <div class="x_panel">
+                <div class="x_content">
+                    <?php if (!empty($error)): ?>
+                        <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
+                    <?php endif; ?>
+                    <form method="post">
+                        <div class="mb-3">
+                            <label for="title" class="form-label">Title</label>
+                            <input type="text" id="title" name="title" class="form-control" required>
                         </div>
-                    </div>
+                        <div class="mb-3">
+                            <label for="body" class="form-label">Body</label>
+                            <textarea id="body" name="body" class="form-control" rows="4"></textarea>
+                        </div>
+                        <?php foreach ($customFields as $field): ?>
+                            <?php
+                                $inputName = 'field_' . $field['id'];
+                                $options = $field['options'];
+                            ?>
+                            <div class="mb-3">
+                                <label class="form-label"><?php echo htmlspecialchars($field['name']); ?></label>
+                                <?php if ($field['field_type'] === 'text'): ?>
+                                    <input type="text" name="<?php echo htmlspecialchars($inputName); ?>" class="form-control">
+                                <?php elseif ($field['field_type'] === 'textarea'): ?>
+                                    <textarea name="<?php echo htmlspecialchars($inputName); ?>" class="form-control"></textarea>
+                                <?php elseif ($field['field_type'] === 'number'): ?>
+                                    <input type="number" name="<?php echo htmlspecialchars($inputName); ?>" class="form-control">
+                                <?php elseif ($field['field_type'] === 'date'): ?>
+                                    <input type="date" name="<?php echo htmlspecialchars($inputName); ?>" class="form-control">
+                                <?php elseif ($field['field_type'] === 'select'): ?>
+                                    <select name="<?php echo htmlspecialchars($inputName); ?>" class="form-select">
+                                        <option value="">-- Select --</option>
+                                        <?php foreach (explode(',', $options) as $opt): ?>
+                                            <option value="<?php echo htmlspecialchars(trim($opt)); ?>"><?php echo htmlspecialchars(trim($opt)); ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                <?php endif; ?>
+                            </div>
+                        <?php endforeach; ?>
+                        <?php foreach ($allTaxonomies as $taxonomy): ?>
+                            <div class="mb-3">
+                                <label class="form-label">Select <?php echo htmlspecialchars($taxonomy['name']); ?></label>
+                                <?php $terms = getTerms($taxonomy['id']); ?>
+                                <select name="taxonomy_<?php echo htmlspecialchars($taxonomy['id']); ?>[]" class="form-select" multiple>
+                                    <?php foreach ($terms as $term): ?>
+                                        <option value="<?php echo htmlspecialchars($term['id']); ?>"><?php echo htmlspecialchars($term['name']); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                        <?php endforeach; ?>
+                        <button type="submit" class="btn btn-success">Save</button>
+                        <a href="dashboard.php" class="btn btn-secondary">Cancel</a>
+                    </form>
                 </div>
             </div>
         </div>
     </div>
-</body>
-</html>
+</div>
+<?php require_once __DIR__ . '/footer.php'; ?>
+

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -13,7 +13,12 @@ html , body{
  
 .full-height{
  height:100%;
- }
+}
+
+/* Ensure the main container spans the full width of the viewport */
+.container.body {
+    max-width: 100%;
+}
 
 .daterangepicker .ranges li {
     color: #73879C

--- a/custom_fields.php
+++ b/custom_fields.php
@@ -1,12 +1,9 @@
 <?php
 /**
  * Gestão de campos personalizados para um tipo de conteúdo.
- *
- * Esta página lista os campos existentes associados a um tipo de conteúdo
- * selecionado e permite adicionar novos campos definindo o tipo de campo e
- * opções (para selects). Requer autenticação.
  */
-require_once 'functions.php';
+
+require_once __DIR__ . '/functions.php';
 startSession();
 requireLogin();
 
@@ -35,80 +32,52 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 // Recupera os campos existentes
 $fields = getCustomFields($typeId);
+
+require_once __DIR__ . '/header.php';
 ?>
-<!DOCTYPE html>
-<html lang="pt">
-<head>
-    <meta charset="UTF-8">
-    <title>Campos personalizados - <?php echo htmlspecialchars($type['name']); ?></title>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/gentelella@2.0.0/build/css/custom.min.css" rel="stylesheet">
-</head>
-<body class="nav-md">
-<div class="container body">
-  <div class="main_container">
-    <div class="top_nav">
-      <div class="nav_menu">
-        <nav class="" role="navigation">
-          <ul class="navbar-nav float-end">
-            <li class="nav-item">
-              <a class="nav-link" href="dashboard.php">Painel</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="logout.php">Terminar sessão</a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </div>
-    <div class="right_col" role="main">
-      <div class="container-fluid">
-        <h2 class="mt-3">Campos personalizados para <?php echo htmlspecialchars($type['name']); ?></h2>
-        <?php if ($error): ?>
-          <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
-        <?php endif; ?>
-        <table class="table table-striped">
-          <thead>
+<div class="container-fluid">
+    <h2 class="mt-3">Campos personalizados para <?php echo htmlspecialchars($type['name']); ?></h2>
+    <?php if ($error): ?>
+        <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
+    <?php endif; ?>
+    <table class="table table-striped">
+        <thead>
             <tr><th>Nome</th><th>Tipo</th><th>Opções</th></tr>
-          </thead>
-          <tbody>
-          <?php foreach ($fields as $field): ?>
+        </thead>
+        <tbody>
+        <?php foreach ($fields as $field): ?>
             <tr>
-              <td><?php echo htmlspecialchars($field['name']); ?></td>
-              <td><?php echo htmlspecialchars($field['field_type']); ?></td>
-              <td><?php echo htmlspecialchars($field['options']); ?></td>
+                <td><?php echo htmlspecialchars($field['name']); ?></td>
+                <td><?php echo htmlspecialchars($field['field_type']); ?></td>
+                <td><?php echo htmlspecialchars($field['options']); ?></td>
             </tr>
-          <?php endforeach; ?>
-          </tbody>
-        </table>
-        <div class="card p-3 mt-4">
-          <h5>Adicionar novo campo</h5>
-          <form method="post" action="">
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <div class="card p-3 mt-4">
+        <h5>Adicionar novo campo</h5>
+        <form method="post" action="">
             <div class="mb-3">
-              <label class="form-label" for="name">Nome</label>
-              <input type="text" class="form-control" id="name" name="name" required>
+                <label class="form-label" for="name">Nome</label>
+                <input type="text" class="form-control" id="name" name="name" required>
             </div>
             <div class="mb-3">
-              <label class="form-label" for="field_type">Tipo</label>
-              <select class="form-select" id="field_type" name="field_type" required>
-                <option value="text">Texto</option>
-                <option value="textarea">Textarea</option>
-                <option value="number">Número</option>
-                <option value="date">Data</option>
-                <option value="select">Select (opções separadas por vírgula)</option>
-              </select>
+                <label class="form-label" for="field_type">Tipo</label>
+                <select class="form-select" id="field_type" name="field_type" required>
+                    <option value="text">Texto</option>
+                    <option value="textarea">Textarea</option>
+                    <option value="number">Número</option>
+                    <option value="date">Data</option>
+                    <option value="select">Select (opções separadas por vírgula)</option>
+                </select>
             </div>
             <div class="mb-3">
-              <label class="form-label" for="options">Opções (apenas para Select)</label>
-              <input type="text" class="form-control" id="options" name="options" placeholder="opção1,opção2,opção3">
+                <label class="form-label" for="options">Opções (apenas para Select)</label>
+                <input type="text" class="form-control" id="options" name="options" placeholder="opção1,opção2,opção3">
             </div>
             <button type="submit" class="btn btn-primary">Adicionar</button>
-          </form>
-        </div>
-      </div>
+        </form>
     </div>
-  </div>
 </div>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.2.0/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+<?php require_once __DIR__ . '/footer.php'; ?>
+

--- a/list_content.php
+++ b/list_content.php
@@ -6,8 +6,8 @@
  * creation date, and values of custom fields along with taxonomy terms for each entry.
  */
 
-require_once 'db.php';
-require_once 'functions.php';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/functions.php';
 
 startSession();
 requireLogin();
@@ -31,87 +31,73 @@ $customFields = getCustomFields($typeId);
 $contents = getContentList($typeId);
 $allTaxonomies = getAllTaxonomies();
 
+require_once __DIR__ . '/header.php';
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>List <?php echo htmlspecialchars($contentType['name']); ?></title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
-    <!-- Gentelella CSS -->
-    <link href="https://colorlibhq.github.io/gentelella/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://colorlibhq.github.io/gentelella/css/custom.min.css" rel="stylesheet">
-</head>
-<body class="nav-md">
-    <div class="container body">
-        <div class="main_container">
-            <div class="right_col" role="main">
-                <div class="page-title">
-                    <div class="title_left">
-                        <h3><?php echo htmlspecialchars($contentType['name']); ?> List</h3>
-                    </div>
-                </div>
-                <div class="clearfix"></div>
-                <div class="row">
-                    <div class="col-md-12 col-sm-12 ">
-                        <div class="x_panel">
-                            <div class="x_content">
-                                <a href="add_content.php?type_id=<?php echo $typeId; ?>" class="btn btn-success mb-3">Add New</a>
-                                <table class="table table-striped">
-                                    <thead>
-                                        <tr>
-                                            <th>Title</th>
-                                            <th>Author</th>
-                                            <th>Date</th>
-                                            <?php foreach ($customFields as $field): ?>
-                                                <th><?php echo htmlspecialchars($field['name']); ?></th>
-                                            <?php endforeach; ?>
-                                            <?php foreach ($allTaxonomies as $tax): ?>
-                                                <th><?php echo htmlspecialchars($tax['name']); ?></th>
-                                            <?php endforeach; ?>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <?php foreach ($contents as $content): ?>
-                                            <tr>
-                                                <td><?php echo htmlspecialchars($content['title']); ?></td>
-                                                <td><?php echo htmlspecialchars($content['author_name']); ?></td>
-                                                <td><?php echo htmlspecialchars($content['created_at']); ?></td>
-                                                <?php foreach ($customFields as $field): ?>
-                                                    <?php
-                                                        $fieldId = $field['id'];
-                                                        $fieldValue = '';
-                                                        foreach ($content['fields'] as $cv) {
-                                                            if ($cv['field_id'] == $fieldId) {
-                                                                $fieldValue = $cv['value'];
-                                                                break;
-                                                            }
-                                                        }
-                                                    ?>
-                                                    <td><?php echo htmlspecialchars($fieldValue); ?></td>
-                                                <?php endforeach; ?>
-                                                <?php foreach ($allTaxonomies as $tax): ?>
-                                                    <?php
-                                                        $termsList = [];
-                                                        foreach ($content['taxonomies'] as $assoc) {
-                                                            if ($assoc['taxonomy_id'] == $tax['id']) {
-                                                                $termsList[] = $assoc['term_name'];
-                                                            }
-                                                        }
-                                                    ?>
-                                                    <td><?php echo htmlspecialchars(implode(', ', $termsList)); ?></td>
-                                                <?php endforeach; ?>
-                                            </tr>
-                                        <?php endforeach; ?>
-                                    </tbody>
-                                </table>
-                                <a href="dashboard.php" class="btn btn-secondary">Back</a>
-                            </div>
-                        </div>
-                    </div>
+<div class="container-fluid">
+    <div class="page-title">
+        <div class="title_left">
+            <h3><?php echo htmlspecialchars($contentType['name']); ?> List</h3>
+        </div>
+    </div>
+    <div class="clearfix"></div>
+    <div class="row">
+        <div class="col-md-12 col-sm-12">
+            <div class="x_panel">
+                <div class="x_content">
+                    <a href="add_content.php?type_id=<?php echo $typeId; ?>" class="btn btn-success mb-3">Add New</a>
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th>Title</th>
+                                <th>Author</th>
+                                <th>Date</th>
+                                <?php foreach ($customFields as $field): ?>
+                                    <th><?php echo htmlspecialchars($field['name']); ?></th>
+                                <?php endforeach; ?>
+                                <?php foreach ($allTaxonomies as $tax): ?>
+                                    <th><?php echo htmlspecialchars($tax['name']); ?></th>
+                                <?php endforeach; ?>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($contents as $content): ?>
+                                <tr>
+                                    <td><?php echo htmlspecialchars($content['title']); ?></td>
+                                    <td><?php echo htmlspecialchars($content['author_name']); ?></td>
+                                    <td><?php echo htmlspecialchars($content['created_at']); ?></td>
+                                    <?php foreach ($customFields as $field): ?>
+                                        <?php
+                                            $fieldId = $field['id'];
+                                            $fieldValue = '';
+                                            foreach ($content['fields'] as $cv) {
+                                                if ($cv['field_id'] == $fieldId) {
+                                                    $fieldValue = $cv['value'];
+                                                    break;
+                                                }
+                                            }
+                                        ?>
+                                        <td><?php echo htmlspecialchars($fieldValue); ?></td>
+                                    <?php endforeach; ?>
+                                    <?php foreach ($allTaxonomies as $tax): ?>
+                                        <?php
+                                            $termsList = [];
+                                            foreach ($content['taxonomies'] as $assoc) {
+                                                if ($assoc['taxonomy_id'] == $tax['id']) {
+                                                    $termsList[] = $assoc['term_name'];
+                                                }
+                                            }
+                                        ?>
+                                        <td><?php echo htmlspecialchars(implode(', ', $termsList)); ?></td>
+                                    <?php endforeach; ?>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                    <a href="dashboard.php" class="btn btn-secondary">Back</a>
                 </div>
             </div>
         </div>
     </div>
-</body>
-</html>
+</div>
+<?php require_once __DIR__ . '/footer.php'; ?>
+

--- a/taxonomies.php
+++ b/taxonomies.php
@@ -9,7 +9,7 @@
  * existentes e um formulário para criar uma nova.
  */
 
-require_once 'functions.php';
+require_once __DIR__ . '/functions.php';
 startSession();
 requireLogin();
 
@@ -17,7 +17,6 @@ $taxonomyId = isset($_GET['taxonomy_id']) ? (int)$_GET['taxonomy_id'] : 0;
 $taxonomy = null;
 if ($taxonomyId) {
     // Gestão de termos para uma taxonomia específica
-    // Processa criação de novo termo
     if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['term_name'])) {
         $termName = trim($_POST['term_name']);
         if ($termName !== '') {
@@ -26,8 +25,6 @@ if ($taxonomyId) {
             exit;
         }
     }
-    // Recupera a taxonomia e os termos associados
-    $taxonomy = null;
     $taxonomies = getTaxonomies();
     foreach ($taxonomies as $t) {
         if ($t['id'] == $taxonomyId) { $taxonomy = $t; break; }
@@ -38,7 +35,6 @@ if ($taxonomyId) {
     }
     $terms = getTerms($taxonomyId);
 } else {
-    // Criação de nova taxonomia
     if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['name'])) {
         $name = trim($_POST['name']);
         if ($name !== '') {
@@ -49,86 +45,56 @@ if ($taxonomyId) {
     }
     $taxonomies = getTaxonomies();
 }
+
+require_once __DIR__ . '/header.php';
 ?>
-<!DOCTYPE html>
-<html lang="pt">
-<head>
-    <meta charset="UTF-8">
-    <title>Taxonomias</title>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/gentelella@2.0.0/build/css/custom.min.css" rel="stylesheet">
-</head>
-<body class="nav-md">
-<div class="container body">
-  <div class="main_container">
-    <div class="top_nav">
-      <div class="nav_menu">
-        <nav class="" role="navigation">
-          <ul class="navbar-nav float-end">
-            <li class="nav-item">
-              <a class="nav-link" href="dashboard.php">Painel</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="logout.php">Terminar sessão</a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </div>
-    <div class="right_col" role="main">
-      <div class="container-fluid">
-        <?php if ($taxonomyId && $taxonomy): ?>
-          <h2 class="mt-3">Termos de <?php echo htmlspecialchars($taxonomy['name']); ?></h2>
-          <table class="table table-striped">
-            <thead><tr><th>Nome</th></tr></thead>
-            <tbody>
-            <?php foreach ($terms as $term): ?>
-              <tr>
-                <td><?php echo htmlspecialchars($term['name']); ?></td>
-              </tr>
-            <?php endforeach; ?>
-            </tbody>
-          </table>
-          <div class="card p-3 mt-4">
-            <h5>Adicionar novo termo</h5>
-            <form method="post" action="">
-              <div class="mb-3">
+<div class="container-fluid">
+<?php if ($taxonomyId && $taxonomy): ?>
+    <h2 class="mt-3">Termos de <?php echo htmlspecialchars($taxonomy['name']); ?></h2>
+    <table class="table table-striped">
+        <thead><tr><th>Nome</th></tr></thead>
+        <tbody>
+        <?php foreach ($terms as $term): ?>
+            <tr><td><?php echo htmlspecialchars($term['name']); ?></td></tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <div class="card p-3 mt-4">
+        <h5>Adicionar novo termo</h5>
+        <form method="post" action="">
+            <div class="mb-3">
                 <label class="form-label" for="term_name">Nome</label>
                 <input type="text" class="form-control" id="term_name" name="term_name" required>
-              </div>
-              <button type="submit" class="btn btn-primary">Adicionar</button>
-              <a href="taxonomies.php" class="btn btn-secondary">Voltar</a>
-            </form>
-          </div>
-        <?php else: ?>
-          <h2 class="mt-3">Taxonomias</h2>
-          <table class="table table-striped">
-            <thead><tr><th>Nome</th><th>Ações</th></tr></thead>
-            <tbody>
-            <?php foreach ($taxonomies as $tax): ?>
-              <tr>
+            </div>
+            <button type="submit" class="btn btn-primary">Adicionar</button>
+            <a href="taxonomies.php" class="btn btn-secondary">Voltar</a>
+        </form>
+    </div>
+<?php else: ?>
+    <h2 class="mt-3">Taxonomias</h2>
+    <table class="table table-striped">
+        <thead><tr><th>Nome</th><th>Ações</th></tr></thead>
+        <tbody>
+        <?php foreach ($taxonomies as $tax): ?>
+            <tr>
                 <td><?php echo htmlspecialchars($tax['name']); ?></td>
                 <td><a href="taxonomies.php?taxonomy_id=<?php echo $tax['id']; ?>">Gerir termos</a></td>
-              </tr>
-            <?php endforeach; ?>
-            </tbody>
-          </table>
-          <div class="card p-3 mt-4">
-            <h5>Criar nova taxonomia</h5>
-            <form method="post" action="">
-              <div class="mb-3">
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <div class="card p-3 mt-4">
+        <h5>Criar nova taxonomia</h5>
+        <form method="post" action="">
+            <div class="mb-3">
                 <label class="form-label" for="name">Nome</label>
                 <input type="text" class="form-control" id="name" name="name" required>
-              </div>
-              <button type="submit" class="btn btn-primary">Criar</button>
-              <a href="dashboard.php" class="btn btn-secondary">Voltar</a>
-            </form>
-          </div>
-        <?php endif; ?>
-      </div>
+            </div>
+            <button type="submit" class="btn btn-primary">Criar</button>
+            <a href="dashboard.php" class="btn btn-secondary">Voltar</a>
+        </form>
     </div>
-  </div>
+<?php endif; ?>
 </div>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.2.0/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+<?php require_once __DIR__ . '/footer.php'; ?>
+


### PR DESCRIPTION
## Summary
- Ensure main container spans the full viewport width
- Use common header/footer and full-width container across content management pages

## Testing
- `php -l add_content.php`
- `php -l list_content.php`
- `php -l custom_fields.php`
- `php -l taxonomies.php`
- `php -l header.php`
- `php -l footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0867fc63c832088ca04bf3b286788