### PR TITLE
Display select field labels in content list

### DIFF
--- a/data/list_content.php
+++ b/data/list_content.php
@@ -34,6 +34,15 @@ foreach ($contents as $content) {
                 break;
             }
         }
+
+        if ($field['type'] === 'taxonomy' && $fieldValue !== '') {
+            $term = getTerm((int)$fieldValue);
+            $fieldValue = $term ? $term['name'] : $fieldValue;
+        } elseif ($field['type'] === 'content' && $fieldValue !== '') {
+            $related = getContent((int)$fieldValue);
+            $fieldValue = $related ? $related['title'] : $fieldValue;
+        }
+
         $row[] = htmlspecialchars($fieldValue);
     }
 

--- a/functions.php
+++ b/functions.php
@@ -291,6 +291,19 @@ function getTerms(int $taxonomy_id): array {
 }
 
 /**
+ * Retrieve a single taxonomy term by id.
+ *
+ * @param int $term_id
+ * @return array|null
+ */
+function getTerm(int $term_id): ?array {
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('SELECT id, taxonomy_id, name FROM taxonomy_terms WHERE id = ?');
+    $stmt->execute([$term_id]);
+    return $stmt->fetch() ?: null;
+}
+
+/**
  * Create a taxonomy term.  Returns new id.
  *
  * @param int $taxonomy_id


### PR DESCRIPTION
## Summary
- Show taxonomy term names or related content titles instead of raw IDs for select fields in content listing
- Add helper to fetch single taxonomy term

## Testing
- `php -l functions.php`
- `php -l data/list_content.php`
- `phpunit --version` *(fails: command not found)*
- `composer test` *(fails: Command "test" is not defined)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b0969615cc8320a86802ab45efdca0