### PR TITLE
Add act=ad support on content_types

### DIFF
--- a/content_types.php
+++ b/content_types.php
@@ -11,6 +11,13 @@ require_once __DIR__ . '/functions.php';
 startSession();
 requireLogin();
 
+// Redirect to the creation form when requested via act=ad for backward compatibility
+$action = isset($_GET['act']) ? $_GET['act'] : '';
+if ($action === 'ad') {
+    header('Location: content_type_form.php');
+    exit;
+}
+
 // Handle deletion of a content type
 $delId = isset($_GET['delete_id']) ? (int)$_GET['delete_id'] : 0;
 


### PR DESCRIPTION
## Summary
- Allow `content_types.php` to handle `act=ad` by redirecting to `content_type_form.php`

## Testing
- `php -l content_types.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0c36ef75c8320adb2ca39173db578