### PR TITLE
Allow selecting custom fields for listings

### DIFF
--- a/custom_fields.php
+++ b/custom_fields.php
@@ -56,14 +56,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $options = isset($_POST['options_content']) ? trim($_POST['options_content']) : '';
     }
     $required = isset($_POST['required']);
+    $showInList = isset($_POST['show_in_list']);
     if ($name !== '' && $label !== '' && $fieldType !== '') {
         if ($fieldId) {
             $existing = getCustomField($fieldId);
             if ($existing && (int)$existing['content_type_id'] === $typeId) {
-                updateCustomField($fieldId, $name, $label, $fieldType, $options, $required);
+                updateCustomField($fieldId, $name, $label, $fieldType, $options, $required, $showInList);
             }
         } else {
-            createCustomField($typeId, $name, $label, $fieldType, $options, $required);
+            createCustomField($typeId, $name, $label, $fieldType, $options, $required, $showInList);
         }
         header('Location: custom_fields.php?type_id=' . $typeId);
         exit;
@@ -84,7 +85,7 @@ require_once __DIR__ . '/header.php';
     <?php endif; ?>
     <table class="table table-striped datatable">
         <thead>
-            <tr><th>Slug</th><th>Rótulo</th><th>Tipo</th><th>Opções</th><th>Obrigatório</th><th>Ações</th></tr>
+            <tr><th>Slug</th><th>Rótulo</th><th>Tipo</th><th>Opções</th><th>Obrigatório</th><th>Listagem</th><th>Ações</th></tr>
         </thead>
         <tbody>
         <?php foreach ($fields as $field): ?>
@@ -114,6 +115,7 @@ require_once __DIR__ . '/header.php';
                     <?php endif; ?>
                 </td>
                 <td><?php echo $field['required'] ? 'Sim' : 'Não'; ?></td>
+                <td><?php echo !empty($field['show_in_list']) ? 'Sim' : 'Não'; ?></td>
                 <td>
                     <a href="custom_fields.php?type_id=<?php echo $typeId; ?>&edit=<?php echo $field['id']; ?>" class="btn btn-sm btn-secondary">Editar</a>
                     <a href="custom_fields.php?type_id=<?php echo $typeId; ?>&delete=<?php echo $field['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Apagar este campo?');">Apagar</a>
@@ -174,6 +176,10 @@ require_once __DIR__ . '/header.php';
             <div class="form-check mb-3">
                 <input class="form-check-input" type="checkbox" id="required" name="required" <?php echo !empty($editField['required']) ? 'checked' : ''; ?>>
                 <label class="form-check-label" for="required">Obrigatório</label>
+            </div>
+            <div class="form-check mb-3">
+                <input class="form-check-input" type="checkbox" id="show_in_list" name="show_in_list" <?php echo !empty($editField['show_in_list']) ? 'checked' : ''; ?>>
+                <label class="form-check-label" for="show_in_list">Mostrar na listagem</label>
             </div>
             <button type="submit" class="btn btn-primary"><?php echo $editField ? 'Guardar' : 'Adicionar'; ?></button>
             <?php if ($editField): ?>

--- a/data/list_content.php
+++ b/data/list_content.php
@@ -13,7 +13,9 @@ if (!$typeId) {
     exit;
 }
 
-$customFields = getCustomFields($typeId);
+$customFields = array_values(array_filter(getCustomFields($typeId), function ($f) {
+    return !empty($f['show_in_list']);
+}));
 $allTaxonomies = getTaxonomiesForContentType($typeId);
 $contents = getContentList($typeId);
 

--- a/list_content.php
+++ b/list_content.php
@@ -37,8 +37,10 @@ if (isset($_GET['delete'])) {
     exit;
 }
 
-// Get custom fields and taxonomies
-$customFields = getCustomFields($typeId);
+// Get custom fields (only those marked to show in list) and taxonomies
+$customFields = array_values(array_filter(getCustomFields($typeId), function ($f) {
+    return !empty($f['show_in_list']);
+}));
 $allTaxonomies = getTaxonomiesForContentType($typeId);
 
 require_once __DIR__ . '/header.php';

--- a/schema.sql
+++ b/schema.sql
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS custom_fields (
     type ENUM('text','textarea','number','date','datetime','select','taxonomy','content') NOT NULL,
     options TEXT,
     required TINYINT(1) NOT NULL DEFAULT 0,
+    show_in_list TINYINT(1) NOT NULL DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (content_type_id) REFERENCES content_types(id) ON DELETE CASCADE
 );


### PR DESCRIPTION
## Summary
- enable configuring custom fields to display in content listings
- persist list visibility via `show_in_list` column
- show only selected custom fields in listing datatables

## Testing
- `php -l functions.php`
- `php -l custom_fields.php`
- `php -l list_content.php`
- `php -l data/list_content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0c9083a0c8320b44cbcea1e2680d8