### PR TITLE
Adicionar opção de ordenação para campos personalizados

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -329,6 +329,16 @@ $(document).ready(function() {
         var $table = $(this);
         var source = $table.data('source');
         var options = { responsive: true };
+        var nonSortable = [];
+        $table.find('thead th').each(function(i){
+            if ($(this).data('orderable') === false){
+                nonSortable.push(i);
+            }
+        });
+        if (nonSortable.length) {
+            options.columnDefs = options.columnDefs || [];
+            options.columnDefs.push({ targets: nonSortable, orderable: false });
+        }
         if ($table.data('no-sort-last')) {
             options.columnDefs = options.columnDefs || [];
             options.columnDefs.push({ targets: -1, orderable: false });

--- a/custom_fields.php
+++ b/custom_fields.php
@@ -57,14 +57,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
     $required = isset($_POST['required']);
     $showInList = isset($_POST['show_in_list']);
+    $sortable = isset($_POST['sortable']);
     if ($name !== '' && $label !== '' && $fieldType !== '') {
         if ($fieldId) {
             $existing = getCustomField($fieldId);
             if ($existing && (int)$existing['content_type_id'] === $typeId) {
-                updateCustomField($fieldId, $name, $label, $fieldType, $options, $required, $showInList);
+                updateCustomField($fieldId, $name, $label, $fieldType, $options, $required, $showInList, $sortable);
             }
         } else {
-            createCustomField($typeId, $name, $label, $fieldType, $options, $required, $showInList);
+            createCustomField($typeId, $name, $label, $fieldType, $options, $required, $showInList, $sortable);
         }
         header('Location: custom_fields.php?type_id=' . $typeId);
         exit;
@@ -85,7 +86,7 @@ require_once __DIR__ . '/header.php';
     <?php endif; ?>
     <table class="table table-striped datatable">
         <thead>
-            <tr><th>Slug</th><th>Rótulo</th><th>Tipo</th><th>Opções</th><th>Obrigatório</th><th>Listagem</th><th>Ações</th></tr>
+            <tr><th>Slug</th><th>Rótulo</th><th>Tipo</th><th>Opções</th><th>Obrigatório</th><th>Listagem</th><th>Ordenável</th><th>Ações</th></tr>
         </thead>
         <tbody>
         <?php foreach ($fields as $field): ?>
@@ -116,6 +117,7 @@ require_once __DIR__ . '/header.php';
                 </td>
                 <td><?php echo $field['required'] ? 'Sim' : 'Não'; ?></td>
                 <td><?php echo !empty($field['show_in_list']) ? 'Sim' : 'Não'; ?></td>
+                <td><?php echo !empty($field['sortable']) ? 'Sim' : 'Não'; ?></td>
                 <td>
                     <a href="custom_fields.php?type_id=<?php echo $typeId; ?>&edit=<?php echo $field['id']; ?>" class="btn btn-sm btn-secondary">Editar</a>
                     <a href="custom_fields.php?type_id=<?php echo $typeId; ?>&delete=<?php echo $field['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Apagar este campo?');">Apagar</a>
@@ -180,6 +182,11 @@ require_once __DIR__ . '/header.php';
             <div class="form-check mb-3">
                 <input class="form-check-input" type="checkbox" id="show_in_list" name="show_in_list" <?php echo !empty($editField['show_in_list']) ? 'checked' : ''; ?>>
                 <label class="form-check-label" for="show_in_list">Mostrar na listagem</label>
+            </div>
+            <div class="form-check mb-3">
+                <input class="form-check-input" type="checkbox" id="sortable" name="sortable" <?php
+                    echo isset($editField['sortable']) ? (!empty($editField['sortable']) ? 'checked' : '') : 'checked'; ?>>
+                <label class="form-check-label" for="sortable">Permitir ordenação</label>
             </div>
             <button type="submit" class="btn btn-primary"><?php echo $editField ? 'Guardar' : 'Adicionar'; ?></button>
             <?php if ($editField): ?>

--- a/functions.php
+++ b/functions.php
@@ -227,8 +227,10 @@ function getCustomFields(int $content_type_id): array {
     $labelExpr = $hasLabel ? 'label' : 'name AS label';
     $hasList = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'show_in_list'")->fetch();
     $listExpr = $hasList ? 'show_in_list' : '0 AS show_in_list';
+    $hasSortable = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'sortable'")->fetch();
+    $sortableExpr = $hasSortable ? 'sortable' : '1 AS sortable';
 
-    $stmt = $pdo->prepare("SELECT id, name, $labelExpr, type, options, required, $listExpr FROM custom_fields WHERE content_type_id = ? ORDER BY id ASC");
+    $stmt = $pdo->prepare("SELECT id, name, $labelExpr, type, options, required, $listExpr, $sortableExpr FROM custom_fields WHERE content_type_id = ? ORDER BY id ASC");
     $stmt->execute([$content_type_id]);
     return $stmt->fetchAll();
 }
@@ -244,28 +246,51 @@ function getCustomFields(int $content_type_id): array {
  * @param bool $required Whether the field is mandatory
  * @return int
  */
-function createCustomField(int $content_type_id, string $name, string $label, string $type, string $options = '', bool $required = false, bool $show_in_list = false): int {
+function createCustomField(int $content_type_id, string $name, string $label, string $type, string $options = '', bool $required = false, bool $show_in_list = false, bool $sortable = true): int {
     $pdo = getPDO();
 
-    // If the table doesn't have certain columns (older schema), insert
-    // without them.  This keeps the function compatible with multiple
-    // schema versions and avoids SQL errors during field creation.
-    $hasLabel = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'label'")->fetch();
-    $hasList  = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'show_in_list'")->fetch();
+    // Detect optional columns to keep compatibility with older schemas.
+    $hasLabel    = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'label'")->fetch();
+    $hasList     = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'show_in_list'")->fetch();
+    $hasSortable = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'sortable'")->fetch();
 
-    if ($hasLabel && $hasList) {
-        $stmt = $pdo->prepare('INSERT INTO custom_fields (content_type_id, name, label, type, options, required, show_in_list) VALUES (?, ?, ?, ?, ?, ?, ?)');
-        $stmt->execute([$content_type_id, $name, $label, $type, $options, $required ? 1 : 0, $show_in_list ? 1 : 0]);
-    } elseif ($hasLabel) {
-        $stmt = $pdo->prepare('INSERT INTO custom_fields (content_type_id, name, label, type, options, required) VALUES (?, ?, ?, ?, ?, ?)');
-        $stmt->execute([$content_type_id, $name, $label, $type, $options, $required ? 1 : 0]);
-    } elseif ($hasList) {
-        $stmt = $pdo->prepare('INSERT INTO custom_fields (content_type_id, name, type, options, required, show_in_list) VALUES (?, ?, ?, ?, ?, ?)');
-        $stmt->execute([$content_type_id, $name, $type, $options, $required ? 1 : 0, $show_in_list ? 1 : 0]);
-    } else {
-        $stmt = $pdo->prepare('INSERT INTO custom_fields (content_type_id, name, type, options, required) VALUES (?, ?, ?, ?, ?)');
-        $stmt->execute([$content_type_id, $name, $type, $options, $required ? 1 : 0]);
+    $columns = ['content_type_id', 'name'];
+    $placeholders = ['?', '?'];
+    $params = [$content_type_id, $name];
+
+    if ($hasLabel) {
+        $columns[] = 'label';
+        $placeholders[] = '?';
+        $params[] = $label;
     }
+
+    $columns[] = 'type';
+    $placeholders[] = '?';
+    $params[] = $type;
+
+    $columns[] = 'options';
+    $placeholders[] = '?';
+    $params[] = $options;
+
+    $columns[] = 'required';
+    $placeholders[] = '?';
+    $params[] = $required ? 1 : 0;
+
+    if ($hasList) {
+        $columns[] = 'show_in_list';
+        $placeholders[] = '?';
+        $params[] = $show_in_list ? 1 : 0;
+    }
+
+    if ($hasSortable) {
+        $columns[] = 'sortable';
+        $placeholders[] = '?';
+        $params[] = $sortable ? 1 : 0;
+    }
+
+    $sql = 'INSERT INTO custom_fields (' . implode(', ', $columns) . ') VALUES (' . implode(', ', $placeholders) . ')';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
 
     return (int)$pdo->lastInsertId();
 }
@@ -280,7 +305,9 @@ function getCustomField(int $id): ?array {
     $pdo = getPDO();
     $hasList = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'show_in_list'")->fetch();
     $listExpr = $hasList ? 'show_in_list' : '0 AS show_in_list';
-    $stmt = $pdo->prepare("SELECT id, content_type_id, name, label, type, options, required, $listExpr FROM custom_fields WHERE id = ?");
+    $hasSortable = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'sortable'")->fetch();
+    $sortableExpr = $hasSortable ? 'sortable' : '1 AS sortable';
+    $stmt = $pdo->prepare("SELECT id, content_type_id, name, label, type, options, required, $listExpr, $sortableExpr FROM custom_fields WHERE id = ?");
     $stmt->execute([$id]);
     return $stmt->fetch() ?: null;
 }
@@ -296,16 +323,40 @@ function getCustomField(int $id): ?array {
  * @param bool $required
  * @return void
  */
-function updateCustomField(int $id, string $name, string $label, string $type, string $options = '', bool $required = false, bool $show_in_list = false): void {
+function updateCustomField(int $id, string $name, string $label, string $type, string $options = '', bool $required = false, bool $show_in_list = false, bool $sortable = true): void {
     $pdo = getPDO();
     $hasList = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'show_in_list'")->fetch();
+    $hasSortable = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'sortable'")->fetch();
+
+    $sets = ['name = ?'];
+    $params = [$name];
+
+    $sets[] = 'label = ?';
+    $params[] = $label;
+
+    $sets[] = 'type = ?';
+    $params[] = $type;
+
+    $sets[] = 'options = ?';
+    $params[] = $options;
+
+    $sets[] = 'required = ?';
+    $params[] = $required ? 1 : 0;
+
     if ($hasList) {
-        $stmt = $pdo->prepare('UPDATE custom_fields SET name = ?, label = ?, type = ?, options = ?, required = ?, show_in_list = ? WHERE id = ?');
-        $stmt->execute([$name, $label, $type, $options, $required ? 1 : 0, $show_in_list ? 1 : 0, $id]);
-    } else {
-        $stmt = $pdo->prepare('UPDATE custom_fields SET name = ?, label = ?, type = ?, options = ?, required = ? WHERE id = ?');
-        $stmt->execute([$name, $label, $type, $options, $required ? 1 : 0, $id]);
+        $sets[] = 'show_in_list = ?';
+        $params[] = $show_in_list ? 1 : 0;
     }
+
+    if ($hasSortable) {
+        $sets[] = 'sortable = ?';
+        $params[] = $sortable ? 1 : 0;
+    }
+
+    $params[] = $id;
+    $sql = 'UPDATE custom_fields SET ' . implode(', ', $sets) . ' WHERE id = ?';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
 }
 
 /**

--- a/list_content.php
+++ b/list_content.php
@@ -69,7 +69,7 @@ require_once __DIR__ . '/header.php';
                                     <th>Date</th>
                                 <?php endif; ?>
                                 <?php foreach ($customFields as $field): ?>
-                                    <th><?php echo htmlspecialchars($field['label']); ?></th>
+                                    <th<?php echo empty($field['sortable']) ? ' data-orderable="false"' : ''; ?>><?php echo htmlspecialchars($field['label']); ?></th>
                                 <?php endforeach; ?>
                                 <?php foreach ($allTaxonomies as $tax): ?>
                                     <th><?php echo htmlspecialchars($tax['label']); ?></th>

--- a/schema.sql
+++ b/schema.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS custom_fields (
     options TEXT,
     required TINYINT(1) NOT NULL DEFAULT 0,
     show_in_list TINYINT(1) NOT NULL DEFAULT 0,
+    sortable TINYINT(1) NOT NULL DEFAULT 1,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (content_type_id) REFERENCES content_types(id) ON DELETE CASCADE
 );


### PR DESCRIPTION
## Resumo
- incluir coluna `sortable` na tabela `custom_fields` e nas funções de criação/edição
- permitir configurar se o campo personalizado pode ser ordenado
- desativar ordenação no DataTable quando o campo não for ordenável

## Testes
- `php -l functions.php`
- `php -l custom_fields.php`
- `php -l list_content.php`
- `node --check assets/js/custom.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0d3bf4484832081d6e9fd413a272e