### PR TITLE
Ensure menu items span full width

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -732,7 +732,8 @@ a:focus {
     cursor: pointer
 }
 .nav.side-menu>li>a {
-    margin-bottom: 6px
+    margin-bottom: 6px;
+    width: 100%;
 }
 .nav.side-menu>li>a:hover {
     color: #F2F5F7 !important

--- a/header.php
+++ b/header.php
@@ -91,10 +91,10 @@ foreach ($sidebarTypes as $sidebarType):
         <div class="top_nav">
             <div class="nav_menu w-100">
                 <nav class="navbar navbar-expand w-100" role="navigation">
-                    <ul class="navbar-nav w-100 justify-content-end">
+                    <ul class="navbar-nav w-100">
                         <!-- Explicit logout button for better visibility -->
-                        <li class="nav-item">
-                            <a href="logout.php" class="btn btn-sm btn-danger">
+                        <li class="nav-item w-100">
+                            <a href="logout.php" class="btn btn-sm btn-danger d-block w-100 text-end">
                                 Terminar sessão (<?php echo htmlspecialchars($user['username']); ?>)
                             </a>
                         </li>


### PR DESCRIPTION
## Summary
- Force sidebar menu items to span the full container width
- Expand top navigation logout item to occupy the available width

## Testing
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b09be8717c83208de9b51ac967c52d