### PR TITLE
Use path-based route for custom field creation

### DIFF
--- a/custom_fields.php
+++ b/custom_fields.php
@@ -90,7 +90,7 @@ require_once __DIR__ . '/header.php';
     <?php endif; ?>
 
     <div class="card p-3 mt-4">
-        <form method="post" action="<?php echo $editField ? BASE_URL . $typeId . '?edit_id=' . $editField['id'] : BASE_URL . $typeId . '?act=ad'; ?>">
+        <form method="post" action="<?php echo $editField ? BASE_URL . $typeId . '?edit_id=' . $editField['id'] : BASE_URL . $typeId . '/ad'; ?>">
             <?php if ($editField): ?>
                 <input type="hidden" name="field_id" value="<?php echo $editField['id']; ?>">
             <?php endif; ?>
@@ -157,7 +157,7 @@ require_once __DIR__ . '/header.php';
     </div>
 <?php else: ?>
     <h2 class="mt-3">Campos personalizados para <?php echo htmlspecialchars($type['label']); ?></h2>
-    <a href="<?= BASE_URL . $typeId; ?>?act=ad" class="btn btn-success mb-3"><i class="fa fa-plus"></i> Adicionar campo</a>
+    <a href="<?= BASE_URL . $typeId; ?>/ad" class="btn btn-success mb-3"><i class="fa fa-plus"></i> Adicionar campo</a>
     <table class="table table-striped datatable">
         <thead>
             <tr><th>Slug</th><th>Rótulo</th><th>Tipo</th><th>Opções</th><th>Obrigatório</th><th>Listagem</th><th>Ações</th></tr>

--- a/router.php
+++ b/router.php
@@ -78,6 +78,12 @@ switch (true) {
         // List all taxonomies
         require __DIR__ . '/taxonomies.php';
         break;
+    case preg_match('#^([0-9]+)/ad$#', $path, $m):
+        // Add a custom field to a content type, e.g. "/cms/3/ad"
+        $_GET['type_id'] = $m[1];
+        $_GET['act'] = 'ad';
+        require __DIR__ . '/custom_fields.php';
+        break;
     case preg_match('#^([0-9]+)$#', $path, $m):
         // Custom fields of a content type by numeric ID, e.g. "/cms/3"
         $_GET['type_id'] = $m[1];


### PR DESCRIPTION
## Summary
- Allow adding custom fields via `/cms/{id}/ad` path
- Map `/cms/{id}/ad` requests in router to `custom_fields.php`

## Testing
- `php -l custom_fields.php router.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3129be1fc8320bb7224a296b7685c