### PR TITLE
Enable password change from profile page

### DIFF
--- a/editar_perfil.php
+++ b/editar_perfil.php
@@ -8,12 +8,23 @@ requireLogin();
 
 $user = currentUser();
 $success = '';
+$errors = [];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $name = trim($_POST['name'] ?? '');
     $email = trim($_POST['email'] ?? '');
     $phone = trim($_POST['phone'] ?? '');
+    $password = trim($_POST['password'] ?? '');
+    $confirmPassword = trim($_POST['password_confirm'] ?? '');
     $photoPath = null;
+
+    if ($password !== '') {
+        if ($password !== $confirmPassword) {
+            $errors[] = 'As passwords não coincidem.';
+        } elseif (!isStrongPassword($password)) {
+            $errors[] = 'A password deve ter pelo menos 8 caracteres e incluir letras maiúsculas, minúsculas e números.';
+        }
+    }
 
     if (!empty($_FILES['photo']['tmp_name'])) {
         $uploadDir = __DIR__ . '/assets/uploads/';
@@ -27,15 +38,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 
-    updateUserProfile($user['id'], $name, $email, $phone, $photoPath);
-    $success = 'Perfil atualizado com sucesso.';
-    $user = currentUser();
+    if (!$errors) {
+        $hash = $password !== '' ? password_hash($password, PASSWORD_DEFAULT) : null;
+        updateUserProfile($user['id'], $name, $email, $phone, $hash, $photoPath);
+        $success = 'Perfil atualizado com sucesso.';
+        $user = currentUser();
+    }
 }
 
 require_once __DIR__ . '/header.php';
 ?>
 <div class="container-fluid">
     <h2>Editar Perfil</h2>
+    <?php foreach ($errors as $err): ?>
+        <div class="alert alert-danger" role="alert"><?php echo htmlspecialchars($err); ?></div>
+    <?php endforeach; ?>
     <?php if ($success): ?>
         <div class="alert alert-success" role="alert">
             <?php echo htmlspecialchars($success); ?>
@@ -64,6 +81,14 @@ require_once __DIR__ . '/header.php';
         <div class="mb-3">
             <label for="phone" class="form-label">Telefone</label>
             <input type="text" class="form-control" id="phone" name="phone" value="<?php echo htmlspecialchars($user['phone'] ?? ''); ?>">
+        </div>
+        <div class="mb-3">
+            <label for="password" class="form-label">Password (deixe em branco para manter)</label>
+            <input type="password" class="form-control" id="password" name="password">
+        </div>
+        <div class="mb-3">
+            <label for="password_confirm" class="form-label">Confirmar Password</label>
+            <input type="password" class="form-control" id="password_confirm" name="password_confirm">
         </div>
         <button type="submit" class="btn btn-primary">Guardar</button>
     </form>

--- a/functions.php
+++ b/functions.php
@@ -168,13 +168,18 @@ function currentUser(): ?array {
  * @param string|null $name
  * @param string|null $email
  * @param string|null $phone
+ * @param string|null $passwordHash
  * @param string|null $photoPath
  * @return void
  */
-function updateUserProfile(int $id, ?string $name, ?string $email, ?string $phone, ?string $photoPath = null): void {
+function updateUserProfile(int $id, ?string $name, ?string $email, ?string $phone, ?string $passwordHash = null, ?string $photoPath = null): void {
     $pdo = getPDO();
     $sql = 'UPDATE users SET name = ?, email = ?, phone = ?';
     $params = [$name, $email, $phone];
+    if ($passwordHash !== null) {
+        $sql .= ', password = ?';
+        $params[] = $passwordHash;
+    }
     if ($photoPath !== null) {
         $sql .= ', photo = ?';
         $params[] = $photoPath;


### PR DESCRIPTION
## Summary
- allow users to change password when editing profile
- extend updateUserProfile to optionally update hashed password
- validate and display password errors on profile form

## Testing
- `php -l editar_perfil.php`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68b433cc8b248320b2881b6831665c35