### PR TITLE
Switch avatar dropdown to Bootstrap 5 API

### DIFF
--- a/header.php
+++ b/header.php
@@ -98,8 +98,8 @@ foreach ($sidebarTypes as $sidebarType):
                 <nav class="nav navbar-nav">
                     <ul class="navbar-right">
 
-                        <li class="nav-item dropdown open" style="padding-left: 15px;">
-                            <a href="javascript:;" class="user-profile dropdown-toggle" aria-haspopup="true" id="navbarDropdown" data-toggle="dropdown" aria-expanded="false">
+                        <li class="nav-item dropdown" style="padding-left: 15px;">
+                            <a href="javascript:;" class="user-profile dropdown-toggle" aria-haspopup="true" id="navbarDropdown" data-bs-toggle="dropdown" aria-expanded="false">
                                 <img src="assets/images/img.jpg" alt=""><?php echo htmlspecialchars($user['username']); ?>
                             </a>
                             <div class="dropdown-menu dropdown-usermenu pull-right" aria-labelledby="navbarDropdown">


### PR DESCRIPTION
## Summary
- Replace deprecated `data-toggle` with `data-bs-toggle` for the avatar menu
- Remove obsolete `open` class from dropdown list item

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b3866d9b848320951a1ac618cda343