### PR TITLE
Enable editing and deleting taxonomy terms

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -425,6 +425,31 @@ function createTerm(int $taxonomy_id, string $term): int {
 }
 
 /**
+ * Update a taxonomy term's name.
+ *
+ * @param int $term_id
+ * @param string $term
+ * @return void
+ */
+function updateTerm(int $term_id, string $term): void {
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('UPDATE taxonomy_terms SET name = ? WHERE id = ?');
+    $stmt->execute([$term, $term_id]);
+}
+
+/**
+ * Delete a taxonomy term by id.
+ *
+ * @param int $term_id
+ * @return void
+ */
+function deleteTerm(int $term_id): void {
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('DELETE FROM taxonomy_terms WHERE id = ?');
+    $stmt->execute([$term_id]);
+}
+
+/**
  * Retrieve taxonomies assigned to a given content type.
  *
  * @param int $content_type_id


### PR DESCRIPTION
## Summary
- Allow editing and deletion of taxonomy terms within taxonomy management page
- Add backend helpers to update and delete taxonomy terms

## Testing
- `php -l functions.php`
- `php -l taxonomies.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0cbcc70808320a36f700f30b31512