### PR TITLE
Use buttons for action columns

### DIFF
--- a/content_types.php
+++ b/content_types.php
@@ -55,12 +55,12 @@ require_once __DIR__ . '/header.php';
                 <td><?php echo htmlspecialchars($type['label']); ?></td>
                 <td><i class="<?php echo htmlspecialchars($type['icon']); ?>"></i></td>
                 <td>
-                    <a href="custom_fields.php?type_id=<?php echo $type['id']; ?>">Campos</a> |
-                    <a href="add_content.php?type_id=<?php echo $type['id']; ?>">Adicionar</a> |
-                    <a href="list_content.php?type_id=<?php echo $type['id']; ?>">Listar</a> |
-                    <a href="content_type_taxonomies.php?type_id=<?php echo $type['id']; ?>">Taxonomias</a> |
-                    <a href="content_type_form.php?id=<?php echo $type['id']; ?>">Editar</a> |
-                    <a href="content_types.php?delete_id=<?php echo $type['id']; ?>" onclick="return confirm('Eliminar este tipo?');">Eliminar</a>
+                    <a href="custom_fields.php?type_id=<?php echo $type['id']; ?>" class="btn btn-sm btn-info">Campos</a>
+                    <a href="add_content.php?type_id=<?php echo $type['id']; ?>" class="btn btn-sm btn-success">Adicionar</a>
+                    <a href="list_content.php?type_id=<?php echo $type['id']; ?>" class="btn btn-sm btn-secondary">Listar</a>
+                    <a href="content_type_taxonomies.php?type_id=<?php echo $type['id']; ?>" class="btn btn-sm btn-warning">Taxonomias</a>
+                    <a href="content_type_form.php?id=<?php echo $type['id']; ?>" class="btn btn-sm btn-primary">Editar</a>
+                    <a href="content_types.php?delete_id=<?php echo $type['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Eliminar este tipo?');">Eliminar</a>
                 </td>
             </tr>
         <?php endforeach; ?>

--- a/dashboard.php
+++ b/dashboard.php
@@ -38,11 +38,11 @@ require_once __DIR__ . '/header.php';
                 <td><?php echo htmlspecialchars($type['label']); ?></td>
                 <td><i class="fa <?php echo htmlspecialchars($type['icon'] ?: 'fa-file-text'); ?>"></i></td>
                 <td>
-                    <a href="custom_fields.php?type_id=<?php echo $type['id']; ?>">Campos</a> |
-                    <a href="add_content.php?type_id=<?php echo $type['id']; ?>">Adicionar</a> |
-                    <a href="list_content.php?type_id=<?php echo $type['id']; ?>">Listar</a> |
-                    <a href="content_types.php?edit_id=<?php echo $type['id']; ?>">Editar</a> |
-                    <a href="content_types.php?delete_id=<?php echo $type['id']; ?>" onclick="return confirm('Eliminar este tipo?');">Eliminar</a>
+                    <a href="custom_fields.php?type_id=<?php echo $type['id']; ?>" class="btn btn-sm btn-info">Campos</a>
+                    <a href="add_content.php?type_id=<?php echo $type['id']; ?>" class="btn btn-sm btn-success">Adicionar</a>
+                    <a href="list_content.php?type_id=<?php echo $type['id']; ?>" class="btn btn-sm btn-secondary">Listar</a>
+                    <a href="content_types.php?edit_id=<?php echo $type['id']; ?>" class="btn btn-sm btn-primary">Editar</a>
+                    <a href="content_types.php?delete_id=<?php echo $type['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Eliminar este tipo?');">Eliminar</a>
                 </td>
             </tr>
         <?php endforeach; ?>
@@ -79,9 +79,9 @@ require_once __DIR__ . '/header.php';
                 <td><?php echo htmlspecialchars($tax['name']); ?></td>
                 <td><?php echo htmlspecialchars($tax['label']); ?></td>
                 <td>
-                    <a href="taxonomies.php?taxonomy_id=<?php echo $tax['id']; ?>">Gerir termos</a> |
-                    <a href="taxonomies.php?edit_id=<?php echo $tax['id']; ?>">Editar</a> |
-                    <a href="taxonomies.php?delete_id=<?php echo $tax['id']; ?>" onclick="return confirm('Eliminar esta taxonomia?');">Eliminar</a>
+                    <a href="taxonomies.php?taxonomy_id=<?php echo $tax['id']; ?>" class="btn btn-sm btn-info">Gerir termos</a>
+                    <a href="taxonomies.php?edit_id=<?php echo $tax['id']; ?>" class="btn btn-sm btn-secondary">Editar</a>
+                    <a href="taxonomies.php?delete_id=<?php echo $tax['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Eliminar esta taxonomia?');">Eliminar</a>
                 </td>
             </tr>
         <?php endforeach; ?>

--- a/taxonomies.php
+++ b/taxonomies.php
@@ -112,8 +112,8 @@ require_once __DIR__ . '/header.php';
                 <tr>
                     <td><?php echo htmlspecialchars($term['name']); ?></td>
                     <td>
-                        <a href="taxonomies.php?taxonomy_id=<?php echo $taxonomyId; ?>&act=ad&term_edit_id=<?php echo $term['id']; ?>">Editar</a> |
-                        <a href="taxonomies.php?taxonomy_id=<?php echo $taxonomyId; ?>&term_delete_id=<?php echo $term['id']; ?>" onclick="return confirm('Eliminar este termo?');">Eliminar</a>
+                        <a href="taxonomies.php?taxonomy_id=<?php echo $taxonomyId; ?>&act=ad&term_edit_id=<?php echo $term['id']; ?>" class="btn btn-sm btn-primary">Editar</a>
+                        <a href="taxonomies.php?taxonomy_id=<?php echo $taxonomyId; ?>&term_delete_id=<?php echo $term['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Eliminar este termo?');">Eliminar</a>
                     </td>
                 </tr>
             <?php endforeach; ?>
@@ -153,9 +153,9 @@ require_once __DIR__ . '/header.php';
                     <td><?php echo htmlspecialchars($tax['name']); ?></td>
                     <td><?php echo htmlspecialchars($tax['label']); ?></td>
                     <td>
-                        <a href="taxonomies.php?taxonomy_id=<?php echo $tax['id']; ?>">Gerir termos</a> |
-                        <a href="taxonomies.php?edit_id=<?php echo $tax['id']; ?>">Editar</a> |
-                        <a href="taxonomies.php?delete_id=<?php echo $tax['id']; ?>" onclick="return confirm('Eliminar esta taxonomia?');">Eliminar</a>
+                        <a href="taxonomies.php?taxonomy_id=<?php echo $tax['id']; ?>" class="btn btn-sm btn-info">Gerir termos</a>
+                        <a href="taxonomies.php?edit_id=<?php echo $tax['id']; ?>" class="btn btn-sm btn-secondary">Editar</a>
+                        <a href="taxonomies.php?delete_id=<?php echo $tax['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Eliminar esta taxonomia?');">Eliminar</a>
                     </td>
                 </tr>
             <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- Replace plain action links with Bootstrap buttons across taxonomy, content-type and dashboard tables

## Testing
- `php -l taxonomies.php`
- `php -l content_types.php`
- `php -l dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0cfdebfc48320829149f6508b283a