### PR TITLE
Add DataTables and template-based login

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -323,3 +323,9 @@ function updtCliParam(cliente, params) {
         }
     });
 }
+
+$(document).ready(function() {
+    $('table.datatable').DataTable({
+        responsive: true
+    });
+});

--- a/content_types.php
+++ b/content_types.php
@@ -38,7 +38,7 @@ require_once __DIR__ . '/header.php';
     <?php if ($error): ?>
         <div class="alert alert-danger"> <?php echo htmlspecialchars($error); ?> </div>
     <?php endif; ?>
-    <table class="table table-striped">
+    <table class="table table-striped datatable">
         <thead><tr><th>Nome</th><th>Ações</th></tr></thead>
         <tbody>
         <?php foreach ($types as $type): ?>

--- a/custom_fields.php
+++ b/custom_fields.php
@@ -40,7 +40,7 @@ require_once __DIR__ . '/header.php';
     <?php if ($error): ?>
         <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
     <?php endif; ?>
-    <table class="table table-striped">
+    <table class="table table-striped datatable">
         <thead>
             <tr><th>Nome</th><th>Tipo</th><th>Opções</th></tr>
         </thead>

--- a/dashboard.php
+++ b/dashboard.php
@@ -27,7 +27,7 @@ require_once __DIR__ . '/header.php';
 <!-- Conteúdo da página -->
 <div class="container-fluid">
     <h2 class="mt-3">Tipos de Conteúdo</h2>
-    <table class="table table-striped">
+    <table class="table table-striped datatable">
         <thead>
             <tr><th>Nome</th><th>Ações</th></tr>
         </thead>
@@ -55,7 +55,7 @@ require_once __DIR__ . '/header.php';
         </form>
     </div>
     <h2 class="mt-5">Taxonomias</h2>
-    <table class="table table-striped">
+    <table class="table table-striped datatable">
         <thead>
             <tr><th>Nome</th><th>Ações</th></tr>
         </thead>

--- a/footer.php
+++ b/footer.php
@@ -12,6 +12,10 @@
 
 <script src="vendors/jquery/dist/jquery.min.js"></script>
 <script src="vendors/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+<script src="vendors/datatables.net/js/dataTables.min.js"></script>
+<script src="vendors/datatables.net-bs5/js/dataTables.bootstrap5.min.js"></script>
+<script src="vendors/datatables.net-responsive/js/dataTables.responsive.min.js"></script>
+<script src="vendors/datatables.net-responsive-bs5/js/responsive.bootstrap5.min.js"></script>
 <script src="assets/js/custom.js"></script>
 
 </body>

--- a/header.php
+++ b/header.php
@@ -25,6 +25,8 @@ $user = currentUser();
     <title>CMS</title>
 <link rel="stylesheet" href="vendors/bootstrap/dist/css/bootstrap.min.css">
 <link rel="stylesheet" href="vendors/font-awesome/css/font-awesome.min.css">
+<link rel="stylesheet" href="vendors/datatables.net-bs5/css/dataTables.bootstrap5.min.css">
+<link rel="stylesheet" href="vendors/datatables.net-responsive-bs5/css/responsive.bootstrap5.min.css">
 <link rel="stylesheet" href="assets/css/custom.css">
 
 

--- a/list_content.php
+++ b/list_content.php
@@ -45,7 +45,7 @@ require_once __DIR__ . '/header.php';
             <div class="x_panel">
                 <div class="x_content">
                     <a href="add_content.php?type_id=<?php echo $typeId; ?>" class="btn btn-success mb-3">Add New</a>
-                    <table class="table table-striped">
+                    <table class="table table-striped datatable">
                         <thead>
                             <tr>
                                 <th>Title</th>

--- a/login.php
+++ b/login.php
@@ -33,39 +33,88 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <html lang="pt">
 <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>CMS – Login</title>
-    <!-- Bootstrap and Gentelella CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ENjdO4Dr2bkBIFxQpeo3xXbl4ClbBZ9OezHET57ikQRAxQF93FhjV0z9WTR2xmQf" crossorigin="anonymous">
+    <link rel="stylesheet" href="vendors/bootstrap/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="vendors/@fortawesome/fontawesome-free/css/all.min.css">
     <link rel="stylesheet" href="https://colorlibhq.github.io/gentelella/build/css/gentelella.min.css">
+    <style>
+      .login-bg {
+        background: linear-gradient(135deg, #2A3F54 0%, #34495e 100%);
+        min-height: 100vh;
+      }
+      .login-input-group .form-control,
+      .login-input-group .input-group-text,
+      .login-input-group .btn {
+        height: 38px;
+        line-height: 1.5;
+      }
+      .login-input-group .form-control {
+        border-radius: 0;
+      }
+      .login-input-group .input-group-text {
+        border-radius: 0.375rem 0 0 0.375rem;
+      }
+      .login-input-group .btn {
+        border-radius: 0 0.375rem 0.375rem 0;
+        border-color: rgb(222, 226, 230) !important;
+      }
+      .login-input-group .form-control:focus {
+        box-shadow: none;
+        border-color: #86b7fe;
+      }
+      .login-input-group .form-control::placeholder {
+        padding-left: 8px;
+      }
+    </style>
 </head>
-<body class="login">
-    <div class="login_wrapper">
-        <section class="login_content">
-            <form method="post" action="">
-                <h1>Entrar no CMS</h1>
-                <?php if ($error): ?>
-                    <div class="alert alert-danger" role="alert">
-                        <?php echo htmlspecialchars($error); ?>
+<body class="login-bg">
+    <div class="container-fluid d-flex align-items-center justify-content-center min-vh-100">
+        <div class="row justify-content-center w-100">
+            <div class="col-xl-4 col-lg-5 col-md-6 col-sm-8 col-10">
+                <div class="card shadow-lg border-0">
+                    <div class="card-body p-5">
+                        <div class="text-center mb-4">
+                            <h3 class="mb-0 fw-bold text-dark">CMS</h3>
+                            <p class="text-muted">Introduza as suas credenciais</p>
+                        </div>
+                        <?php if ($error): ?>
+                            <div class="alert alert-danger" role="alert">
+                                <?php echo htmlspecialchars($error); ?>
+                            </div>
+                        <?php endif; ?>
+                        <form method="post" action="">
+                            <div class="mb-3">
+                                <label for="username" class="form-label text-muted">Utilizador</label>
+                                <div class="input-group login-input-group">
+                                    <span class="input-group-text bg-light border-end-0">
+                                        <i class="fas fa-user text-muted"></i>
+                                    </span>
+                                    <input type="text" name="username" id="username" class="form-control border-start-0 ps-0" placeholder="Utilizador" required autofocus>
+                                </div>
+                            </div>
+                            <div class="mb-3">
+                                <label for="password" class="form-label text-muted">Palavra‑passe</label>
+                                <div class="input-group login-input-group">
+                                    <span class="input-group-text bg-light border-end-0">
+                                        <i class="fas fa-lock text-muted"></i>
+                                    </span>
+                                    <input type="password" name="password" id="password" class="form-control border-start-0 ps-0" placeholder="Palavra‑passe" required>
+                                </div>
+                            </div>
+                            <div class="d-grid mb-3">
+                                <button type="submit" class="btn btn-primary btn-lg">
+                                    <i class="fas fa-sign-in-alt me-2"></i>Entrar
+                                </button>
+                            </div>
+                        </form>
                     </div>
-                <?php endif; ?>
-                <div class="mb-3">
-                    <input type="text" name="username" class="form-control" placeholder="Utilizador" required autofocus>
                 </div>
-                <div class="mb-3">
-                    <input type="password" name="password" class="form-control" placeholder="Palavra‑passe" required>
-                </div>
-                <div>
-                    <button type="submit" class="btn btn-primary">Entrar</button>
-                </div>
-                <div class="clearfix"></div>
-            </form>
-        </section>
+            </div>
+        </div>
     </div>
-    <!-- Bootstrap JS -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-QT8V3PQR9on7WZzscCvtAHvjNa3Wxj4Rtx6ATLv3b29btaLGGkpqCj1BEcLFcVVU" crossorigin="anonymous"></script>
-    <!-- Gentelella JS -->
+    <script src="vendors/jquery/dist/jquery.min.js"></script>
+    <script src="vendors/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://colorlibhq.github.io/gentelella/build/js/gentelella.min.js"></script>
 </body>
 </html>

--- a/taxonomies.php
+++ b/taxonomies.php
@@ -51,7 +51,7 @@ require_once __DIR__ . '/header.php';
 <div class="container-fluid">
 <?php if ($taxonomyId && $taxonomy): ?>
     <h2 class="mt-3">Termos de <?php echo htmlspecialchars($taxonomy['name']); ?></h2>
-    <table class="table table-striped">
+    <table class="table table-striped datatable">
         <thead><tr><th>Nome</th></tr></thead>
         <tbody>
         <?php foreach ($terms as $term): ?>
@@ -72,7 +72,7 @@ require_once __DIR__ . '/header.php';
     </div>
 <?php else: ?>
     <h2 class="mt-3">Taxonomias</h2>
-    <table class="table table-striped">
+    <table class="table table-striped datatable">
         <thead><tr><th>Nome</th><th>Ações</th></tr></thead>
         <tbody>
         <?php foreach ($taxonomies as $tax): ?>


### PR DESCRIPTION
## Summary
- enable dynamic tables with DataTables across CMS pages
- redesign login screen to match template style

## Testing
- `php -l header.php`
- `php -l footer.php`
- `php -l content_types.php`
- `php -l list_content.php`
- `php -l custom_fields.php`
- `php -l dashboard.php`
- `php -l taxonomies.php`
- `php -l login.php`


------
https://chatgpt.com/codex/tasks/task_e_68b088b9d9548320a5bde7aeb3399e59