### PR TITLE
Add back button on content type taxonomies page

### DIFF
--- a/content_type_taxonomies.php
+++ b/content_type_taxonomies.php
@@ -36,6 +36,7 @@ require_once __DIR__ . '/header.php';
             </div>
         <?php endforeach; ?>
         <button type="submit" class="btn btn-primary mt-3">Guardar</button>
+        <a href="content_types.php" class="btn btn-secondary mt-3 ms-2">Voltar</a>
     </form>
 </div>
 <?php require_once __DIR__ . '/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add Voltar link on taxonomy association form to return to content types list

## Testing
- `php -l content_type_taxonomies.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0d756c13483209fa1663da686588c