### PR TITLE
Simplify custom field edit URLs

### DIFF
--- a/router.php
+++ b/router.php
@@ -85,10 +85,9 @@ switch (true) {
 
         require __DIR__ . '/custom_fields.php';
         break;
-    case preg_match('#^campos/([0-9]+)/edit-field/([0-9]+)$#', $path, $m):
-        // Edit a custom field of a content type
-        $_GET['type_id'] = $m[1];
-        $_GET['edit_id'] = $m[2];
+    case preg_match('#^campos/edit-field/([0-9]+)$#', $path, $m):
+        // Edit a custom field, e.g. "/cms/campos/edit-field/10"
+        $_GET['edit_id'] = $m[1];
         require __DIR__ . '/custom_fields.php';
         break;
     case preg_match('#^campos/([0-9]+)$#', $path, $m):


### PR DESCRIPTION
## Summary
- Map `/campos/edit-field/{fieldId}` without requiring content type id
- Deduce content type from field id when editing a custom field
- Update forms and links to use the new URL structure

## Testing
- `php -l router.php`
- `php -l custom_fields.php`


------
https://chatgpt.com/codex/tasks/task_e_68b31c698de48320a83e3f0d1d110572