### PR TITLE
Fix edit link path for content list

### DIFF
--- a/data/list_content.php
+++ b/data/list_content.php
@@ -71,7 +71,10 @@ foreach ($contents as $content) {
         $row[] = htmlspecialchars(implode(', ', $termsList));
     }
 
-    $cmsBase  = rtrim(dirname(BASE_URL), '/') . '/';
+    // BASE_URL inside this script may include a trailing "/data" segment
+    // because the file lives in a subdirectory. Remove any trailing
+    // "/data" so that generated links point to the CMS root.
+    $cmsBase  = preg_replace('#/data/?$#', '', rtrim(BASE_URL, '/')) . '/';
     $typeBase = $cmsBase . rawurlencode($typeSlug);
     $editUrl  = $typeBase . '/edit/' . $content['id'];
     $deleteUrl = $typeBase . '?delete=' . $content['id'];


### PR DESCRIPTION
## Summary
- ensure generated edit URLs strip trailing `/data` so links point to CMS root

## Testing
- `php -l data/list_content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b31b02f0f4832097c7aca18149b5b3