### PR TITLE
Add friendly routes for taxonomy management

### DIFF
--- a/router.php
+++ b/router.php
@@ -28,6 +28,14 @@ switch (true) {
     case $path === 'content-types':
         require __DIR__ . '/content_types.php';
         break;
+    case $path === 'taxonomies/add':
+        $_GET['act'] = 'ad';
+        require __DIR__ . '/taxonomies.php';
+        break;
+    case preg_match('#^taxonomies/edit/([0-9]+)$#', $path, $m):
+        $_GET['taxonomy_id'] = $m[1];
+        require __DIR__ . '/taxonomies.php';
+        break;
     case $path === 'taxonomies':
         require __DIR__ . '/taxonomies.php';
         break;

--- a/taxonomies.php
+++ b/taxonomies.php
@@ -3,11 +3,11 @@
  * Gestão de taxonomias e termos.
  *
  * Esta página permite criar novas taxonomias e gerir os termos de cada
- * taxonomia seleccionada. Se um parâmetro `taxonomy_id` for passado, a
- * interface apresenta os termos dessa taxonomia. Para adicionar novos termos,
- * utilizar `taxonomies.php?taxonomy_id={ID}&act=ad`. Caso contrário, lista-se
- * todas as taxonomias existentes. Para criar uma nova taxonomia, utilizar
- * `taxonomies.php?act=ad`.
+ * taxonomia seleccionada. Se um parâmetro `taxonomy_id` for passado via rota
+ * `taxonomies/edit/{ID}`, a interface apresenta os termos dessa taxonomia. Para
+ * adicionar novos termos, utilizar `taxonomies/edit/{ID}?act=ad`. Caso
+ * contrário, lista-se todas as taxonomias existentes. Para criar uma nova
+ * taxonomia, utilizar `taxonomies/add`.
  */
 
 require_once __DIR__ . '/functions.php';
@@ -29,7 +29,7 @@ if ($taxonomyId) {
 
     if ($termDeleteId) {
         deleteTerm($termDeleteId);
-        header('Location: taxonomies.php?taxonomy_id=' . $taxonomyId);
+        header('Location: taxonomies/edit/' . $taxonomyId);
         exit;
     }
 
@@ -41,7 +41,7 @@ if ($taxonomyId) {
             } else {
                 createTerm($taxonomyId, $termName);
             }
-            header('Location: taxonomies.php?taxonomy_id=' . $taxonomyId);
+            header('Location: taxonomies/edit/' . $taxonomyId);
             exit;
         }
     }
@@ -66,7 +66,7 @@ if ($taxonomyId) {
         if ($associated) {
             $params .= '&associated=' . $associated;
         }
-        header('Location: taxonomies.php?' . $params);
+        header('Location: taxonomies?' . $params);
         exit;
     }
 
@@ -79,7 +79,7 @@ if ($taxonomyId) {
             } else {
                 createTaxonomy($name, $label);
             }
-            header('Location: taxonomies.php');
+            header('Location: taxonomies');
             exit;
         } else {
             $error = 'Nome e rótulo são obrigatórios.';
@@ -100,18 +100,18 @@ require_once __DIR__ . '/header.php';
     <?php if ($act === 'ad'): ?>
         <h2 class="mt-3"><?php echo $editingTerm ? 'Editar termo' : 'Adicionar novo termo a ' . htmlspecialchars($taxonomy['label']); ?></h2>
         <div class="card p-3 mt-4">
-            <form method="post" action="?taxonomy_id=<?php echo $taxonomyId; ?>&act=ad<?php echo $editingTerm ? '&term_edit_id=' . $editingTerm['id'] : ''; ?>">
+            <form method="post" action="?act=ad<?php echo $editingTerm ? '&term_edit_id=' . $editingTerm['id'] : ''; ?>">
                 <div class="mb-3">
                     <label class="form-label" for="term_name">Nome</label>
                     <input type="text" class="form-control" id="term_name" name="term_name" value="<?php echo htmlspecialchars($editingTerm['name'] ?? ''); ?>" required>
                 </div>
                 <button type="submit" class="btn btn-primary"><i class="fa <?php echo $editingTerm ? 'fa-save' : 'fa-plus'; ?>"></i> <?php echo $editingTerm ? 'Guardar' : 'Adicionar'; ?></button>
-                <a href="taxonomies.php?taxonomy_id=<?php echo $taxonomyId; ?>" class="btn btn-secondary"><i class="fa fa-arrow-left"></i> Voltar</a>
+                <a href="taxonomies/edit/<?php echo $taxonomyId; ?>" class="btn btn-secondary"><i class="fa fa-arrow-left"></i> Voltar</a>
             </form>
         </div>
     <?php else: ?>
         <h2 class="mt-3">Termos de <?php echo htmlspecialchars($taxonomy['label']); ?></h2>
-        <a href="taxonomies.php?taxonomy_id=<?php echo $taxonomyId; ?>&act=ad" class="btn btn-success mb-3"><i class="fa fa-plus"></i> Adicionar termo</a>
+        <a href="taxonomies/edit/<?php echo $taxonomyId; ?>?act=ad" class="btn btn-success mb-3"><i class="fa fa-plus"></i> Adicionar termo</a>
         <table class="table table-striped datatable">
             <thead><tr><th>Nome</th><th>Ações</th></tr></thead>
             <tbody>
@@ -119,14 +119,14 @@ require_once __DIR__ . '/header.php';
                 <tr>
                     <td><?php echo htmlspecialchars($term['name']); ?></td>
                     <td>
-                        <a href="taxonomies.php?taxonomy_id=<?php echo $taxonomyId; ?>&act=ad&term_edit_id=<?php echo $term['id']; ?>" class="btn btn-sm btn-primary"><i class="fa fa-pencil"></i> Editar</a>
-                        <a href="taxonomies.php?taxonomy_id=<?php echo $taxonomyId; ?>&term_delete_id=<?php echo $term['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Eliminar este termo?');"><i class="fa fa-trash"></i> Eliminar</a>
+                        <a href="taxonomies/edit/<?php echo $taxonomyId; ?>?act=ad&term_edit_id=<?php echo $term['id']; ?>" class="btn btn-sm btn-primary"><i class="fa fa-pencil"></i> Editar</a>
+                        <a href="taxonomies/edit/<?php echo $taxonomyId; ?>?term_delete_id=<?php echo $term['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Eliminar este termo?');"><i class="fa fa-trash"></i> Eliminar</a>
                     </td>
                 </tr>
             <?php endforeach; ?>
             </tbody>
         </table>
-        <a href="taxonomies.php" class="btn btn-secondary"><i class="fa fa-arrow-left"></i> Voltar</a>
+        <a href="taxonomies" class="btn btn-secondary"><i class="fa fa-arrow-left"></i> Voltar</a>
     <?php endif; ?>
 
 <?php else: ?>
@@ -146,7 +146,7 @@ require_once __DIR__ . '/header.php';
                     <input type="text" class="form-control" id="label" name="label" value="<?php echo htmlspecialchars($editing['label'] ?? ''); ?>" required>
                 </div>
                 <button type="submit" class="btn btn-primary"><i class="fa <?php echo $editing ? 'fa-save' : 'fa-plus'; ?>"></i> <?php echo $editing ? 'Guardar' : 'Criar'; ?></button>
-                <a href="taxonomies.php" class="btn btn-secondary"><i class="fa fa-arrow-left"></i> Voltar</a>
+                <a href="taxonomies" class="btn btn-secondary"><i class="fa fa-arrow-left"></i> Voltar</a>
             </form>
         </div>
     <?php else: ?>
@@ -160,7 +160,7 @@ require_once __DIR__ . '/header.php';
             </div>
         <?php endif; ?>
         <h2 class="mt-3">Taxonomias</h2>
-        <a href="taxonomies.php?act=ad" class="btn btn-success mb-3"><i class="fa fa-plus"></i> Adicionar taxonomia</a>
+        <a href="taxonomies/add" class="btn btn-success mb-3"><i class="fa fa-plus"></i> Adicionar taxonomia</a>
         <table class="table table-striped datatable">
             <thead><tr><th>Rótulo</th><th>Slug</th><th>Ações</th></tr></thead>
             <tbody>
@@ -173,9 +173,9 @@ require_once __DIR__ . '/header.php';
                     <td><?php echo htmlspecialchars($tax['label']); ?></td>
                     <td><?php echo htmlspecialchars($tax['name']); ?></td>
                     <td>
-                        <a href="taxonomies.php?taxonomy_id=<?php echo $tax['id']; ?>" class="btn btn-sm btn-info"><i class="fa fa-tags"></i> Gerir termos</a>
-                        <a href="taxonomies.php?edit_id=<?php echo $tax['id']; ?>" class="btn btn-sm btn-secondary"><i class="fa fa-pencil"></i> Editar</a>
-                        <a href="taxonomies.php?delete_id=<?php echo $tax['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('<?php echo htmlspecialchars($confirmMsg, ENT_QUOTES); ?>');"><i class="fa fa-trash"></i> Eliminar</a>
+                        <a href="taxonomies/edit/<?php echo $tax['id']; ?>" class="btn btn-sm btn-info"><i class="fa fa-tags"></i> Gerir termos</a>
+                        <a href="taxonomies?edit_id=<?php echo $tax['id']; ?>" class="btn btn-sm btn-secondary"><i class="fa fa-pencil"></i> Editar</a>
+                        <a href="taxonomies?delete_id=<?php echo $tax['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('<?php echo htmlspecialchars($confirmMsg, ENT_QUOTES); ?>');"><i class="fa fa-trash"></i> Eliminar</a>
                     </td>
                 </tr>
             <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- add /taxonomies/add and /taxonomies/edit/{id} routes
- update taxonomy management page to redirect and link using new friendly paths

## Testing
- `php -l router.php`
- `php -l taxonomies.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2e73d2048832094d9d1f86a560197