### PR TITLE
Fix taxonomy redirects

### DIFF
--- a/taxonomies.php
+++ b/taxonomies.php
@@ -31,7 +31,7 @@ if ($taxonomyId) {
 
     if ($termDeleteId) {
         deleteTerm($termDeleteId);
-        header('Location: taxonomies/edit-terms/' . $taxonomyId);
+        header('Location: ' . BASE_URL . 'taxonomies/edit-terms/' . $taxonomyId);
         exit;
     }
 
@@ -43,7 +43,7 @@ if ($taxonomyId) {
             } else {
                 createTerm($taxonomyId, $termName);
             }
-            header('Location: taxonomies/edit-terms/' . $taxonomyId);
+            header('Location: ' . BASE_URL . 'taxonomies/edit-terms/' . $taxonomyId);
             exit;
         }
     }
@@ -68,7 +68,7 @@ if ($taxonomyId) {
         if ($associated) {
             $params .= '&associated=' . $associated;
         }
-        header('Location: taxonomies?' . $params);
+        header('Location: ' . BASE_URL . 'taxonomies?' . $params);
         exit;
     }
 
@@ -81,7 +81,7 @@ if ($taxonomyId) {
             } else {
                 createTaxonomy($name, $label);
             }
-            header('Location: taxonomies');
+            header('Location: ' . BASE_URL . 'taxonomies');
             exit;
         } else {
             $error = 'Nome e rótulo são obrigatórios.';


### PR DESCRIPTION
## Summary
- ensure taxonomy term management uses BASE_URL for redirects
- fix taxonomy add/edit redirect URLs to use BASE_URL

## Testing
- `php -l taxonomies.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3200bfdc4832089eb1d4cefb8c919