### PR TITLE
feat: adjust user management UI and visibility

### DIFF
--- a/user_form.php
+++ b/user_form.php
@@ -75,13 +75,15 @@ require_once __DIR__ . '/header.php';
             <?php endif; ?>
             <input type="file" class="form-control" id="photo" name="photo">
         </div>
-        <div class="mb-3">
-            <label for="name" class="form-label">Nome</label>
-            <input type="text" class="form-control" id="name" name="name" value="<?= htmlspecialchars($userData['name']); ?>">
-        </div>
-        <div class="mb-3">
-            <label for="email" class="form-label">E-mail</label>
-            <input type="email" class="form-control" id="email" name="email" value="<?= htmlspecialchars($userData['email']); ?>">
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                <label for="name" class="form-label">Nome</label>
+                <input type="text" class="form-control" id="name" name="name" value="<?= htmlspecialchars($userData['name']); ?>">
+            </div>
+            <div class="col-md-6 mb-3">
+                <label for="email" class="form-label">E-mail</label>
+                <input type="email" class="form-control" id="email" name="email" value="<?= htmlspecialchars($userData['email']); ?>">
+            </div>
         </div>
         <div class="mb-3">
             <label for="phone" class="form-label">Telefone</label>

--- a/users.php
+++ b/users.php
@@ -14,12 +14,17 @@ if (isset($_GET['delete_id'])) {
     exit;
 }
 
+// Fetch users and hide superadmin (ID 1) for non-superadmin accounts
+$user = currentUser();
 $users = getUsers();
+if (($user['id'] ?? 0) !== 1) {
+    $users = array_filter($users, fn($u) => $u['id'] !== 1);
+}
+
 require_once __DIR__ . '/header.php';
 ?>
 <div class="container-fluid">
     <h2>Utilizadores</h2>
-    <a href="<?= BASE_URL ?>user/add" class="btn btn-primary mb-3"><i class="fa fa-plus"></i> Adicionar Utilizador</a>
     <table class="table table-striped">
         <thead>
             <tr>
@@ -53,5 +58,6 @@ require_once __DIR__ . '/header.php';
         <?php endforeach; ?>
         </tbody>
     </table>
+    <a href="<?= BASE_URL ?>user/add" class="btn btn-primary mt-3"><i class="fa fa-plus"></i> Adicionar Utilizador</a>
 </div>
 <?php require_once __DIR__ . '/footer.php'; ?>


### PR DESCRIPTION
## Summary
- hide superadmin from other admins in user list
- move "Adicionar Utilizador" button below the user table
- display name and email fields side by side in user form

## Testing
- `php -l users.php user_form.php`

------
https://chatgpt.com/codex/tasks/task_e_68b433aaa76083208ce009d2e2707255