### PR TITLE
Fix user dropdown alignment for Bootstrap 5

### DIFF
--- a/header.php
+++ b/header.php
@@ -96,13 +96,13 @@ foreach ($sidebarTypes as $sidebarType):
                     <a id="menu_toggle"><i class="fa fa-bars"></i></a>
                 </div>
                 <nav class="nav navbar-nav">
-                    <ul class="navbar-right">
+                    <ul class="navbar-nav ms-auto">
 
-                        <li class="nav-item dropdown" style="padding-left: 15px;">
-                            <a href="javascript:;" class="user-profile dropdown-toggle" aria-haspopup="true" id="navbarDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                        <li class="nav-item dropdown ms-3">
+                            <a href="javascript:;" class="user-profile nav-link dropdown-toggle" aria-haspopup="true" id="navbarDropdown" data-bs-toggle="dropdown" aria-expanded="false">
                                 <img src="assets/images/img.jpg" alt=""><?php echo htmlspecialchars($user['username']); ?>
                             </a>
-                            <div class="dropdown-menu dropdown-usermenu pull-right" aria-labelledby="navbarDropdown">
+                            <div class="dropdown-menu dropdown-menu-end dropdown-usermenu" aria-labelledby="navbarDropdown">
                                 <a class="dropdown-item" href="<?= BASE_URL ?>editar-perfil"> Profile</a>
                                 <a class="dropdown-item" href="<?= BASE_URL ?>definicoes">
                                     <span class="badge bg-red pull-right">50%</span>
@@ -116,7 +116,7 @@ foreach ($sidebarTypes as $sidebarType):
                     </ul>
 
 
-                    
+
                 </nav>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Align top-right user dropdown using Bootstrap 5 `ms-auto`
- Use `nav-link` and `dropdown-menu-end` classes for proper styling

## Testing
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b381b122ec8320b1d5455bae492f29