### PR TITLE
Prevent superadmin level edits and enforce strong passwords

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -112,6 +112,21 @@ function loginUser(string $username, string $password): bool {
 }
 
 /**
+ * Validate password strength.
+ * A strong password has at least 8 characters and includes
+ * uppercase and lowercase letters plus at least one number.
+ *
+ * @param string $password
+ * @return bool
+ */
+function isStrongPassword(string $password): bool {
+    return strlen($password) >= 8
+        && preg_match('/[A-Z]/', $password)
+        && preg_match('/[a-z]/', $password)
+        && preg_match('/\d/', $password);
+}
+
+/**
  * Log out the current user by destroying the session and clearing
  * cookies.  After calling this function you should redirect the
  * browser to a public page.
@@ -211,8 +226,12 @@ function createUser(string $username, string $passwordHash, ?string $name, ?stri
  */
 function updateUser(int $id, string $username, ?string $passwordHash, ?string $name, ?string $email, ?string $phone, int $role, ?string $photoPath = null): void {
     $pdo = getPDO();
-    $sql = 'UPDATE users SET username = ?, name = ?, email = ?, phone = ?, role = ?';
-    $params = [$username, $name, $email, $phone, $role];
+    $sql = 'UPDATE users SET username = ?, name = ?, email = ?, phone = ?';
+    $params = [$username, $name, $email, $phone];
+    if ($id !== 1) {
+        $sql .= ', role = ?';
+        $params[] = $role;
+    }
     if ($passwordHash !== null) {
         $sql .= ', password = ?';
         $params[] = $passwordHash;

--- a/user_form.php
+++ b/user_form.php
@@ -16,10 +16,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $phone = trim($_POST['phone'] ?? '');
     $role = (int)($_POST['role'] ?? 3);
     $password = trim($_POST['password'] ?? '');
+    $confirmPassword = trim($_POST['password_confirm'] ?? '');
     $photoPath = $userData['photo'] ?? null;
 
     if (!$editing && $password === '') {
         $errors[] = 'A password é obrigatória.';
+    }
+
+    if ($password !== '') {
+        if ($password !== $confirmPassword) {
+            $errors[] = 'As passwords não coincidem.';
+        } elseif (!isStrongPassword($password)) {
+            $errors[] = 'A password deve ter pelo menos 8 caracteres e incluir letras maiúsculas, minúsculas e números.';
+        }
     }
 
     if (!empty($_FILES['photo']['tmp_name'])) {
@@ -80,15 +89,24 @@ require_once __DIR__ . '/header.php';
         </div>
         <div class="mb-3">
             <label for="role" class="form-label">Nível</label>
-            <select class="form-control" id="role" name="role">
-                <option value="1" <?= $userData['role'] == 1 ? 'selected' : ''; ?>>Superadmin</option>
-                <option value="2" <?= $userData['role'] == 2 ? 'selected' : ''; ?>>Administrador</option>
-                <option value="3" <?= $userData['role'] == 3 ? 'selected' : ''; ?>>Utilizador</option>
-            </select>
+            <?php if ($editing && $id == 1): ?>
+                <input type="text" class="form-control" value="Superadmin" disabled>
+                <input type="hidden" name="role" value="1">
+            <?php else: ?>
+                <select class="form-control" id="role" name="role">
+                    <option value="1" <?= $userData['role'] == 1 ? 'selected' : ''; ?>>Superadmin</option>
+                    <option value="2" <?= $userData['role'] == 2 ? 'selected' : ''; ?>>Administrador</option>
+                    <option value="3" <?= $userData['role'] == 3 ? 'selected' : ''; ?>>Utilizador</option>
+                </select>
+            <?php endif; ?>
         </div>
         <div class="mb-3">
             <label for="password" class="form-label">Password <?= $editing ? '(deixe em branco para manter)' : ''; ?></label>
             <input type="password" class="form-control" id="password" name="password" <?= $editing ? '' : 'required'; ?>>
+        </div>
+        <div class="mb-3">
+            <label for="password_confirm" class="form-label">Confirmar Password <?= $editing ? '(deixe em branco para manter)' : ''; ?></label>
+            <input type="password" class="form-control" id="password_confirm" name="password_confirm" <?= $editing ? '' : 'required'; ?>>
         </div>
         <button type="submit" class="btn btn-primary">Guardar</button>
     </form>


### PR DESCRIPTION
## Summary
- Block role changes for user ID 1 and ignore role update at DB level
- Add password confirmation field with strength validation

## Testing
- `php -l functions.php`
- `php -l user_form.php`


------
https://chatgpt.com/codex/tasks/task_e_68b43227fd6483209543198f9a37fa0c