### PR TITLE
Add label support to CMS entities

### DIFF
--- a/add_content.php
+++ b/add_content.php
@@ -65,7 +65,7 @@ require_once __DIR__ . '/header.php';
 <div class="container-fluid">
     <div class="page-title">
         <div class="title_left">
-            <h3>Add <?php echo htmlspecialchars($contentType['name']); ?></h3>
+            <h3>Add <?php echo htmlspecialchars($contentType['label']); ?></h3>
         </div>
     </div>
     <div class="clearfix"></div>
@@ -88,20 +88,21 @@ require_once __DIR__ . '/header.php';
                         <?php foreach ($customFields as $field): ?>
                             <?php
                                 $inputName = 'field_' . $field['id'];
-                                $options = $field['options'];
+                                $options   = $field['options'];
+                                $isRequired = $field['required'] ? 'required' : '';
                             ?>
                             <div class="mb-3">
-                                <label class="form-label"><?php echo htmlspecialchars($field['name']); ?></label>
-                                <?php if ($field['field_type'] === 'text'): ?>
-                                    <input type="text" name="<?php echo htmlspecialchars($inputName); ?>" class="form-control">
-                                <?php elseif ($field['field_type'] === 'textarea'): ?>
-                                    <textarea name="<?php echo htmlspecialchars($inputName); ?>" class="form-control"></textarea>
-                                <?php elseif ($field['field_type'] === 'number'): ?>
-                                    <input type="number" name="<?php echo htmlspecialchars($inputName); ?>" class="form-control">
-                                <?php elseif ($field['field_type'] === 'date'): ?>
-                                    <input type="date" name="<?php echo htmlspecialchars($inputName); ?>" class="form-control">
-                                <?php elseif ($field['field_type'] === 'select'): ?>
-                                    <select name="<?php echo htmlspecialchars($inputName); ?>" class="form-select">
+                                <label class="form-label"><?php echo htmlspecialchars($field['label']); ?></label>
+                                <?php if ($field['type'] === 'text'): ?>
+                                    <input type="text" name="<?php echo htmlspecialchars($inputName); ?>" class="form-control" <?php echo $isRequired; ?>>
+                                <?php elseif ($field['type'] === 'textarea'): ?>
+                                    <textarea name="<?php echo htmlspecialchars($inputName); ?>" class="form-control" <?php echo $isRequired; ?>></textarea>
+                                <?php elseif ($field['type'] === 'number'): ?>
+                                    <input type="number" name="<?php echo htmlspecialchars($inputName); ?>" class="form-control" <?php echo $isRequired; ?>>
+                                <?php elseif ($field['type'] === 'date'): ?>
+                                    <input type="date" name="<?php echo htmlspecialchars($inputName); ?>" class="form-control" <?php echo $isRequired; ?>>
+                                <?php elseif ($field['type'] === 'select'): ?>
+                                    <select name="<?php echo htmlspecialchars($inputName); ?>" class="form-select" <?php echo $isRequired; ?>>
                                         <option value="">-- Select --</option>
                                         <?php foreach (explode(',', $options) as $opt): ?>
                                             <option value="<?php echo htmlspecialchars(trim($opt)); ?>"><?php echo htmlspecialchars(trim($opt)); ?></option>
@@ -112,7 +113,7 @@ require_once __DIR__ . '/header.php';
                         <?php endforeach; ?>
                         <?php foreach ($allTaxonomies as $taxonomy): ?>
                             <div class="mb-3">
-                                <label class="form-label">Select <?php echo htmlspecialchars($taxonomy['name']); ?></label>
+                                <label class="form-label">Select <?php echo htmlspecialchars($taxonomy['label']); ?></label>
                                 <?php $terms = getTerms($taxonomy['id']); ?>
                                 <select name="taxonomy_<?php echo htmlspecialchars($taxonomy['id']); ?>[]" class="form-select" multiple>
                                     <?php foreach ($terms as $term): ?>

--- a/content_types.php
+++ b/content_types.php
@@ -15,13 +15,14 @@ requireLogin();
 // Tratamento da submissão do formulário para criar um novo tipo
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $name = isset($_POST['name']) ? trim($_POST['name']) : '';
-    if ($name !== '') {
-        createContentType($name);
+    $name  = isset($_POST['name']) ? trim($_POST['name']) : '';
+    $label = isset($_POST['label']) ? trim($_POST['label']) : '';
+    if ($name !== '' && $label !== '') {
+        createContentType($name, $label);
         header('Location: content_types.php');
         exit;
     } else {
-        $error = 'O nome é obrigatório.';
+        $error = 'Nome e rótulo são obrigatórios.';
     }
 }
 
@@ -39,11 +40,12 @@ require_once __DIR__ . '/header.php';
         <div class="alert alert-danger"> <?php echo htmlspecialchars($error); ?> </div>
     <?php endif; ?>
     <table class="table table-striped datatable">
-        <thead><tr><th>Nome</th><th>Ações</th></tr></thead>
+        <thead><tr><th>Slug</th><th>Rótulo</th><th>Ações</th></tr></thead>
         <tbody>
         <?php foreach ($types as $type): ?>
             <tr>
                 <td><?php echo htmlspecialchars($type['name']); ?></td>
+                <td><?php echo htmlspecialchars($type['label']); ?></td>
                 <td>
                     <a href="custom_fields.php?type_id=<?php echo $type['id']; ?>">Campos</a> |
                     <a href="add_content.php?type_id=<?php echo $type['id']; ?>">Adicionar</a> |
@@ -57,8 +59,12 @@ require_once __DIR__ . '/header.php';
         <h5>Criar novo tipo de conteúdo</h5>
         <form method="post" action="">
             <div class="mb-3">
-                <label class="form-label" for="name">Nome</label>
+                <label class="form-label" for="name">Slug</label>
                 <input type="text" class="form-control" id="name" name="name" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="label">Rótulo</label>
+                <input type="text" class="form-control" id="label" name="label" required>
             </div>
             <button type="submit" class="btn btn-primary">Criar</button>
         </form>

--- a/custom_fields.php
+++ b/custom_fields.php
@@ -18,15 +18,17 @@ if (!$type) {
 // Processa submissão do formulário para criar um novo campo
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $name = isset($_POST['name']) ? trim($_POST['name']) : '';
+    $name     = isset($_POST['name']) ? trim($_POST['name']) : '';
+    $label    = isset($_POST['label']) ? trim($_POST['label']) : '';
     $fieldType = isset($_POST['field_type']) ? trim($_POST['field_type']) : '';
-    $options = isset($_POST['options']) ? trim($_POST['options']) : null;
-    if ($name !== '' && $fieldType !== '') {
-        createCustomField($typeId, $name, $fieldType, $options);
+    $options  = isset($_POST['options']) ? trim($_POST['options']) : '';
+    $required = isset($_POST['required']);
+    if ($name !== '' && $label !== '' && $fieldType !== '') {
+        createCustomField($typeId, $name, $label, $fieldType, $options, $required);
         header('Location: custom_fields.php?type_id=' . $typeId);
         exit;
     } else {
-        $error = 'Nome e tipo são obrigatórios.';
+        $error = 'Nome, rótulo e tipo são obrigatórios.';
     }
 }
 
@@ -36,20 +38,22 @@ $fields = getCustomFields($typeId);
 require_once __DIR__ . '/header.php';
 ?>
 <div class="container-fluid">
-    <h2 class="mt-3">Campos personalizados para <?php echo htmlspecialchars($type['name']); ?></h2>
+    <h2 class="mt-3">Campos personalizados para <?php echo htmlspecialchars($type['label']); ?></h2>
     <?php if ($error): ?>
         <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
     <?php endif; ?>
     <table class="table table-striped datatable">
         <thead>
-            <tr><th>Nome</th><th>Tipo</th><th>Opções</th></tr>
+            <tr><th>Slug</th><th>Rótulo</th><th>Tipo</th><th>Opções</th><th>Obrigatório</th></tr>
         </thead>
         <tbody>
         <?php foreach ($fields as $field): ?>
             <tr>
                 <td><?php echo htmlspecialchars($field['name']); ?></td>
-                <td><?php echo htmlspecialchars($field['field_type']); ?></td>
+                <td><?php echo htmlspecialchars($field['label']); ?></td>
+                <td><?php echo htmlspecialchars($field['type']); ?></td>
                 <td><?php echo htmlspecialchars($field['options']); ?></td>
+                <td><?php echo $field['required'] ? 'Sim' : 'Não'; ?></td>
             </tr>
         <?php endforeach; ?>
         </tbody>
@@ -58,8 +62,12 @@ require_once __DIR__ . '/header.php';
         <h5>Adicionar novo campo</h5>
         <form method="post" action="">
             <div class="mb-3">
-                <label class="form-label" for="name">Nome</label>
+                <label class="form-label" for="name">Slug</label>
                 <input type="text" class="form-control" id="name" name="name" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="label">Rótulo</label>
+                <input type="text" class="form-control" id="label" name="label" required>
             </div>
             <div class="mb-3">
                 <label class="form-label" for="field_type">Tipo</label>
@@ -74,6 +82,10 @@ require_once __DIR__ . '/header.php';
             <div class="mb-3">
                 <label class="form-label" for="options">Opções (apenas para Select)</label>
                 <input type="text" class="form-control" id="options" name="options" placeholder="opção1,opção2,opção3">
+            </div>
+            <div class="form-check mb-3">
+                <input class="form-check-input" type="checkbox" id="required" name="required">
+                <label class="form-check-label" for="required">Obrigatório</label>
             </div>
             <button type="submit" class="btn btn-primary">Adicionar</button>
         </form>

--- a/dashboard.php
+++ b/dashboard.php
@@ -29,12 +29,13 @@ require_once __DIR__ . '/header.php';
     <h2 class="mt-3">Tipos de Conteúdo</h2>
     <table class="table table-striped datatable">
         <thead>
-            <tr><th>Nome</th><th>Ações</th></tr>
+            <tr><th>Slug</th><th>Rótulo</th><th>Ações</th></tr>
         </thead>
         <tbody>
         <?php foreach ($types as $type): ?>
             <tr>
                 <td><?php echo htmlspecialchars($type['name']); ?></td>
+                <td><?php echo htmlspecialchars($type['label']); ?></td>
                 <td>
                     <a href="custom_fields.php?type_id=<?php echo $type['id']; ?>">Campos</a> |
                     <a href="add_content.php?type_id=<?php echo $type['id']; ?>">Adicionar</a> |
@@ -48,8 +49,12 @@ require_once __DIR__ . '/header.php';
         <h5>Criar novo tipo de conteúdo</h5>
         <form method="post" action="content_types.php">
             <div class="mb-3">
-                <label class="form-label" for="name">Nome</label>
+                <label class="form-label" for="name">Slug</label>
                 <input type="text" class="form-control" id="name" name="name" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="label">Rótulo</label>
+                <input type="text" class="form-control" id="label" name="label" required>
             </div>
             <button type="submit" class="btn btn-primary">Criar</button>
         </form>
@@ -57,12 +62,13 @@ require_once __DIR__ . '/header.php';
     <h2 class="mt-5">Taxonomias</h2>
     <table class="table table-striped datatable">
         <thead>
-            <tr><th>Nome</th><th>Ações</th></tr>
+            <tr><th>Slug</th><th>Rótulo</th><th>Ações</th></tr>
         </thead>
         <tbody>
         <?php foreach ($taxonomies as $tax): ?>
             <tr>
                 <td><?php echo htmlspecialchars($tax['name']); ?></td>
+                <td><?php echo htmlspecialchars($tax['label']); ?></td>
                 <td><a href="taxonomies.php?taxonomy_id=<?php echo $tax['id']; ?>">Gerir termos</a></td>
             </tr>
         <?php endforeach; ?>
@@ -72,8 +78,12 @@ require_once __DIR__ . '/header.php';
         <h5>Criar nova taxonomia</h5>
         <form method="post" action="taxonomies.php">
             <div class="mb-3">
-                <label class="form-label" for="tname">Nome</label>
+                <label class="form-label" for="tname">Slug</label>
                 <input type="text" class="form-control" id="tname" name="name" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="tlabel">Rótulo</label>
+                <input type="text" class="form-control" id="tlabel" name="label" required>
             </div>
             <button type="submit" class="btn btn-primary">Criar</button>
         </form>

--- a/functions.php
+++ b/functions.php
@@ -212,7 +212,7 @@ function createTaxonomy(string $name, string $label): int {
  */
 function getTerms(int $taxonomy_id): array {
     $pdo = getPDO();
-    $stmt = $pdo->prepare('SELECT id, term FROM taxonomy_terms WHERE taxonomy_id = ? ORDER BY term ASC');
+    $stmt = $pdo->prepare('SELECT id, name FROM taxonomy_terms WHERE taxonomy_id = ? ORDER BY name ASC');
     $stmt->execute([$taxonomy_id]);
     return $stmt->fetchAll();
 }
@@ -226,7 +226,7 @@ function getTerms(int $taxonomy_id): array {
  */
 function createTerm(int $taxonomy_id, string $term): int {
     $pdo = getPDO();
-    $stmt = $pdo->prepare('INSERT INTO taxonomy_terms (taxonomy_id, term) VALUES (?, ?)');
+    $stmt = $pdo->prepare('INSERT INTO taxonomy_terms (taxonomy_id, name) VALUES (?, ?)');
     $stmt->execute([$taxonomy_id, $term]);
     return (int)$pdo->lastInsertId();
 }
@@ -310,7 +310,7 @@ function getContentList(int $content_type_id): array {
         $cstmt->execute([$content['id']]);
         $content['fields'] = $cstmt->fetchAll();
         // Fetch taxonomy assignments
-        $tstmt = $pdo->prepare('SELECT ct.taxonomy_id, tt.term AS term_name FROM content_taxonomy ct JOIN taxonomy_terms tt ON ct.term_id = tt.id WHERE ct.content_id = ?');
+        $tstmt = $pdo->prepare('SELECT ct.taxonomy_id, tt.name AS term_name FROM content_taxonomy ct JOIN taxonomy_terms tt ON ct.term_id = tt.id WHERE ct.content_id = ?');
         $tstmt->execute([$content['id']]);
         $content['taxonomies'] = $tstmt->fetchAll();
     }

--- a/list_content.php
+++ b/list_content.php
@@ -36,7 +36,7 @@ require_once __DIR__ . '/header.php';
 <div class="container-fluid">
     <div class="page-title">
         <div class="title_left">
-            <h3><?php echo htmlspecialchars($contentType['name']); ?> List</h3>
+            <h3><?php echo htmlspecialchars($contentType['label']); ?> List</h3>
         </div>
     </div>
     <div class="clearfix"></div>
@@ -52,10 +52,10 @@ require_once __DIR__ . '/header.php';
                                 <th>Author</th>
                                 <th>Date</th>
                                 <?php foreach ($customFields as $field): ?>
-                                    <th><?php echo htmlspecialchars($field['name']); ?></th>
+                                    <th><?php echo htmlspecialchars($field['label']); ?></th>
                                 <?php endforeach; ?>
                                 <?php foreach ($allTaxonomies as $tax): ?>
-                                    <th><?php echo htmlspecialchars($tax['name']); ?></th>
+                                    <th><?php echo htmlspecialchars($tax['label']); ?></th>
                                 <?php endforeach; ?>
                             </tr>
                         </thead>

--- a/schema.sql
+++ b/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS users (
 CREATE TABLE IF NOT EXISTS content_types (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
+    label VARCHAR(100) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -18,8 +19,10 @@ CREATE TABLE IF NOT EXISTS custom_fields (
     id INT AUTO_INCREMENT PRIMARY KEY,
     content_type_id INT NOT NULL,
     name VARCHAR(100) NOT NULL,
-    field_type ENUM('text','textarea','number','date','select') NOT NULL,
+    label VARCHAR(100) NOT NULL,
+    type ENUM('text','textarea','number','date','select') NOT NULL,
     options TEXT,
+    required TINYINT(1) NOT NULL DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (content_type_id) REFERENCES content_types(id) ON DELETE CASCADE
 );
@@ -27,6 +30,7 @@ CREATE TABLE IF NOT EXISTS custom_fields (
 CREATE TABLE IF NOT EXISTS taxonomies (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
+    label VARCHAR(100) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/taxonomies.php
+++ b/taxonomies.php
@@ -36,9 +36,10 @@ if ($taxonomyId) {
     $terms = getTerms($taxonomyId);
 } else {
     if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['name'])) {
-        $name = trim($_POST['name']);
-        if ($name !== '') {
-            createTaxonomy($name);
+        $name  = trim($_POST['name']);
+        $label = trim($_POST['label'] ?? '');
+        if ($name !== '' && $label !== '') {
+            createTaxonomy($name, $label);
             header('Location: taxonomies.php');
             exit;
         }
@@ -50,7 +51,7 @@ require_once __DIR__ . '/header.php';
 ?>
 <div class="container-fluid">
 <?php if ($taxonomyId && $taxonomy): ?>
-    <h2 class="mt-3">Termos de <?php echo htmlspecialchars($taxonomy['name']); ?></h2>
+    <h2 class="mt-3">Termos de <?php echo htmlspecialchars($taxonomy['label']); ?></h2>
     <table class="table table-striped datatable">
         <thead><tr><th>Nome</th></tr></thead>
         <tbody>
@@ -73,11 +74,12 @@ require_once __DIR__ . '/header.php';
 <?php else: ?>
     <h2 class="mt-3">Taxonomias</h2>
     <table class="table table-striped datatable">
-        <thead><tr><th>Nome</th><th>Ações</th></tr></thead>
+        <thead><tr><th>Slug</th><th>Rótulo</th><th>Ações</th></tr></thead>
         <tbody>
         <?php foreach ($taxonomies as $tax): ?>
             <tr>
                 <td><?php echo htmlspecialchars($tax['name']); ?></td>
+                <td><?php echo htmlspecialchars($tax['label']); ?></td>
                 <td><a href="taxonomies.php?taxonomy_id=<?php echo $tax['id']; ?>">Gerir termos</a></td>
             </tr>
         <?php endforeach; ?>
@@ -87,8 +89,12 @@ require_once __DIR__ . '/header.php';
         <h5>Criar nova taxonomia</h5>
         <form method="post" action="">
             <div class="mb-3">
-                <label class="form-label" for="name">Nome</label>
+                <label class="form-label" for="name">Slug</label>
                 <input type="text" class="form-control" id="name" name="name" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="label">Rótulo</label>
+                <input type="text" class="form-control" id="label" name="label" required>
             </div>
             <button type="submit" class="btn btn-primary">Criar</button>
             <a href="dashboard.php" class="btn btn-secondary">Voltar</a>


### PR DESCRIPTION
## Summary
- handle label and required fields for content types, taxonomies and custom fields
- update database schema and queries to match new fields
- display labels in forms and listings

## Testing
- `php -l functions.php`
- `php -l content_types.php`
- `php -l dashboard.php`
- `php -l taxonomies.php`
- `php -l custom_fields.php`
- `php -l add_content.php`
- `php -l list_content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b08a373c3083209a367d1109df1eec