### PR TITLE
Simplify content type URLs

### DIFF
--- a/add_content.php
+++ b/add_content.php
@@ -83,7 +83,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $termIds = isset($_POST[$termsKey]) ? (array)$_POST[$termsKey] : [];
             setContentTaxonomyTerms($contentId, $taxonomy['id'], $termIds);
         }
-        header('Location: ' . BASE_URL . 'tipode-conteudo/' . rawurlencode($typeSlug));
+        header('Location: ' . BASE_URL . rawurlencode($typeSlug));
         exit;
     }
 }
@@ -171,7 +171,7 @@ require_once __DIR__ . '/header.php';
                             </div>
                         <?php endforeach; ?>
                         <button type="submit" class="btn btn-success"><i class="fa fa-save"></i> Save</button>
-                        <a href="<?= BASE_URL ?>tipode-conteudo/<?php echo htmlspecialchars(rawurlencode($typeSlug)); ?>" class="btn btn-secondary"><i class="fa fa-arrow-left"></i> Cancel</a>
+                        <a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($typeSlug)); ?>" class="btn btn-secondary"><i class="fa fa-arrow-left"></i> Cancel</a>
                     </form>
                 </div>
             </div>

--- a/content_types.php
+++ b/content_types.php
@@ -69,8 +69,8 @@ require_once __DIR__ . '/header.php';
                 <td><i class="<?php echo htmlspecialchars($type['icon']); ?>"></i></td>
                 <td>
                     <a href="<?= BASE_URL . $type['id']; ?>" class="btn btn-sm btn-info"><i class="fa fa-list-alt"></i> Campos</a>
-                    <a href="<?= BASE_URL ?>tipode-conteudo/<?php echo htmlspecialchars(rawurlencode($type['name'])); ?>/add" class="btn btn-sm btn-success"><i class="fa fa-plus"></i> Adicionar</a>
-                    <a href="<?= BASE_URL ?>tipode-conteudo/<?php echo htmlspecialchars(rawurlencode($type['name'])); ?>" class="btn btn-sm btn-secondary"><i class="fa fa-list"></i> Listar</a>
+                    <a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($type['name'])); ?>/add" class="btn btn-sm btn-success"><i class="fa fa-plus"></i> Adicionar</a>
+                    <a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($type['name'])); ?>" class="btn btn-sm btn-secondary"><i class="fa fa-list"></i> Listar</a>
                     <a href="<?= BASE_URL ?>content-type-taxonomies/<?php echo $type['id']; ?>" class="btn btn-sm btn-warning"><i class="fa fa-tags"></i> Taxonomias</a>
                     <a href="content_type_form.php?id=<?php echo $type['id']; ?>" class="btn btn-sm btn-primary"><i class="fa fa-pencil"></i> Editar</a>
                     <a href="content_types.php?delete_id=<?php echo $type['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('<?php echo htmlspecialchars($confirmMsg, ENT_QUOTES); ?>');"><i class="fa fa-trash"></i> Eliminar</a>

--- a/data/list_content.php
+++ b/data/list_content.php
@@ -71,7 +71,7 @@ foreach ($contents as $content) {
         $row[] = htmlspecialchars(implode(', ', $termsList));
     }
 
-    $baseUrl = BASE_URL . 'tipode-conteudo/' . rawurlencode($typeSlug);
+    $baseUrl = BASE_URL . rawurlencode($typeSlug);
     $actions = '<a href="' . $baseUrl . '/' . $content['id'] . '" class="btn btn-sm btn-primary"><i class="fa fa-pencil"></i> Editar</a> ';
     $actions .= '<a href="' . $baseUrl . '?delete=' . $content['id'] . '" class="btn btn-sm btn-danger" onclick="return confirm(\'Apagar este conteúdo?\');"><i class="fa fa-trash"></i> Apagar</a>';
     $row[] = $actions;

--- a/edit_content.php
+++ b/edit_content.php
@@ -66,7 +66,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $termIds = isset($_POST[$termsKey]) ? (array)$_POST[$termsKey] : [];
             setContentTaxonomyTerms($contentId, $taxonomy['id'], $termIds);
         }
-        header('Location: ' . BASE_URL . 'tipode-conteudo/' . rawurlencode($typeSlug));
+        header('Location: ' . BASE_URL . rawurlencode($typeSlug));
         exit;
     }
 }
@@ -159,7 +159,7 @@ require_once __DIR__ . '/header.php';
                             </div>
                         <?php endforeach; ?>
                         <button type="submit" class="btn btn-success"><i class="fa fa-save"></i> Save</button>
-                        <a href="<?= BASE_URL ?>tipode-conteudo/<?php echo htmlspecialchars(rawurlencode($typeSlug)); ?>" class="btn btn-secondary"><i class="fa fa-arrow-left"></i> Cancel</a>
+                        <a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($typeSlug)); ?>" class="btn btn-secondary"><i class="fa fa-arrow-left"></i> Cancel</a>
                     </form>
                 </div>
             </div>

--- a/header.php
+++ b/header.php
@@ -73,8 +73,8 @@ foreach ($sidebarTypes as $sidebarType):
                             <li><a><i class="<?php echo htmlspecialchars($sidebarType['icon'] ?? 'fa fa-file-text'); ?>"></i> <?php echo htmlspecialchars($sidebarType['label']); ?> <span class="fa fa-chevron-down"></span></a>
 
                                 <ul class="nav child_menu">
-                                    <li><a href="<?= BASE_URL ?>tipode-conteudo/<?php echo htmlspecialchars(rawurlencode($sidebarType['name'])); ?>/add">Adicionar</a></li>
-                                    <li><a href="<?= BASE_URL ?>tipode-conteudo/<?php echo htmlspecialchars(rawurlencode($sidebarType['name'])); ?>">Listar</a></li>
+                                    <li><a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($sidebarType['name'])); ?>/add">Adicionar</a></li>
+                                    <li><a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($sidebarType['name'])); ?>">Listar</a></li>
                                     <li><a href="<?= BASE_URL . $sidebarType['id']; ?>">Campos</a></li>
                                     <li><a href="<?= BASE_URL ?>content-type-taxonomies/<?php echo $sidebarType['id']; ?>">Taxonomias</a></li>
                                 </ul>

--- a/list_content.php
+++ b/list_content.php
@@ -43,7 +43,7 @@ if (isset($_GET['delete'])) {
     if ($content && (int)$content['content_type_id'] === $typeId) {
         deleteContent($deleteId);
     }
-    header('Location: ' . BASE_URL . 'tipode-conteudo/' . rawurlencode($typeSlug));
+    header('Location: ' . BASE_URL . rawurlencode($typeSlug));
     exit;
 }
 
@@ -66,7 +66,7 @@ require_once __DIR__ . '/header.php';
         <div class="col-md-12 col-sm-12">
             <div class="x_panel">
                 <div class="x_content">
-                    <a href="<?= BASE_URL ?>tipode-conteudo/<?php echo htmlspecialchars(rawurlencode($typeSlug)); ?>/add" class="btn btn-success mb-3"><i class="fa fa-plus"></i> Add New</a>
+                    <a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($typeSlug)); ?>/add" class="btn btn-success mb-3"><i class="fa fa-plus"></i> Add New</a>
                     <table class="table table-striped datatable" data-source="data/list_content.php" data-type-id="<?php echo $typeId; ?>">
                         <thead>
                             <tr>

--- a/router.php
+++ b/router.php
@@ -90,17 +90,21 @@ switch (true) {
         $_GET['type_id'] = $m[1];
         require __DIR__ . '/custom_fields.php';
         break;
-    case preg_match('#^tipode-conteudo/([^/]+)/add$#', $path, $m):
+    case preg_match('#^content-type-taxonomies/([0-9]+)$#', $path, $m):
+        $_GET['type_id'] = $m[1];
+        require __DIR__ . '/content_type_taxonomies.php';
+        break;
+    case preg_match('#^([^/]+)/add$#', $path, $m):
         $_GET['type_slug'] = $m[1];
         require __DIR__ . '/add_content.php';
         break;
-    case preg_match('#^tipode-conteudo/([^/]+)/([0-9]+)$#', $path, $m):
+    case preg_match('#^([^/]+)/([0-9]+)$#', $path, $m):
         $_GET['id'] = $m[2];
         // Optional slug is $m[1] if needed in the script
         $_GET['type_slug'] = $m[1];
         require __DIR__ . '/edit_content.php';
         break;
-    case preg_match('#^tipode-conteudo/([^/]+)$#', $path, $m):
+    case preg_match('#^([^/]+)$#', $path, $m):
         $_GET['type_slug'] = $m[1];
         require __DIR__ . '/list_content.php';
         break;


### PR DESCRIPTION
## Summary
- Remove `tipode-conteudo` prefix from content type routes
- Update navigation and content pages to new `/cms/{type}` URL structure
- Add route for content type taxonomy management

## Testing
- `php -l router.php header.php content_types.php add_content.php edit_content.php list_content.php data/list_content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3158915348320b910b0e7c649f9b8