### PR TITLE
Add friendly route for content type taxonomies

### DIFF
--- a/content_type_taxonomies.php
+++ b/content_type_taxonomies.php
@@ -28,7 +28,7 @@ $current = array_map(fn($t) => (int)$t['id'], getTaxonomiesForContentType($typeI
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $selected = isset($_POST['taxonomies']) ? array_map('intval', (array)$_POST['taxonomies']) : [];
     setContentTypeTaxonomies($typeId, $selected);
-    header('Location: content_type_taxonomies.php?type_id=' . $typeId);
+    header('Location: ' . BASE_URL . 'content-type-taxonomies/' . $typeId);
     exit;
 }
 

--- a/content_types.php
+++ b/content_types.php
@@ -71,7 +71,7 @@ require_once __DIR__ . '/header.php';
                     <a href="<?= BASE_URL . $type['id']; ?>" class="btn btn-sm btn-info"><i class="fa fa-list-alt"></i> Campos</a>
                     <a href="<?= BASE_URL ?>tipode-conteudo/<?php echo htmlspecialchars(rawurlencode($type['name'])); ?>/add" class="btn btn-sm btn-success"><i class="fa fa-plus"></i> Adicionar</a>
                     <a href="<?= BASE_URL ?>tipode-conteudo/<?php echo htmlspecialchars(rawurlencode($type['name'])); ?>" class="btn btn-sm btn-secondary"><i class="fa fa-list"></i> Listar</a>
-                    <a href="content_type_taxonomies.php?type_id=<?php echo $type['id']; ?>" class="btn btn-sm btn-warning"><i class="fa fa-tags"></i> Taxonomias</a>
+                    <a href="<?= BASE_URL ?>content-type-taxonomies/<?php echo $type['id']; ?>" class="btn btn-sm btn-warning"><i class="fa fa-tags"></i> Taxonomias</a>
                     <a href="content_type_form.php?id=<?php echo $type['id']; ?>" class="btn btn-sm btn-primary"><i class="fa fa-pencil"></i> Editar</a>
                     <a href="content_types.php?delete_id=<?php echo $type['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('<?php echo htmlspecialchars($confirmMsg, ENT_QUOTES); ?>');"><i class="fa fa-trash"></i> Eliminar</a>
                 </td>

--- a/header.php
+++ b/header.php
@@ -76,7 +76,7 @@ foreach ($sidebarTypes as $sidebarType):
                                     <li><a href="<?= BASE_URL ?>tipode-conteudo/<?php echo htmlspecialchars(rawurlencode($sidebarType['name'])); ?>/add">Adicionar</a></li>
                                     <li><a href="<?= BASE_URL ?>tipode-conteudo/<?php echo htmlspecialchars(rawurlencode($sidebarType['name'])); ?>">Listar</a></li>
                                     <li><a href="<?= BASE_URL . $sidebarType['id']; ?>">Campos</a></li>
-                                    <li><a href="content_type_taxonomies.php?type_id=<?php echo $sidebarType['id']; ?>">Taxonomias</a></li>
+                                    <li><a href="<?= BASE_URL ?>content-type-taxonomies/<?php echo $sidebarType['id']; ?>">Taxonomias</a></li>
                                 </ul>
                             </li>
 <?php endforeach; ?>

--- a/router.php
+++ b/router.php
@@ -78,6 +78,11 @@ switch (true) {
         // List all taxonomies
         require __DIR__ . '/taxonomies.php';
         break;
+    case preg_match('#^content-type-taxonomies/([0-9]+)$#', $path, $m):
+        // Manage taxonomies associated with a content type
+        $_GET['type_id'] = $m[1];
+        require __DIR__ . '/content_type_taxonomies.php';
+        break;
     case preg_match('#^([0-9]+)/ad$#', $path, $m):
         // Add a custom field to a content type, e.g. "/cms/3/ad"
         $_GET['type_id'] = $m[1];


### PR DESCRIPTION
## Summary
- Add routing for `/content-type-taxonomies/{id}` to expose taxonomy associations for content types
- Update links to use the new friendly URL
- Redirect taxonomy form to the new path after saving

## Testing
- `php -l content_types.php`
- `php -l header.php`
- `php -l content_type_taxonomies.php`
- `php -l router.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3144ee87883208d8fa21b7f060453