### PR TITLE
feat: show username beside profile image

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -3071,6 +3071,8 @@ span.right {
 
 a.user-profile {
     color: #5E6974 !important;
+    display: flex;
+    align-items: center;
 }
 
 .user-profile img {
@@ -3078,6 +3080,10 @@ a.user-profile {
     height: 29px;
     border-radius: 50%;
     margin-right: 10px;
+}
+
+.user-profile .user-name {
+    margin-left: 0;
 }
 
 ul.top_profiles {

--- a/header.php
+++ b/header.php
@@ -99,12 +99,10 @@ foreach ($sidebarTypes as $sidebarType):
 
       <ul class="navbar-nav ms-auto d-flex align-items-center">
         <li class="nav-item dropdown ms-3">
-          <a href="javascript:;" class="user-profile nav-link dropdown-toggle"
+          <a href="javascript:;" class="user-profile nav-link dropdown-toggle d-flex align-items-center"
              id="navbarDropdown" data-bs-toggle="dropdown" aria-expanded="false">
             <img src="assets/images/img.jpg" alt="">
-
-            <?= htmlspecialchars($user['username']); ?>
-
+            <span class="user-name"><?= htmlspecialchars($user['username']); ?></span>
           </a>
           <div class="dropdown-menu dropdown-menu-end dropdown-usermenu"
                aria-labelledby="navbarDropdown">


### PR DESCRIPTION
## Summary
- display logged user's name beside the profile image in the top navigation
- align profile entry with flex styles

## Testing
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b39da37c608320aca46b458c0e5996