### PR TITLE
Switch content type add/edit to friendly routes

### DIFF
--- a/content_type_form.php
+++ b/content_type_form.php
@@ -25,7 +25,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         } else {
             createContentType($name, $label, $icon === '' ? 'fa fa-file-text' : $icon, $showAuthor, $showDate);
         }
-        header('Location: content_types.php');
+        header('Location: ' . BASE_URL . 'content-types');
         exit;
     } else {
         $error = 'Nome e rótulo são obrigatórios.';
@@ -39,7 +39,7 @@ require_once __DIR__ . '/header.php';
     <?php if ($error): ?>
         <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
     <?php endif; ?>
-    <form method="post" action="<?php echo $editing ? '?id=' . $editing['id'] : ''; ?>">
+    <form method="post" action="<?php echo $editing ? BASE_URL . 'content-type/edit/' . $editing['id'] : BASE_URL . 'content-type/add'; ?>">
         <div class="mb-3">
             <label class="form-label" for="name">Slug</label>
             <input type="text" class="form-control" id="name" name="name" value="<?php echo htmlspecialchars($editing['name'] ?? ''); ?>" required>

--- a/content_type_taxonomies.php
+++ b/content_type_taxonomies.php
@@ -44,7 +44,7 @@ require_once __DIR__ . '/header.php';
             </div>
         <?php endforeach; ?>
         <button type="submit" class="btn btn-primary mt-3"><i class="fa fa-save"></i> Guardar</button>
-        <a href="content_types.php" class="btn btn-secondary mt-3 ms-2"><i class="fa fa-arrow-left"></i> Voltar</a>
+        <a href="<?= BASE_URL ?>content-types" class="btn btn-secondary mt-3 ms-2"><i class="fa fa-arrow-left"></i> Voltar</a>
     </form>
 </div>
 <?php require_once __DIR__ . '/footer.php'; ?>

--- a/content_types.php
+++ b/content_types.php
@@ -14,7 +14,7 @@ requireLogin();
 // Redirect to the creation form when requested via act=ad for backward compatibility
 $action = isset($_GET['act']) ? $_GET['act'] : '';
 if ($action === 'ad') {
-    header('Location: content_type_form.php');
+    header('Location: ' . BASE_URL . 'content-type/add');
     exit;
 }
 
@@ -28,7 +28,7 @@ if ($delId) {
     if ($associated) {
         $params .= '&associated=' . $associated;
     }
-    header('Location: content_types.php?' . $params);
+    header('Location: ' . BASE_URL . 'content-types?' . $params);
     exit;
 }
 
@@ -53,7 +53,7 @@ require_once __DIR__ . '/header.php';
             </div>
         <?php endif; ?>
         <h2>Tipos de Conteúdo</h2>
-        <a class="btn btn-primary" href="content_type_form.php"><i class="fa fa-plus"></i> Criar novo tipo de conteúdo</a>
+        <a class="btn btn-primary" href="<?= BASE_URL ?>content-type/add"><i class="fa fa-plus"></i> Criar novo tipo de conteúdo</a>
  
     <table class="table table-striped datatable" data-no-sort-last="true">
         <thead><tr><th>Rótulo</th><th>Slug</th><th>Ícone</th><th>Ações</th></tr></thead>
@@ -74,8 +74,8 @@ require_once __DIR__ . '/header.php';
                     <a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($type['name'])); ?>/add" class="btn btn-sm btn-success"><i class="fa fa-plus"></i> Adicionar</a>
                     <a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($type['name'])); ?>" class="btn btn-sm btn-secondary"><i class="fa fa-list"></i> Listar</a>
                     <a href="<?= BASE_URL ?>content-type-taxonomies/<?php echo $type['id']; ?>" class="btn btn-sm btn-warning"><i class="fa fa-tags"></i> Taxonomias</a>
-                    <a href="content_type_form.php?id=<?php echo $type['id']; ?>" class="btn btn-sm btn-primary"><i class="fa fa-pencil"></i> Editar</a>
-                    <a href="content_types.php?delete_id=<?php echo $type['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('<?php echo htmlspecialchars($confirmMsg, ENT_QUOTES); ?>');"><i class="fa fa-trash"></i> Eliminar</a>
+                    <a href="<?= BASE_URL ?>content-type/edit/<?php echo $type['id']; ?>" class="btn btn-sm btn-primary"><i class="fa fa-pencil"></i> Editar</a>
+                    <a href="<?= BASE_URL ?>content-types?delete_id=<?php echo $type['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('<?php echo htmlspecialchars($confirmMsg, ENT_QUOTES); ?>');"><i class="fa fa-trash"></i> Eliminar</a>
                 </td>
             </tr>
         <?php endforeach; ?>

--- a/router.php
+++ b/router.php
@@ -35,6 +35,13 @@ switch (true) {
     case $path === 'content-types':
         require __DIR__ . '/content_types.php';
         break;
+    case $path === 'content-type/add':
+        require __DIR__ . '/content_type_form.php';
+        break;
+    case preg_match('#^content-type/edit/([0-9]+)$#', $path, $m):
+        $_GET['id'] = $m[1];
+        require __DIR__ . '/content_type_form.php';
+        break;
     case $path === 'taxonomies/add':
         // Create a new taxonomy
         $_GET['act'] = 'ad';


### PR DESCRIPTION
## Summary
- Route `/content-type/add` and `/content-type/edit/{id}` through router
- Update content type form to post to friendly URLs
- Link content type pages to new routes

## Testing
- `php -l router.php`
- `php -l content_type_form.php`
- `php -l content_types.php`
- `php -l content_type_taxonomies.php`


------
https://chatgpt.com/codex/tasks/task_e_68b371ea1ac883208300917cc8e1aebc