### PR TITLE
fix: adjust custom fields route

### DIFF
--- a/content_types.php
+++ b/content_types.php
@@ -69,7 +69,7 @@ require_once __DIR__ . '/header.php';
                 <td><i class="<?php echo htmlspecialchars($type['icon']); ?>"></i></td>
                 <td>
 
-                    <a href="<?= BASE_URL . $type['id']; ?>" class="btn btn-sm btn-info"><i class="fa fa-list-alt"></i> Campos</a>
+                    <a href="<?= BASE_URL . 'campos/' . $type['id']; ?>" class="btn btn-sm btn-info"><i class="fa fa-list-alt"></i> Campos</a>
 
                     <a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($type['name'])); ?>/add" class="btn btn-sm btn-success"><i class="fa fa-plus"></i> Adicionar</a>
                     <a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($type['name'])); ?>" class="btn btn-sm btn-secondary"><i class="fa fa-list"></i> Listar</a>

--- a/custom_fields.php
+++ b/custom_fields.php
@@ -29,7 +29,7 @@ if ($deleteId) {
     if ($field && (int) $field['content_type_id'] === $typeId) {
         deleteCustomField($deleteId);
     }
-    header('Location: ' . BASE_URL . 'campos/cam/' . $typeId);
+    header('Location: ' . BASE_URL . 'campos/' . $typeId);
     exit;
 }
 
@@ -70,7 +70,7 @@ if (($_SERVER['REQUEST_METHOD'] === 'POST') && ($act === 'ad' || $editField)) {
         } else {
             createCustomField($typeId, $name, $label, $fieldType, $options, $required, $showInList, $sortable);
         }
-        header('Location: ' . BASE_URL . 'campos/cam/' . $typeId);
+        header('Location: ' . BASE_URL . 'campos/' . $typeId);
         exit;
     } else {
         $error = 'Nome, rótulo e tipo são obrigatórios.';
@@ -91,7 +91,7 @@ require_once __DIR__ . '/header.php';
 
     <div class="card p-3 mt-4">
 
-        <form method="post" action="<?php echo $editField ? BASE_URL . 'campos/cam/' . $typeId . '?edit_id=' . $editField['id'] : BASE_URL . 'campos/cam/' . $typeId . '/ad'; ?>">
+        <form method="post" action="<?php echo $editField ? BASE_URL . 'campos/' . $typeId . '?edit_id=' . $editField['id'] : BASE_URL . 'campos/' . $typeId . '/ad'; ?>">
             <?php if ($editField): ?>
                 <input type="hidden" name="field_id" value="<?php echo $editField['id']; ?>">
             <?php endif; ?>
@@ -153,12 +153,12 @@ require_once __DIR__ . '/header.php';
                 <label class="form-check-label" for="sortable">Permitir ordenação</label>
             </div>
             <button type="submit" class="btn btn-primary"><i class="fa <?php echo $editField ? 'fa-save' : 'fa-plus'; ?>"></i> <?php echo $editField ? 'Guardar' : 'Adicionar'; ?></button>
-            <a href="<?= BASE_URL . 'campos/cam/' . $typeId; ?>" class="btn btn-secondary ms-2"><i class="fa fa-arrow-left"></i> Voltar</a>
+            <a href="<?= BASE_URL . 'campos/' . $typeId; ?>" class="btn btn-secondary ms-2"><i class="fa fa-arrow-left"></i> Voltar</a>
         </form>
     </div>
 <?php else: ?>
     <h2 class="mt-3">Campos personalizados para <?php echo htmlspecialchars($type['label']); ?></h2>
-    <a href="<?= BASE_URL . 'campos/cam/' . $typeId; ?>/ad" class="btn btn-success mb-3"><i class="fa fa-plus"></i> Adicionar campo</a>
+    <a href="<?= BASE_URL . 'campos/' . $typeId; ?>/ad" class="btn btn-success mb-3"><i class="fa fa-plus"></i> Adicionar campo</a>
     <table class="table table-striped datatable">
         <thead>
             <tr><th>Slug</th><th>Rótulo</th><th>Tipo</th><th>Opções</th><th>Obrigatório</th><th>Listagem</th><th>Ações</th></tr>
@@ -193,8 +193,8 @@ require_once __DIR__ . '/header.php';
                 <td><?php echo $field['required'] ? 'Sim' : 'Não'; ?></td>
                 <td><?php echo !empty($field['show_in_list']) ? 'Sim' : 'Não'; ?></td>
                 <td>
-                    <a href="<?= BASE_URL . 'campos/cam/' . $typeId . '/edit-field/' . $field['id']; ?>" class="btn btn-sm btn-secondary"><i class="fa fa-pencil"></i> Editar</a>
-                    <a href="<?= BASE_URL . 'campos/cam/' . $typeId; ?>?delete_id=<?php echo $field['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Apagar este campo?');"><i class="fa fa-trash"></i> Apagar</a>
+                    <a href="<?= BASE_URL . 'campos/' . $typeId . '/edit-field/' . $field['id']; ?>" class="btn btn-sm btn-secondary"><i class="fa fa-pencil"></i> Editar</a>
+                    <a href="<?= BASE_URL . 'campos/' . $typeId; ?>?delete_id=<?php echo $field['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Apagar este campo?');"><i class="fa fa-trash"></i> Apagar</a>
                 </td>
             </tr>
         <?php endforeach; ?>

--- a/header.php
+++ b/header.php
@@ -76,7 +76,7 @@ foreach ($sidebarTypes as $sidebarType):
 
                                     <li><a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($sidebarType['name'])); ?>/add">Adicionar</a></li>
                                     <li><a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($sidebarType['name'])); ?>">Listar</a></li>
-                                    <li><a href="<?= BASE_URL . $sidebarType['id']; ?>">Campos</a></li>
+                                    <li><a href="<?= BASE_URL . 'campos/' . $sidebarType['id']; ?>">Campos</a></li>
                                     <li><a href="<?= BASE_URL ?>content-type-taxonomies/<?php echo $sidebarType['id']; ?>">Taxonomias</a></li>
                                 </ul>
                             </li>

--- a/router.php
+++ b/router.php
@@ -78,21 +78,21 @@ switch (true) {
         // List all taxonomies
         require __DIR__ . '/taxonomies.php';
         break;
-    case preg_match('#^campos/cam/([0-9]+)/ad$#', $path, $m):
-        // Add a custom field to a content type, e.g. "/cms/campos/cam/3/ad"
+    case preg_match('#^campos/([0-9]+)/ad$#', $path, $m):
+        // Add a custom field to a content type, e.g. "/cms/campos/3/ad"
         $_GET['type_id'] = $m[1];
         $_GET['act'] = 'ad';
 
         require __DIR__ . '/custom_fields.php';
         break;
-    case preg_match('#^campos/cam/([0-9]+)/edit-field/([0-9]+)$#', $path, $m):
+    case preg_match('#^campos/([0-9]+)/edit-field/([0-9]+)$#', $path, $m):
         // Edit a custom field of a content type
         $_GET['type_id'] = $m[1];
         $_GET['edit_id'] = $m[2];
         require __DIR__ . '/custom_fields.php';
         break;
-    case preg_match('#^campos/cam/([0-9]+)$#', $path, $m):
-        // Custom fields of a content type by numeric ID, e.g. "/cms/campos/cam/3"
+    case preg_match('#^campos/([0-9]+)$#', $path, $m):
+        // Custom fields of a content type by numeric ID, e.g. "/cms/campos/3"
         $_GET['type_id'] = $m[1];
         require __DIR__ . '/custom_fields.php';
         break;


### PR DESCRIPTION
## Summary
- Route custom fields through `/campos/{id}` paths
- Update navigation and redirects to use new path

## Testing
- `php -l router.php`
- `php -l custom_fields.php`
- `php -l content_types.php`
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b317d2600c8320b508cc9930cddbae