### PR TITLE
Restrict taxonomies in edit page to content type

### DIFF
--- a/edit_content.php
+++ b/edit_content.php
@@ -19,7 +19,7 @@ if (!$content) {
 $typeId = (int)$content['content_type_id'];
 $contentType = getContentType($typeId);
 $customFields = getCustomFields($typeId);
-$allTaxonomies = getAllTaxonomies();
+$allTaxonomies = getTaxonomiesForContentType($typeId);
 $customValues = getCustomValuesForContent($contentId);
 $taxonomyMap = getContentTaxonomy($contentId);
 


### PR DESCRIPTION
## Summary
- only load taxonomies assigned to the content type when editing content

## Testing
- `php -l edit_content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b09509e59083208012fed7a207b6ff