### PR TITLE
feat: add explicit edit route

### DIFF
--- a/data/list_content.php
+++ b/data/list_content.php
@@ -71,9 +71,12 @@ foreach ($contents as $content) {
         $row[] = htmlspecialchars(implode(', ', $termsList));
     }
 
-    $baseUrl = BASE_URL . rawurlencode($typeSlug);
-    $actions = '<a href="' . $baseUrl . '/' . $content['id'] . '" class="btn btn-sm btn-primary"><i class="fa fa-pencil"></i> Editar</a> ';
-    $actions .= '<a href="' . $baseUrl . '?delete=' . $content['id'] . '" class="btn btn-sm btn-danger" onclick="return confirm(\'Apagar este conteúdo?\');"><i class="fa fa-trash"></i> Apagar</a>';
+    $cmsBase  = rtrim(dirname(BASE_URL), '/') . '/';
+    $typeBase = $cmsBase . rawurlencode($typeSlug);
+    $editUrl  = $typeBase . '/edit/' . $content['id'];
+    $deleteUrl = $typeBase . '?delete=' . $content['id'];
+    $actions = '<a href="' . $editUrl . '" class="btn btn-sm btn-primary"><i class="fa fa-pencil"></i> Editar</a> ';
+    $actions .= '<a href="' . $deleteUrl . '" class="btn btn-sm btn-danger" onclick="return confirm(\'Apagar este conteúdo?\');"><i class="fa fa-trash"></i> Apagar</a>';
     $row[] = $actions;
 
     $data[] = $row;

--- a/router.php
+++ b/router.php
@@ -104,12 +104,15 @@ switch (true) {
         $_GET['type_slug'] = $m[1];
         require __DIR__ . '/add_content.php';
         break;
-    case preg_match('#^([^/]+)/([0-9]+)$#', $path, $m):
-        $_GET['id'] = $m[2];
-        // Optional slug is $m[1] if needed in the script
+    case preg_match('#^([^/]+)/edit/([0-9]+)$#', $path, $m):
         $_GET['type_slug'] = $m[1];
+        $_GET['id'] = $m[2];
         require __DIR__ . '/edit_content.php';
         break;
+    case preg_match('#^([^/]+)/([0-9]+)$#', $path, $m):
+        // Support legacy URLs like "/tipo/3" by redirecting to "/tipo/edit/3"
+        header('Location: ' . $base . '/' . rawurlencode($m[1]) . '/edit/' . $m[2]);
+        exit;
     case preg_match('#^([^/]+)$#', $path, $m):
         $_GET['type_slug'] = $m[1];
         require __DIR__ . '/list_content.php';


### PR DESCRIPTION
## Summary
- fix base URL for edit links
- expose `/type/edit/id` route

## Testing
- `php -l data/list_content.php`
- `php -l router.php`


------
https://chatgpt.com/codex/tasks/task_e_68b319a4fc2c8320b65a04ee5d3a8aa5