### PR TITLE
Ensure side-menu items span full width

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -729,6 +729,7 @@ a:focus {
 .nav.side-menu>li {
     position: relative;
     display: block;
+    width: 100%;
     cursor: pointer
 }
 .nav.side-menu>li>a {


### PR DESCRIPTION
## Summary
- Set `.nav.side-menu > li` elements to 100% width so side-menu items occupy the full horizontal space.

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b22052a083208986e51aa1622f31