### PR TITLE
Allow customizing author and date columns per content type

### DIFF
--- a/content_type_form.php
+++ b/content_type_form.php
@@ -16,12 +16,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $name  = isset($_POST['name']) ? trim($_POST['name']) : '';
     $label = isset($_POST['label']) ? trim($_POST['label']) : '';
     $icon  = isset($_POST['icon']) ? trim($_POST['icon']) : 'fa fa-file-text';
+    $showAuthor = isset($_POST['show_author']);
+    $showDate   = isset($_POST['show_date']);
 
     if ($name !== '' && $label !== '') {
         if ($id) {
-            updateContentType($id, $name, $label, $icon === '' ? 'fa fa-file-text' : $icon);
+            updateContentType($id, $name, $label, $icon === '' ? 'fa fa-file-text' : $icon, $showAuthor, $showDate);
         } else {
-            createContentType($name, $label, $icon === '' ? 'fa fa-file-text' : $icon);
+            createContentType($name, $label, $icon === '' ? 'fa fa-file-text' : $icon, $showAuthor, $showDate);
         }
         header('Location: content_types.php');
         exit;
@@ -49,6 +51,14 @@ require_once __DIR__ . '/header.php';
         <div class="mb-3">
             <label class="form-label" for="icon">Ícone (classe Font Awesome)</label>
             <input type="text" class="form-control" id="icon" name="icon" value="<?php echo htmlspecialchars($editing['icon'] ?? ''); ?>" placeholder="fa fa-file-text">
+        </div>
+        <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" id="show_author" name="show_author" <?php echo !empty($editing['show_author']) ? 'checked' : ''; ?>>
+            <label class="form-check-label" for="show_author">Mostrar autor na listagem</label>
+        </div>
+        <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" id="show_date" name="show_date" <?php echo !empty($editing['show_date']) ? 'checked' : ''; ?>>
+            <label class="form-check-label" for="show_date">Mostrar data na listagem</label>
         </div>
         <button type="submit" class="btn btn-primary"><?php echo $editing ? 'Atualizar' : 'Criar'; ?></button>
     </form>

--- a/data/list_content.php
+++ b/data/list_content.php
@@ -13,6 +13,12 @@ if (!$typeId) {
     exit;
 }
 
+$contentType = getContentType($typeId);
+if (!$contentType) {
+    echo json_encode(['data' => []]);
+    exit;
+}
+
 $customFields = array_values(array_filter(getCustomFields($typeId), function ($f) {
     return !empty($f['show_in_list']);
 }));
@@ -21,11 +27,13 @@ $contents = getContentList($typeId);
 
 $data = [];
 foreach ($contents as $content) {
-    $row = [
-        htmlspecialchars($content['title']),
-        htmlspecialchars($content['author_name']),
-        htmlspecialchars($content['created_at'])
-    ];
+    $row = [htmlspecialchars($content['title'])];
+    if (!empty($contentType['show_author'])) {
+        $row[] = htmlspecialchars($content['author_name']);
+    }
+    if (!empty($contentType['show_date'])) {
+        $row[] = htmlspecialchars($content['created_at']);
+    }
 
     foreach ($customFields as $field) {
         $fieldId = $field['id'];

--- a/list_content.php
+++ b/list_content.php
@@ -2,8 +2,9 @@
 /**
  * list_content.php
  *
- * Displays a list of content entries for a given content type. It shows the title, author,
- * creation date, and values of custom fields along with taxonomy terms for each entry.
+ * Displays a list of content entries for a given content type. It shows the title and,
+ * depending on the content type settings, the author and creation date. Custom fields
+ * marked for listing and taxonomy terms are also displayed for each entry.
  */
 
 require_once __DIR__ . '/db.php';
@@ -61,8 +62,12 @@ require_once __DIR__ . '/header.php';
                         <thead>
                             <tr>
                                 <th>Title</th>
-                                <th>Author</th>
-                                <th>Date</th>
+                                <?php if (!empty($contentType['show_author'])): ?>
+                                    <th>Author</th>
+                                <?php endif; ?>
+                                <?php if (!empty($contentType['show_date'])): ?>
+                                    <th>Date</th>
+                                <?php endif; ?>
                                 <?php foreach ($customFields as $field): ?>
                                     <th><?php echo htmlspecialchars($field['label']); ?></th>
                                 <?php endforeach; ?>

--- a/schema.sql
+++ b/schema.sql
@@ -13,6 +13,8 @@ CREATE TABLE IF NOT EXISTS content_types (
     name VARCHAR(100) NOT NULL,
     label VARCHAR(100) NOT NULL,
     icon VARCHAR(100) NOT NULL DEFAULT 'fa fa-file-text',
+    show_author TINYINT(1) NOT NULL DEFAULT 0,
+    show_date TINYINT(1) NOT NULL DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 


### PR DESCRIPTION
## Summary
- add `show_author` and `show_date` flags to content types
- expose new flags in create/update helpers and content type form
- show author and date columns in content lists only when enabled

## Testing
- `php -l functions.php`
- `php -l content_type_form.php`
- `php -l list_content.php`
- `php -l data/list_content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0cb056a608320ad9c89cdb55510e4