### PR TITLE
feat: allow assigning taxonomies to content types

### DIFF
--- a/add_content.php
+++ b/add_content.php
@@ -30,7 +30,7 @@ if (!$contentType) {
 }
 // Get custom fields and taxonomies
 $customFields = getCustomFields($typeId);
-$allTaxonomies = getAllTaxonomies();
+$allTaxonomies = getTaxonomiesForContentType($typeId);
 
 // Handle form submission
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/content_type_taxonomies.php
+++ b/content_type_taxonomies.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Associate taxonomies with a specific content type.
+ */
+
+require_once __DIR__ . '/functions.php';
+startSession();
+requireLogin();
+
+$typeId = isset($_GET['type_id']) ? (int)$_GET['type_id'] : 0;
+$type   = $typeId ? getContentType($typeId) : null;
+if (!$type) {
+    echo "Tipo de conteúdo inválido.";
+    exit;
+}
+
+$allTaxonomies = getTaxonomies();
+$current = array_map(fn($t) => (int)$t['id'], getTaxonomiesForContentType($typeId));
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $selected = isset($_POST['taxonomies']) ? array_map('intval', (array)$_POST['taxonomies']) : [];
+    setContentTypeTaxonomies($typeId, $selected);
+    header('Location: content_type_taxonomies.php?type_id=' . $typeId);
+    exit;
+}
+
+require_once __DIR__ . '/header.php';
+?>
+<div class="container-fluid">
+    <h2 class="mt-3">Taxonomias para <?php echo htmlspecialchars($type['label']); ?></h2>
+    <form method="post">
+        <?php foreach ($allTaxonomies as $tax): ?>
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="tax_<?php echo $tax['id']; ?>" name="taxonomies[]" value="<?php echo $tax['id']; ?>" <?php echo in_array($tax['id'], $current) ? 'checked' : ''; ?>>
+                <label class="form-check-label" for="tax_<?php echo $tax['id']; ?>"><?php echo htmlspecialchars($tax['label']); ?></label>
+            </div>
+        <?php endforeach; ?>
+        <button type="submit" class="btn btn-primary mt-3">Guardar</button>
+    </form>
+</div>
+<?php require_once __DIR__ . '/footer.php'; ?>

--- a/content_types.php
+++ b/content_types.php
@@ -49,7 +49,8 @@ require_once __DIR__ . '/header.php';
                 <td>
                     <a href="custom_fields.php?type_id=<?php echo $type['id']; ?>">Campos</a> |
                     <a href="add_content.php?type_id=<?php echo $type['id']; ?>">Adicionar</a> |
-                    <a href="list_content.php?type_id=<?php echo $type['id']; ?>">Listar</a>
+                    <a href="list_content.php?type_id=<?php echo $type['id']; ?>">Listar</a> |
+                    <a href="content_type_taxonomies.php?type_id=<?php echo $type['id']; ?>">Taxonomias</a>
                 </td>
             </tr>
         <?php endforeach; ?>

--- a/functions.php
+++ b/functions.php
@@ -250,6 +250,39 @@ function createTerm(int $taxonomy_id, string $term): int {
 }
 
 /**
+ * Retrieve taxonomies assigned to a given content type.
+ *
+ * @param int $content_type_id
+ * @return array
+ */
+function getTaxonomiesForContentType(int $content_type_id): array {
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('SELECT t.id, t.name, t.label FROM taxonomies t JOIN content_type_taxonomy ctt ON t.id = ctt.taxonomy_id WHERE ctt.content_type_id = ? ORDER BY t.id ASC');
+    $stmt->execute([$content_type_id]);
+    return $stmt->fetchAll();
+}
+
+/**
+ * Assign a set of taxonomies to a content type.
+ * Existing assignments are removed before inserting the new ones.
+ *
+ * @param int $content_type_id
+ * @param array $taxonomy_ids
+ * @return void
+ */
+function setContentTypeTaxonomies(int $content_type_id, array $taxonomy_ids): void {
+    $pdo = getPDO();
+    $pdo->beginTransaction();
+    $del = $pdo->prepare('DELETE FROM content_type_taxonomy WHERE content_type_id = ?');
+    $del->execute([$content_type_id]);
+    $ins = $pdo->prepare('INSERT INTO content_type_taxonomy (content_type_id, taxonomy_id) VALUES (?, ?)');
+    foreach ($taxonomy_ids as $tid) {
+        $ins->execute([$content_type_id, $tid]);
+    }
+    $pdo->commit();
+}
+
+/**
  * Create a content entry.  The function inserts a row into the
  * `content` table and returns the new content id.
  *

--- a/header.php
+++ b/header.php
@@ -63,8 +63,20 @@ $user = currentUser();
                             <li><a href="dashboard.php"><i class="fa fa-home"></i> Dashboard</a></li>
                             <li><a href="content_types.php"><i class="fa fa-cubes"></i> Tipos de Conteúdo</a></li>
                             <li><a href="taxonomies.php"><i class="fa fa-tags"></i> Taxonomias</a></li>
-                            <li><a href="add_content.php"><i class="fa fa-plus-circle"></i> Adicionar Conteúdo</a></li>
-                            <li><a href="list_content.php"><i class="fa fa-list"></i> Listar Conteúdo</a></li>
+<?php
+// Dynamically list each content type with shortcuts to common actions.
+$sidebarTypes = getContentTypes();
+foreach ($sidebarTypes as $sidebarType):
+?>
+                            <li><a><i class="fa fa-file-text"></i> <?php echo htmlspecialchars($sidebarType['label']); ?> <span class="fa fa-chevron-down"></span></a>
+                                <ul class="nav child_menu">
+                                    <li><a href="add_content.php?type_id=<?php echo $sidebarType['id']; ?>">Adicionar</a></li>
+                                    <li><a href="list_content.php?type_id=<?php echo $sidebarType['id']; ?>">Listar</a></li>
+                                    <li><a href="custom_fields.php?type_id=<?php echo $sidebarType['id']; ?>">Campos</a></li>
+                                    <li><a href="content_type_taxonomies.php?type_id=<?php echo $sidebarType['id']; ?>">Taxonomias</a></li>
+                                </ul>
+                            </li>
+<?php endforeach; ?>
                         </ul>
                     </div>
                 </div>

--- a/list_content.php
+++ b/list_content.php
@@ -29,7 +29,7 @@ if (!$contentType) {
 // Get custom fields, taxonomies and content list
 $customFields = getCustomFields($typeId);
 $contents = getContentList($typeId);
-$allTaxonomies = getAllTaxonomies();
+$allTaxonomies = getTaxonomiesForContentType($typeId);
 
 require_once __DIR__ . '/header.php';
 ?>

--- a/schema.sql
+++ b/schema.sql
@@ -63,6 +63,14 @@ CREATE TABLE IF NOT EXISTS custom_values (
     FOREIGN KEY (field_id) REFERENCES custom_fields(id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS content_type_taxonomy (
+    content_type_id INT NOT NULL,
+    taxonomy_id INT NOT NULL,
+    PRIMARY KEY (content_type_id, taxonomy_id),
+    FOREIGN KEY (content_type_id) REFERENCES content_types(id) ON DELETE CASCADE,
+    FOREIGN KEY (taxonomy_id) REFERENCES taxonomies(id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS content_taxonomy (
     content_id INT NOT NULL,
     taxonomy_id INT NOT NULL,


### PR DESCRIPTION
## Summary
- list content types and actions in the sidebar menu
- allow administrators to assign taxonomies to content types
- only show relevant taxonomies when adding or listing content

## Testing
- `php -l header.php`
- `php -l functions.php`
- `php -l add_content.php`
- `php -l content_types.php`
- `php -l content_type_taxonomies.php`
- `php -l schema.sql`
- `php -l list_content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b08ecc63a4832099420462c928e74d