### PR TITLE
Enable drag-and-drop ordering for content types

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -329,6 +329,10 @@ $(document).ready(function() {
         var $table = $(this);
         var source = $table.data('source');
         var options = { responsive: true };
+        if ($table.hasClass('rowreorder')) {
+            options.rowReorder = true;
+            options.order = [];
+        }
         options.language = { url: 'vendors/datatables.net/i18n/pt-PT.json' };
         var nonSortable = [];
         $table.find('thead th').each(function(i){
@@ -353,6 +357,18 @@ $(document).ready(function() {
             };
         }
         var table = $table.DataTable(options);
+        if ($table.hasClass('rowreorder')) {
+            table.on('row-reorder', function() {
+                var order = [];
+                table.rows({ order: 'index' }).every(function() {
+                    order.push($(this.node()).data('id'));
+                });
+                var url = $table.data('reorder-url');
+                if (url) {
+                    $.post(url, { order: order });
+                }
+            });
+        }
         var $toggles = $table.prev('.column-toggler');
         if ($toggles.length) {
             $toggles.find('input[type="checkbox"]').on('change', function() {

--- a/content_types.php
+++ b/content_types.php
@@ -55,7 +55,7 @@ require_once __DIR__ . '/header.php';
         <h2>Tipos de Conteúdo</h2>
         <a class="btn btn-primary" href="<?= BASE_URL ?>content-type/add"><i class="fa fa-plus"></i> Criar novo tipo de conteúdo</a>
  
-    <table class="table table-striped datatable" data-no-sort-last="true">
+    <table class="table table-striped datatable rowreorder" data-reorder-url="reorder_content_types.php" data-no-sort-last="true">
         <thead><tr><th>Rótulo</th><th>Slug</th><th>Ícone</th><th>Ações</th></tr></thead>
         <tbody>
         <?php foreach ($types as $type): ?>
@@ -63,7 +63,7 @@ require_once __DIR__ . '/header.php';
                 $cnt = countContentByContentType($type['id']);
                 $confirmMsg = $cnt ? "Eliminar este tipo? Existem $cnt conteúdos associados." : 'Eliminar este tipo?';
             ?>
-            <tr>
+            <tr data-id="<?php echo $type['id']; ?>">
                 <td><?php echo htmlspecialchars($type['label']); ?></td>
                 <td><?php echo htmlspecialchars($type['name']); ?></td>
                 <td><i class="<?php echo htmlspecialchars($type['icon']); ?>"></i></td>

--- a/footer.php
+++ b/footer.php
@@ -16,6 +16,7 @@
 <script src="vendors/datatables.net-bs5/js/dataTables.bootstrap5.min.js"></script>
 <script src="vendors/datatables.net-responsive/js/dataTables.responsive.min.js"></script>
 <script src="vendors/datatables.net-responsive-bs5/js/responsive.bootstrap5.min.js"></script>
+<script src="https://cdn.datatables.net/rowreorder/1.3.3/js/dataTables.rowReorder.min.js"></script>
 <script src="https://colorlibhq.github.io/gentelella/build/js/gentelella.min.js"></script>
 <script src="assets/js/custom.js"></script>
 

--- a/functions.php
+++ b/functions.php
@@ -151,9 +151,11 @@ function getContentTypes(): array {
     $pdo = getPDO();
     $hasAuthor = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_author'")->fetch();
     $hasDate   = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_date'")->fetch();
+    $hasOrder  = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'sort_order'")->fetch();
     $authorExpr = $hasAuthor ? 'show_author' : '1 AS show_author';
     $dateExpr   = $hasDate ? 'show_date' : '1 AS show_date';
-    $stmt = $pdo->query("SELECT id, name, label, icon, $authorExpr, $dateExpr FROM content_types ORDER BY id ASC");
+    $orderBy    = $hasOrder ? 'sort_order, id' : 'id';
+    $stmt = $pdo->query("SELECT id, name, label, icon, $authorExpr, $dateExpr FROM content_types ORDER BY $orderBy ASC");
     return $stmt->fetchAll();
 }
 
@@ -204,6 +206,11 @@ function createContentType(string $name, string $label, string $icon, bool $show
     $pdo = getPDO();
     $hasAuthor = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_author'")->fetch();
     $hasDate   = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_date'")->fetch();
+    $hasOrder  = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'sort_order'")->fetch();
+    if (!$hasOrder) {
+        $pdo->exec("ALTER TABLE content_types ADD COLUMN sort_order INT NOT NULL DEFAULT 0");
+        $hasOrder = true;
+    }
     if ($hasAuthor && $hasDate) {
         $stmt = $pdo->prepare('INSERT INTO content_types (name, label, icon, show_author, show_date) VALUES (?, ?, ?, ?, ?)');
         $stmt->execute([$name, $label, $icon, $show_author ? 1 : 0, $show_date ? 1 : 0]);
@@ -217,7 +224,12 @@ function createContentType(string $name, string $label, string $icon, bool $show
         $stmt = $pdo->prepare('INSERT INTO content_types (name, label, icon) VALUES (?, ?, ?)');
         $stmt->execute([$name, $label, $icon]);
     }
-    return (int)$pdo->lastInsertId();
+    $id = (int)$pdo->lastInsertId();
+    if ($hasOrder) {
+        $stmt = $pdo->prepare('UPDATE content_types SET sort_order = ? WHERE id = ?');
+        $stmt->execute([$id, $id]);
+    }
+    return $id;
 }
 
 /**
@@ -258,6 +270,23 @@ function deleteContentType(int $id): void {
     $pdo = getPDO();
     $stmt = $pdo->prepare('DELETE FROM content_types WHERE id = ?');
     $stmt->execute([$id]);
+}
+
+/**
+ * Update the ordering of content types based on a list of ids.
+ *
+ * @param array $ids Ordered list of content type ids
+ */
+function reorderContentTypes(array $ids): void {
+    $pdo = getPDO();
+    $hasOrder = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'sort_order'")->fetch();
+    if (!$hasOrder) {
+        $pdo->exec("ALTER TABLE content_types ADD COLUMN sort_order INT NOT NULL DEFAULT 0");
+    }
+    $stmt = $pdo->prepare('UPDATE content_types SET sort_order = ? WHERE id = ?');
+    foreach ($ids as $position => $id) {
+        $stmt->execute([$position + 1, (int)$id]);
+    }
 }
 
 /**

--- a/header.php
+++ b/header.php
@@ -28,6 +28,7 @@ $user = currentUser();
 <link rel="stylesheet" href="vendors/font-awesome/css/font-awesome.min.css">
 <link rel="stylesheet" href="vendors/datatables.net-bs5/css/dataTables.bootstrap5.min.css">
 <link rel="stylesheet" href="vendors/datatables.net-responsive-bs5/css/responsive.bootstrap5.min.css">
+<link rel="stylesheet" href="https://cdn.datatables.net/rowreorder/1.3.3/css/rowReorder.bootstrap5.min.css">
 <link rel="stylesheet" href="https://colorlibhq.github.io/gentelella/build/css/gentelella.min.css">
 <link rel="stylesheet" href="assets/css/custom.css">
 

--- a/reorder_content_types.php
+++ b/reorder_content_types.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/functions.php';
+startSession();
+requireLogin();
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['order']) && is_array($_POST['order'])) {
+    reorderContentTypes(array_map('intval', $_POST['order']));
+    header('Content-Type: application/json');
+    echo json_encode(['status' => 'ok']);
+    exit;
+}
+http_response_code(400);
+?>

--- a/schema.sql
+++ b/schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS content_types (
     icon VARCHAR(100) NOT NULL DEFAULT 'fa fa-file-text',
     show_author TINYINT(1) NOT NULL DEFAULT 0,
     show_date TINYINT(1) NOT NULL DEFAULT 0,
+    sort_order INT NOT NULL DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 


### PR DESCRIPTION
## Summary
- allow drag-and-drop reordering of content types
- persist ordering and apply it to the sidebar menu

## Testing
- `php -l functions.php`
- `php -l content_types.php`
- `php -l header.php`
- `php -l footer.php`
- `php -l reorder_content_types.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3754634388320b83128add7e1fa4a