### PR TITLE
Adicionar menu de utilizador com dropdown e rotas amigáveis

### DIFF
--- a/definicoes.php
+++ b/definicoes.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Página de definições do utilizador.
+ */
+require_once __DIR__ . '/functions.php';
+startSession();
+requireLogin();
+
+require_once __DIR__ . '/header.php';
+?>
+<div class="container-fluid">
+    <h2>Definições</h2>
+    <!-- Conteúdo de definições -->
+</div>
+<?php
+require_once __DIR__ . '/footer.php';

--- a/editar_perfil.php
+++ b/editar_perfil.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Página para editar o perfil do utilizador.
+ */
+require_once __DIR__ . '/functions.php';
+startSession();
+requireLogin();
+
+require_once __DIR__ . '/header.php';
+?>
+<div class="container-fluid">
+    <h2>Editar Perfil</h2>
+    <!-- Conteúdo de edição de perfil -->
+</div>
+<?php
+require_once __DIR__ . '/footer.php';

--- a/header.php
+++ b/header.php
@@ -93,11 +93,16 @@ foreach ($sidebarTypes as $sidebarType):
             <div class="nav_menu w-100">
                 <nav class="navbar navbar-expand w-100" role="navigation">
                     <ul class="navbar-nav w-100">
-                        <!-- Explicit logout button for better visibility -->
-                        <li class="nav-item ms-auto">
-                            <a href="<?= BASE_URL ?>logout" class="btn btn-sm btn-danger"><i class="fa fa-sign-out"></i>
-                                Terminar sessão (<?php echo htmlspecialchars($user['username']); ?>)
+                        <li class="nav-item dropdown ms-auto">
+                            <a class="nav-link dropdown-toggle" href="#" id="userMenu" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                <i class="fa fa-user"></i> <?php echo htmlspecialchars($user['username']); ?>
                             </a>
+                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userMenu">
+                                <li><a class="dropdown-item" href="<?= BASE_URL ?>editar-perfil">Editar perfil</a></li>
+                                <li><a class="dropdown-item" href="<?= BASE_URL ?>definicoes">Definições</a></li>
+                                <li><hr class="dropdown-divider"></li>
+                                <li><a class="dropdown-item text-danger" href="<?= BASE_URL ?>terminar-sessao"><i class="fa fa-sign-out"></i> Terminar sessão</a></li>
+                            </ul>
                         </li>
                     </ul>
                 </nav>

--- a/router.php
+++ b/router.php
@@ -19,8 +19,15 @@ switch (true) {
     case $path === 'login':
         require __DIR__ . '/login.php';
         break;
+    case $path === 'terminar-sessao':
     case $path === 'logout':
         require __DIR__ . '/logout.php';
+        break;
+    case $path === 'editar-perfil':
+        require __DIR__ . '/editar_perfil.php';
+        break;
+    case $path === 'definicoes':
+        require __DIR__ . '/definicoes.php';
         break;
     case $path === 'dashboard':
         require __DIR__ . '/dashboard.php';


### PR DESCRIPTION
## Sumário
- Substitui o botão de terminar sessão por um menu dropdown com opções de editar perfil, definições e logout
- Adiciona páginas placeholder para editar perfil e definições
- Cria rotas amigáveis para editar perfil, definições e terminar sessão

## Testes
- `php -l header.php`
- `php -l router.php`
- `php -l editar_perfil.php`
- `php -l definicoes.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2ebbb732083208b689f50427899c0