### PR TITLE
Use Ajax with DataTables for content listing

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -325,7 +325,18 @@ function updtCliParam(cliente, params) {
 }
 
 $(document).ready(function() {
-    $('table.datatable').DataTable({
-        responsive: true
+    $('table.datatable').each(function() {
+        var $table = $(this);
+        var source = $table.data('source');
+        var options = { responsive: true };
+        if (source) {
+            var typeId = $table.data('type-id');
+            options.ajax = {
+                url: source,
+                type: 'POST',
+                data: { type_id: typeId }
+            };
+        }
+        $table.DataTable(options);
     });
 });

--- a/data/list_content.php
+++ b/data/list_content.php
@@ -1,0 +1,57 @@
+<?php
+require_once __DIR__ . '/../db.php';
+require_once __DIR__ . '/../functions.php';
+
+startSession();
+requireLogin();
+
+header('Content-Type: application/json');
+
+$typeId = isset($_POST['type_id']) ? (int)$_POST['type_id'] : 0;
+if (!$typeId) {
+    echo json_encode(['data' => []]);
+    exit;
+}
+
+$customFields = getCustomFields($typeId);
+$allTaxonomies = getTaxonomiesForContentType($typeId);
+$contents = getContentList($typeId);
+
+$data = [];
+foreach ($contents as $content) {
+    $row = [
+        htmlspecialchars($content['title']),
+        htmlspecialchars($content['author_name']),
+        htmlspecialchars($content['created_at'])
+    ];
+
+    foreach ($customFields as $field) {
+        $fieldId = $field['id'];
+        $fieldValue = '';
+        foreach ($content['fields'] as $cv) {
+            if ($cv['field_id'] == $fieldId) {
+                $fieldValue = $cv['value'];
+                break;
+            }
+        }
+        $row[] = htmlspecialchars($fieldValue);
+    }
+
+    foreach ($allTaxonomies as $tax) {
+        $termsList = [];
+        foreach ($content['taxonomies'] as $assoc) {
+            if ($assoc['taxonomy_id'] == $tax['id']) {
+                $termsList[] = $assoc['term_name'];
+            }
+        }
+        $row[] = htmlspecialchars(implode(', ', $termsList));
+    }
+
+    $actions = '<a href="edit_content.php?id=' . $content['id'] . '" class="btn btn-sm btn-primary">Editar</a> ';
+    $actions .= '<a href="list_content.php?type_id=' . $typeId . '&delete=' . $content['id'] . '" class="btn btn-sm btn-danger" onclick="return confirm(\'Apagar este conteúdo?\');">Apagar</a>';
+    $row[] = $actions;
+
+    $data[] = $row;
+}
+
+echo json_encode(['data' => $data]);

--- a/list_content.php
+++ b/list_content.php
@@ -37,9 +37,8 @@ if (isset($_GET['delete'])) {
     exit;
 }
 
-// Get custom fields, taxonomies and content list
+// Get custom fields and taxonomies
 $customFields = getCustomFields($typeId);
-$contents = getContentList($typeId);
 $allTaxonomies = getTaxonomiesForContentType($typeId);
 
 require_once __DIR__ . '/header.php';
@@ -56,7 +55,7 @@ require_once __DIR__ . '/header.php';
             <div class="x_panel">
                 <div class="x_content">
                     <a href="add_content.php?type_id=<?php echo $typeId; ?>" class="btn btn-success mb-3">Add New</a>
-                    <table class="table table-striped datatable">
+                    <table class="table table-striped datatable" data-source="data/list_content.php" data-type-id="<?php echo $typeId; ?>">
                         <thead>
                             <tr>
                                 <th>Title</th>
@@ -71,43 +70,7 @@ require_once __DIR__ . '/header.php';
                                 <th>Ações</th>
                             </tr>
                         </thead>
-                        <tbody>
-                            <?php foreach ($contents as $content): ?>
-                                <tr>
-                                    <td><?php echo htmlspecialchars($content['title']); ?></td>
-                                    <td><?php echo htmlspecialchars($content['author_name']); ?></td>
-                                    <td><?php echo htmlspecialchars($content['created_at']); ?></td>
-                                    <?php foreach ($customFields as $field): ?>
-                                        <?php
-                                            $fieldId = $field['id'];
-                                            $fieldValue = '';
-                                            foreach ($content['fields'] as $cv) {
-                                                if ($cv['field_id'] == $fieldId) {
-                                                    $fieldValue = $cv['value'];
-                                                    break;
-                                                }
-                                            }
-                                        ?>
-                                        <td><?php echo htmlspecialchars($fieldValue); ?></td>
-                                    <?php endforeach; ?>
-                                    <?php foreach ($allTaxonomies as $tax): ?>
-                                        <?php
-                                            $termsList = [];
-                                            foreach ($content['taxonomies'] as $assoc) {
-                                                if ($assoc['taxonomy_id'] == $tax['id']) {
-                                                    $termsList[] = $assoc['term_name'];
-                                                }
-                                            }
-                                        ?>
-                                        <td><?php echo htmlspecialchars(implode(', ', $termsList)); ?></td>
-                                    <?php endforeach; ?>
-                                    <td>
-                                        <a href="edit_content.php?id=<?php echo $content['id']; ?>" class="btn btn-sm btn-primary">Editar</a>
-                                        <a href="list_content.php?type_id=<?php echo $typeId; ?>&delete=<?php echo $content['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Apagar este conteúdo?');">Apagar</a>
-                                    </td>
-                                </tr>
-                            <?php endforeach; ?>
-                        </tbody>
+                        <tbody></tbody>
                     </table>
                     <a href="dashboard.php" class="btn btn-secondary">Back</a>
                 </div>


### PR DESCRIPTION
## Summary
- fetch content lists with new POST endpoint `data/list_content.php`
- switch `list_content.php` to DataTables AJAX loading
- auto-initialize DataTables via `data-source` attributes in `custom.js`

## Testing
- `php -l data/list_content.php`
- `php -l list_content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b092950e80832094ed110524757a35