### PR TITLE
Enable custom field management and refine authentication UI

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -198,6 +198,48 @@ function createCustomField(int $content_type_id, string $name, string $label, st
 }
 
 /**
+ * Fetch a single custom field by id.
+ *
+ * @param int $id
+ * @return array|null
+ */
+function getCustomField(int $id): ?array {
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('SELECT id, content_type_id, name, label, type, options, required FROM custom_fields WHERE id = ?');
+    $stmt->execute([$id]);
+    return $stmt->fetch() ?: null;
+}
+
+/**
+ * Update an existing custom field.
+ *
+ * @param int $id
+ * @param string $name
+ * @param string $label
+ * @param string $type
+ * @param string $options
+ * @param bool $required
+ * @return void
+ */
+function updateCustomField(int $id, string $name, string $label, string $type, string $options = '', bool $required = false): void {
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('UPDATE custom_fields SET name = ?, label = ?, type = ?, options = ?, required = ? WHERE id = ?');
+    $stmt->execute([$name, $label, $type, $options, $required ? 1 : 0, $id]);
+}
+
+/**
+ * Delete a custom field by id.
+ *
+ * @param int $id
+ * @return void
+ */
+function deleteCustomField(int $id): void {
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('DELETE FROM custom_fields WHERE id = ?');
+    $stmt->execute([$id]);
+}
+
+/**
  * Retrieve all taxonomies.
  *
  * @return array

--- a/header.php
+++ b/header.php
@@ -78,9 +78,9 @@ $user = currentUser();
             <div class="nav_menu">
                 <nav class="navbar navbar-expand" role="navigation">
                     <ul class="navbar-nav ms-auto">
+                        <!-- Explicit logout button for better visibility -->
                         <li class="nav-item">
-                            <a href="logout.php" class="user-profile nav-link">
-                                <!-- Display username and logout link -->
+                            <a href="logout.php" class="btn btn-sm btn-danger">
                                 Terminar sessão (<?php echo htmlspecialchars($user['username']); ?>)
                             </a>
                         </li>

--- a/login.php
+++ b/login.php
@@ -40,7 +40,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <link rel="stylesheet" href="vendors/font-awesome/css/font-awesome.min.css">
     <link rel="stylesheet" href="vendors/nprogress/nprogress.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css">
-    <link rel="stylesheet" href="https://colorlibhq.github.io/gentelella/build/css/custom.min.css">
+    <link rel="stylesheet" href="https://colorlibhq.github.io/gentelella/build/css/gentelella.min.css">
+    <link rel="stylesheet" href="assets/css/custom.css">
+    <!-- Layout follows the Gentelella theme -->
 </head>
 <body class="login">
     <div>
@@ -62,7 +64,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <input type="password" class="form-control" placeholder="Palavra‑passe" name="password" required />
               </div>
               <div>
-                <button class="btn btn-default submit" type="submit">Entrar</button>
+                <button class="btn btn-primary submit" type="submit">Entrar</button>
               </div>
               <div class="clearfix"></div>
             </form>


### PR DESCRIPTION
## Summary
- allow editing and deleting of custom fields
- style logout link as a visible button
- apply Gentelella theme styling to login page

## Testing
- `php -l functions.php custom_fields.php header.php login.php`

------
https://chatgpt.com/codex/tasks/task_e_68b08dddcf6c83208ecf8e7a90885fbf