### PR TITLE
Add column selectors for content types list

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -329,6 +329,10 @@ $(document).ready(function() {
         var $table = $(this);
         var source = $table.data('source');
         var options = { responsive: true };
+        if ($table.data('no-sort-last')) {
+            options.columnDefs = options.columnDefs || [];
+            options.columnDefs.push({ targets: -1, orderable: false });
+        }
         if (source) {
             var typeId = $table.data('type-id');
             options.ajax = {
@@ -337,6 +341,13 @@ $(document).ready(function() {
                 data: { type_id: typeId }
             };
         }
-        $table.DataTable(options);
+        var table = $table.DataTable(options);
+        var $toggles = $table.prev('.column-toggler');
+        if ($toggles.length) {
+            $toggles.find('input[type="checkbox"]').on('change', function() {
+                var column = table.column($(this).data('column'));
+                column.visible(this.checked);
+            });
+        }
     });
 });

--- a/content_types.php
+++ b/content_types.php
@@ -33,7 +33,13 @@ require_once __DIR__ . '/header.php';
         <h2>Tipos de Conteúdo</h2>
         <a class="btn btn-primary" href="content_type_form.php">Criar novo tipo de conteúdo</a>
     </div>
-    <table class="table table-striped datatable">
+    <div class="column-toggler mb-2">
+        <label class="me-2"><input type="checkbox" data-column="0" checked> Slug</label>
+        <label class="me-2"><input type="checkbox" data-column="1" checked> Rótulo</label>
+        <label class="me-2"><input type="checkbox" data-column="2" checked> Ícone</label>
+        <label class="me-2"><input type="checkbox" data-column="3" checked> Ações</label>
+    </div>
+    <table class="table table-striped datatable" data-no-sort-last="true">
         <thead><tr><th>Slug</th><th>Rótulo</th><th>Ícone</th><th>Ações</th></tr></thead>
         <tbody>
         <?php foreach ($types as $type): ?>


### PR DESCRIPTION
## Summary
- allow column visibility toggling via checkboxes in content type table
- disable sorting on the action column

## Testing
- `php -l content_types.php`
- `node --check assets/js/custom.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b0c2d779448320b9128c5c8dd0a5e0