### PR TITLE
Place creation buttons beneath tables and add back links

### DIFF
--- a/content_types.php
+++ b/content_types.php
@@ -53,8 +53,6 @@ require_once __DIR__ . '/header.php';
             </div>
         <?php endif; ?>
         <h2>Tipos de Conteúdo</h2>
-        <a class="btn btn-primary" href="<?= BASE_URL ?>content-type/add"><i class="fa fa-plus"></i> Criar novo tipo de conteúdo</a>
- 
     <table class="table table-striped datatable" data-no-sort-last="true">
         <thead><tr><th>Rótulo</th><th>Slug</th><th data-orderable="false">Ícone</th><th>Ações</th></tr></thead>
         <tbody>
@@ -81,6 +79,10 @@ require_once __DIR__ . '/header.php';
         <?php endforeach; ?>
         </tbody>
     </table>
+    <div class="mt-3">
+        <a class="btn btn-success" href="<?= BASE_URL ?>content-type/add"><i class="fa fa-plus"></i> Criar novo tipo de conteúdo</a>
+        <a href="<?= BASE_URL ?>dashboard" class="btn btn-secondary ms-2"><i class="fa fa-arrow-left"></i> Voltar</a>
+    </div>
 </div>
 
 <?php

--- a/taxonomies.php
+++ b/taxonomies.php
@@ -162,7 +162,6 @@ require_once __DIR__ . '/header.php';
             </div>
         <?php endif; ?>
         <h2 class="mt-3">Taxonomias</h2>
-        <a href="taxonomies/add" class="btn btn-success mb-3"><i class="fa fa-plus"></i> Adicionar taxonomia</a>
         <table class="table table-striped datatable">
             <thead><tr><th>Rótulo</th><th>Slug</th><th>Ações</th></tr></thead>
             <tbody>
@@ -183,6 +182,10 @@ require_once __DIR__ . '/header.php';
             <?php endforeach; ?>
             </tbody>
         </table>
+        <div class="mt-3">
+            <a href="taxonomies/add" class="btn btn-success"><i class="fa fa-plus"></i> Adicionar taxonomia</a>
+            <a href="<?= BASE_URL ?>dashboard" class="btn btn-secondary ms-2"><i class="fa fa-arrow-left"></i> Voltar</a>
+        </div>
     <?php endif; ?>
 <?php endif; ?>
 </div>


### PR DESCRIPTION
## Summary
- Move "Criar novo tipo de conteúdo" button below the content types table and add a voltar link
- Move "Adicionar taxonomia" button below taxonomy table and add a voltar link

## Testing
- `php -l content_types.php`
- `php -l taxonomies.php`


------
https://chatgpt.com/codex/tasks/task_e_68b429f408ec8320b0313daefb88e267