### PR TITLE
Add dedicated taxonomies creation route

### DIFF
--- a/taxonomies.php
+++ b/taxonomies.php
@@ -6,16 +6,17 @@
  * taxonomia seleccionada. Se um parâmetro `taxonomy_id` for passado, a
  * interface apresenta os termos dessa taxonomia e um formulário para
  * adicionar novos termos. Caso contrário, lista-se todas as taxonomias
- * existentes e um formulário para criar uma nova.
+ * existentes. Para criar uma nova taxonomia, utilizar `taxonomies.php?act=ad`.
  */
 
 require_once __DIR__ . '/functions.php';
 startSession();
 requireLogin();
 
-$error = '';
-$taxonomyId = isset($_GET['taxonomy_id']) ? (int)$_GET['taxonomy_id'] : 0;
-$taxonomy = null;
+ $error = '';
+ $taxonomyId = isset($_GET['taxonomy_id']) ? (int)$_GET['taxonomy_id'] : 0;
+ $act = $_GET['act'] ?? '';
+ $taxonomy = null;
 if ($taxonomyId) {
     // Gestão de termos para uma taxonomia específica
     if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['term_name'])) {
@@ -46,7 +47,7 @@ if ($taxonomyId) {
         exit;
     }
 
-    if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['name'])) {
+    if (($act === 'ad' || $editing) && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['name'])) {
         $name  = trim($_POST['name']);
         $label = trim($_POST['label'] ?? '');
         if ($name !== '' && $label !== '') {
@@ -61,7 +62,10 @@ if ($taxonomyId) {
             $error = 'Nome e rótulo são obrigatórios.';
         }
     }
-    $taxonomies = getTaxonomies();
+
+    if ($act !== 'ad' && !$editing) {
+        $taxonomies = getTaxonomies();
+    }
 }
 
 require_once __DIR__ . '/header.php';
@@ -89,45 +93,45 @@ require_once __DIR__ . '/header.php';
         </form>
     </div>
 <?php else: ?>
-    <h2 class="mt-3">Taxonomias</h2>
-    <?php if ($error): ?>
-        <div class="alert alert-danger"> <?php echo htmlspecialchars($error); ?> </div>
+    <?php if ($act === 'ad' || $editing): ?>
+        <h2 class="mt-3"><?php echo $editing ? 'Editar taxonomia' : 'Criar nova taxonomia'; ?></h2>
+        <?php if ($error): ?>
+            <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
+        <?php endif; ?>
+        <div class="card p-3 mt-4">
+            <form method="post" action="<?php echo $editing ? '?edit_id=' . $editing['id'] : '?act=ad'; ?>">
+                <div class="mb-3">
+                    <label class="form-label" for="name">Slug</label>
+                    <input type="text" class="form-control" id="name" name="name" value="<?php echo htmlspecialchars($editing['name'] ?? ''); ?>" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label" for="label">Rótulo</label>
+                    <input type="text" class="form-control" id="label" name="label" value="<?php echo htmlspecialchars($editing['label'] ?? ''); ?>" required>
+                </div>
+                <button type="submit" class="btn btn-primary"><?php echo $editing ? 'Guardar' : 'Criar'; ?></button>
+                <a href="taxonomies.php" class="btn btn-secondary">Voltar</a>
+            </form>
+        </div>
+    <?php else: ?>
+        <h2 class="mt-3">Taxonomias</h2>
+        <a href="taxonomies.php?act=ad" class="btn btn-success mb-3">Adicionar taxonomia</a>
+        <table class="table table-striped datatable">
+            <thead><tr><th>Slug</th><th>Rótulo</th><th>Ações</th></tr></thead>
+            <tbody>
+            <?php foreach ($taxonomies as $tax): ?>
+                <tr>
+                    <td><?php echo htmlspecialchars($tax['name']); ?></td>
+                    <td><?php echo htmlspecialchars($tax['label']); ?></td>
+                    <td>
+                        <a href="taxonomies.php?taxonomy_id=<?php echo $tax['id']; ?>">Gerir termos</a> |
+                        <a href="taxonomies.php?edit_id=<?php echo $tax['id']; ?>">Editar</a> |
+                        <a href="taxonomies.php?delete_id=<?php echo $tax['id']; ?>" onclick="return confirm('Eliminar esta taxonomia?');">Eliminar</a>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
     <?php endif; ?>
-    <table class="table table-striped datatable">
-        <thead><tr><th>Slug</th><th>Rótulo</th><th>Ações</th></tr></thead>
-        <tbody>
-        <?php foreach ($taxonomies as $tax): ?>
-            <tr>
-                <td><?php echo htmlspecialchars($tax['name']); ?></td>
-                <td><?php echo htmlspecialchars($tax['label']); ?></td>
-                <td>
-                    <a href="taxonomies.php?taxonomy_id=<?php echo $tax['id']; ?>">Gerir termos</a> |
-                    <a href="taxonomies.php?edit_id=<?php echo $tax['id']; ?>">Editar</a> |
-                    <a href="taxonomies.php?delete_id=<?php echo $tax['id']; ?>" onclick="return confirm('Eliminar esta taxonomia?');">Eliminar</a>
-                </td>
-            </tr>
-        <?php endforeach; ?>
-        </tbody>
-    </table>
-    <div class="card p-3 mt-4">
-        <h5><?php echo isset($editing) && $editing ? 'Editar taxonomia' : 'Criar nova taxonomia'; ?></h5>
-        <form method="post" action="<?php echo isset($editing) && $editing ? '?edit_id=' . $editing['id'] : ''; ?>">
-            <div class="mb-3">
-                <label class="form-label" for="name">Slug</label>
-                <input type="text" class="form-control" id="name" name="name" value="<?php echo htmlspecialchars($editing['name'] ?? ''); ?>" required>
-            </div>
-            <div class="mb-3">
-                <label class="form-label" for="label">Rótulo</label>
-                <input type="text" class="form-control" id="label" name="label" value="<?php echo htmlspecialchars($editing['label'] ?? ''); ?>" required>
-            </div>
-            <button type="submit" class="btn btn-primary"><?php echo isset($editing) && $editing ? 'Guardar' : 'Criar'; ?></button>
-            <?php if (isset($editing) && $editing): ?>
-                <a href="taxonomies.php" class="btn btn-secondary">Cancelar</a>
-            <?php else: ?>
-                <a href="dashboard.php" class="btn btn-secondary">Voltar</a>
-            <?php endif; ?>
-        </form>
-    </div>
 <?php endif; ?>
 </div>
 <?php require_once __DIR__ . '/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Separate listing from creation for taxonomies
- Provide dedicated `?act=ad` route and button for adding taxonomies

## Testing
- `php -l taxonomies.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0c0f38f2c8320a1f8fb561b67ebee