### PR TITLE
fix: disable sorting for icon column on content types page

### DIFF
--- a/content_types.php
+++ b/content_types.php
@@ -56,7 +56,7 @@ require_once __DIR__ . '/header.php';
         <a class="btn btn-primary" href="<?= BASE_URL ?>content-type/add"><i class="fa fa-plus"></i> Criar novo tipo de conteúdo</a>
  
     <table class="table table-striped datatable" data-no-sort-last="true">
-        <thead><tr><th>Rótulo</th><th>Slug</th><th>Ícone</th><th>Ações</th></tr></thead>
+        <thead><tr><th>Rótulo</th><th>Slug</th><th data-orderable="false">Ícone</th><th>Ações</th></tr></thead>
         <tbody>
         <?php foreach ($types as $type): ?>
             <?php


### PR DESCRIPTION
## Summary
- disable datatable sorting for the icon column on content types page

## Testing
- `php -l content_types.php`


------
https://chatgpt.com/codex/tasks/task_e_68b388d5b6288320b8e1c45722735759