### PR TITLE
Fix undefined fields variable on custom fields page

### DIFF
--- a/custom_fields.php
+++ b/custom_fields.php
@@ -77,10 +77,8 @@ if (($_SERVER['REQUEST_METHOD'] === 'POST') && ($act === 'ad' || $editField)) {
     }
 }
 
-// Recupera os campos existentes apenas quando a listagem é exibida
-if ($act !== 'ad' && !$editField) {
-    $fields = getCustomFields($typeId);
-}
+// Recupera os campos existentes para exibição
+$fields = getCustomFields($typeId);
 
 require_once __DIR__ . '/header.php';
 ?>


### PR DESCRIPTION
## Summary
- always load existing custom fields

## Testing
- `php -l custom_fields.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0d6ed5d2c8320a860eea9d5ac2b49