### PR TITLE
Add menu sort order for content types

### DIFF
--- a/content_type_form.php
+++ b/content_type_form.php
@@ -18,12 +18,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $icon  = isset($_POST['icon']) ? trim($_POST['icon']) : 'fa fa-file-text';
     $showAuthor = isset($_POST['show_author']);
     $showDate   = isset($_POST['show_date']);
+    $sortOrder  = isset($_POST['sort_order']) ? (int)$_POST['sort_order'] : 0;
 
     if ($name !== '' && $label !== '') {
         if ($id) {
-            updateContentType($id, $name, $label, $icon === '' ? 'fa fa-file-text' : $icon, $showAuthor, $showDate);
+            updateContentType($id, $name, $label, $icon === '' ? 'fa fa-file-text' : $icon, $showAuthor, $showDate, $sortOrder);
         } else {
-            createContentType($name, $label, $icon === '' ? 'fa fa-file-text' : $icon, $showAuthor, $showDate);
+            createContentType($name, $label, $icon === '' ? 'fa fa-file-text' : $icon, $showAuthor, $showDate, $sortOrder);
         }
         header('Location: ' . BASE_URL . 'content-types');
         exit;
@@ -51,6 +52,10 @@ require_once __DIR__ . '/header.php';
         <div class="mb-3">
             <label class="form-label" for="icon">Ícone (classe Font Awesome)</label>
             <input type="text" class="form-control" id="icon" name="icon" value="<?php echo htmlspecialchars($editing['icon'] ?? ''); ?>" placeholder="fa fa-file-text">
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="sort_order">Ordem no menu</label>
+            <input type="number" class="form-control" id="sort_order" name="sort_order" value="<?php echo htmlspecialchars($editing['sort_order'] ?? 0); ?>">
         </div>
         <div class="form-check mb-3">
             <input class="form-check-input" type="checkbox" id="show_author" name="show_author" <?php echo !empty($editing['show_author']) ? 'checked' : ''; ?>>

--- a/content_types.php
+++ b/content_types.php
@@ -54,7 +54,7 @@ require_once __DIR__ . '/header.php';
         <?php endif; ?>
         <h2>Tipos de Conteúdo</h2>
     <table class="table table-striped datatable" data-no-sort-last="true">
-        <thead><tr><th>Rótulo</th><th>Slug</th><th data-orderable="false">Ícone</th><th>Ações</th></tr></thead>
+        <thead><tr><th>Ordem</th><th>Rótulo</th><th>Slug</th><th data-orderable="false">Ícone</th><th>Ações</th></tr></thead>
         <tbody>
         <?php foreach ($types as $type): ?>
             <?php
@@ -62,6 +62,7 @@ require_once __DIR__ . '/header.php';
                 $confirmMsg = $cnt ? "Eliminar este tipo? Existem $cnt conteúdos associados." : 'Eliminar este tipo?';
             ?>
             <tr data-id="<?php echo $type['id']; ?>">
+                <td><?php echo htmlspecialchars($type['sort_order']); ?></td>
                 <td><?php echo htmlspecialchars($type['label']); ?></td>
                 <td><?php echo htmlspecialchars($type['name']); ?></td>
                 <td><i class="<?php echo htmlspecialchars($type['icon']); ?>"></i></td>

--- a/functions.php
+++ b/functions.php
@@ -151,9 +151,11 @@ function getContentTypes(): array {
     $pdo = getPDO();
     $hasAuthor = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_author'")->fetch();
     $hasDate   = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_date'")->fetch();
+    $hasOrder  = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'sort_order'")->fetch();
     $authorExpr = $hasAuthor ? 'show_author' : '1 AS show_author';
     $dateExpr   = $hasDate ? 'show_date' : '1 AS show_date';
-    $stmt = $pdo->query("SELECT id, name, label, icon, $authorExpr, $dateExpr FROM content_types ORDER BY id ASC");
+    $orderExpr  = $hasOrder ? 'sort_order' : 'id';
+    $stmt = $pdo->query("SELECT id, name, label, icon, $authorExpr, $dateExpr, $orderExpr AS sort_order FROM content_types ORDER BY $orderExpr ASC, id ASC");
     return $stmt->fetchAll();
 }
 
@@ -167,9 +169,11 @@ function getContentType(int $id): ?array {
     $pdo = getPDO();
     $hasAuthor = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_author'")->fetch();
     $hasDate   = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_date'")->fetch();
+    $hasOrder  = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'sort_order'")->fetch();
     $authorExpr = $hasAuthor ? 'show_author' : '1 AS show_author';
     $dateExpr   = $hasDate ? 'show_date' : '1 AS show_date';
-    $stmt = $pdo->prepare("SELECT id, name, label, icon, $authorExpr, $dateExpr FROM content_types WHERE id = ?");
+    $orderExpr  = $hasOrder ? 'sort_order' : '0 AS sort_order';
+    $stmt = $pdo->prepare("SELECT id, name, label, icon, $authorExpr, $dateExpr, $orderExpr FROM content_types WHERE id = ?");
     $stmt->execute([$id]);
     return $stmt->fetch() ?: null;
 }
@@ -184,9 +188,11 @@ function getContentTypeBySlug(string $slug): ?array {
     $pdo = getPDO();
     $hasAuthor = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_author'")->fetch();
     $hasDate   = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_date'")->fetch();
+    $hasOrder  = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'sort_order'")->fetch();
     $authorExpr = $hasAuthor ? 'show_author' : '1 AS show_author';
     $dateExpr   = $hasDate ? 'show_date' : '1 AS show_date';
-    $stmt = $pdo->prepare("SELECT id, name, label, icon, $authorExpr, $dateExpr FROM content_types WHERE name = ?");
+    $orderExpr  = $hasOrder ? 'sort_order' : '0 AS sort_order';
+    $stmt = $pdo->prepare("SELECT id, name, label, icon, $authorExpr, $dateExpr, $orderExpr FROM content_types WHERE name = ?");
     $stmt->execute([$slug]);
     return $stmt->fetch() ?: null;
 }
@@ -194,17 +200,31 @@ function getContentTypeBySlug(string $slug): ?array {
 /**
  * Create a new content type.  Returns the id of the new row.
  *
- * @param string $name Slug used internally
- * @param string $label Human-readable label
- * @param string $icon  CSS class for an icon
+ * @param string $name       Slug used internally
+ * @param string $label      Human-readable label
+ * @param string $icon       CSS class for an icon
+ * @param int    $sort_order Order used in navigation
  * @return int
  */
 
-function createContentType(string $name, string $label, string $icon, bool $show_author = false, bool $show_date = false): int {
+function createContentType(string $name, string $label, string $icon, bool $show_author = false, bool $show_date = false, int $sort_order = 0): int {
     $pdo = getPDO();
     $hasAuthor = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_author'")->fetch();
     $hasDate   = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_date'")->fetch();
-    if ($hasAuthor && $hasDate) {
+    $hasOrder  = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'sort_order'")->fetch();
+    if ($hasAuthor && $hasDate && $hasOrder) {
+        $stmt = $pdo->prepare('INSERT INTO content_types (name, label, icon, sort_order, show_author, show_date) VALUES (?, ?, ?, ?, ?, ?)');
+        $stmt->execute([$name, $label, $icon, $sort_order, $show_author ? 1 : 0, $show_date ? 1 : 0]);
+    } elseif ($hasAuthor && $hasOrder) {
+        $stmt = $pdo->prepare('INSERT INTO content_types (name, label, icon, sort_order, show_author) VALUES (?, ?, ?, ?, ?)');
+        $stmt->execute([$name, $label, $icon, $sort_order, $show_author ? 1 : 0]);
+    } elseif ($hasDate && $hasOrder) {
+        $stmt = $pdo->prepare('INSERT INTO content_types (name, label, icon, sort_order, show_date) VALUES (?, ?, ?, ?, ?)');
+        $stmt->execute([$name, $label, $icon, $sort_order, $show_date ? 1 : 0]);
+    } elseif ($hasOrder) {
+        $stmt = $pdo->prepare('INSERT INTO content_types (name, label, icon, sort_order) VALUES (?, ?, ?, ?)');
+        $stmt->execute([$name, $label, $icon, $sort_order]);
+    } elseif ($hasAuthor && $hasDate) {
         $stmt = $pdo->prepare('INSERT INTO content_types (name, label, icon, show_author, show_date) VALUES (?, ?, ?, ?, ?)');
         $stmt->execute([$name, $label, $icon, $show_author ? 1 : 0, $show_date ? 1 : 0]);
     } elseif ($hasAuthor) {
@@ -223,17 +243,33 @@ function createContentType(string $name, string $label, string $icon, bool $show
 /**
  * Update an existing content type.
  *
- * @param int $id
- * @param string $name
- * @param string $label
+ * @param int         $id
+ * @param string      $name
+ * @param string      $label
  * @param string|null $icon
+ * @param bool        $show_author
+ * @param bool        $show_date
+ * @param int         $sort_order
  * @return void
  */
-function updateContentType(int $id, string $name, string $label, ?string $icon = null, bool $show_author = false, bool $show_date = false): void {
+function updateContentType(int $id, string $name, string $label, ?string $icon = null, bool $show_author = false, bool $show_date = false, int $sort_order = 0): void {
     $pdo = getPDO();
     $hasAuthor = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_author'")->fetch();
     $hasDate   = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_date'")->fetch();
-    if ($hasAuthor && $hasDate) {
+    $hasOrder  = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'sort_order'")->fetch();
+    if ($hasAuthor && $hasDate && $hasOrder) {
+        $stmt = $pdo->prepare('UPDATE content_types SET name = ?, label = ?, icon = ?, sort_order = ?, show_author = ?, show_date = ? WHERE id = ?');
+        $stmt->execute([$name, $label, $icon, $sort_order, $show_author ? 1 : 0, $show_date ? 1 : 0, $id]);
+    } elseif ($hasAuthor && $hasOrder) {
+        $stmt = $pdo->prepare('UPDATE content_types SET name = ?, label = ?, icon = ?, sort_order = ?, show_author = ? WHERE id = ?');
+        $stmt->execute([$name, $label, $icon, $sort_order, $show_author ? 1 : 0, $id]);
+    } elseif ($hasDate && $hasOrder) {
+        $stmt = $pdo->prepare('UPDATE content_types SET name = ?, label = ?, icon = ?, sort_order = ?, show_date = ? WHERE id = ?');
+        $stmt->execute([$name, $label, $icon, $sort_order, $show_date ? 1 : 0, $id]);
+    } elseif ($hasOrder) {
+        $stmt = $pdo->prepare('UPDATE content_types SET name = ?, label = ?, icon = ?, sort_order = ? WHERE id = ?');
+        $stmt->execute([$name, $label, $icon, $sort_order, $id]);
+    } elseif ($hasAuthor && $hasDate) {
         $stmt = $pdo->prepare('UPDATE content_types SET name = ?, label = ?, icon = ?, show_author = ?, show_date = ? WHERE id = ?');
         $stmt->execute([$name, $label, $icon, $show_author ? 1 : 0, $show_date ? 1 : 0, $id]);
     } elseif ($hasAuthor) {

--- a/schema.sql
+++ b/schema.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS content_types (
     name VARCHAR(100) NOT NULL,
     label VARCHAR(100) NOT NULL,
     icon VARCHAR(100) NOT NULL DEFAULT 'fa fa-file-text',
+    sort_order INT NOT NULL DEFAULT 0,
     show_author TINYINT(1) NOT NULL DEFAULT 0,
     show_date TINYINT(1) NOT NULL DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP


### PR DESCRIPTION
## Summary
- allow specifying a sort order for content types
- order content type list and sidebar menu based on the stored order

## Testing
- `php -l functions.php`
- `php -l content_type_form.php`
- `php -l content_types.php`


------
https://chatgpt.com/codex/tasks/task_e_68b42c2f67e48320ae4a58328d2f089e