### PR TITLE
Switch avatar dropdown to Bootstrap 5 API

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1850,18 +1850,22 @@ ul.msg_list li a .message {
     border-top-right-radius: 0
 }
 
+.dropdown-menu.dropdown-menu-end {
+    left: auto;
+    right: 0;
+    float: none;
+}
+
 .dropdown-menu>li>a {
     color: #5A738E
 }
 
-.navbar-nav .open .dropdown-menu {
+.navbar-nav .dropdown-menu.show {
     position: absolute;
     background: #fff;
     margin-top: 0;
     border: 1px solid #D9DEE4;
     -webkit-box-shadow: none;
-    right: 0;
-    left: auto;
     width: 220px
 }
 

--- a/header.php
+++ b/header.php
@@ -98,18 +98,18 @@ foreach ($sidebarTypes as $sidebarType):
                 <nav class="nav navbar-nav">
                     <ul class="navbar-right">
 
-                        <li class="nav-item dropdown open" style="padding-left: 15px;">
-                            <a href="javascript:;" class="user-profile dropdown-toggle" aria-haspopup="true" id="navbarDropdown" data-toggle="dropdown" aria-expanded="false">
+                        <li class="nav-item dropdown" style="padding-left: 15px;">
+                            <a href="javascript:;" class="user-profile dropdown-toggle" aria-haspopup="true" id="navbarDropdown" data-bs-toggle="dropdown" aria-expanded="false">
                                 <img src="assets/images/img.jpg" alt=""><?php echo htmlspecialchars($user['username']); ?>
                             </a>
-                            <div class="dropdown-menu dropdown-usermenu pull-right" aria-labelledby="navbarDropdown">
+                            <div class="dropdown-menu dropdown-usermenu dropdown-menu-end" aria-labelledby="navbarDropdown">
                                 <a class="dropdown-item" href="<?= BASE_URL ?>editar-perfil"> Profile</a>
                                 <a class="dropdown-item" href="<?= BASE_URL ?>definicoes">
-                                    <span class="badge bg-red pull-right">50%</span>
+                                    <span class="badge bg-red float-end">50%</span>
                                     <span>Settings</span>
                                 </a>
                                 <a class="dropdown-item" href="javascript:;">Help</a>
-                                <a class="dropdown-item" href="<?= BASE_URL ?>terminar-sessao"><i class="fa fa-sign-out pull-right"></i> Log Out</a>
+                                <a class="dropdown-item" href="<?= BASE_URL ?>terminar-sessao"><i class="fa fa-sign-out float-end"></i> Log Out</a>
                             </div>
                         </li>
 


### PR DESCRIPTION
## Summary
- Align avatar dropdown with Bootstrap 5 by replacing deprecated `pull-right` utilities
- Add stylesheet rule for `dropdown-menu-end` and update dropdown CSS

## Testing
- `node - <<'NODE'...NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b3866d9b848320951a1ac618cda343