### PR TITLE
Restrict content type and taxonomy management to admins

### DIFF
--- a/content_type_form.php
+++ b/content_type_form.php
@@ -7,6 +7,7 @@
 require_once __DIR__ . '/functions.php';
 startSession();
 requireLogin();
+requireRole(2);
 
 $error = '';
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;

--- a/content_type_taxonomies.php
+++ b/content_type_taxonomies.php
@@ -6,6 +6,7 @@
 require_once __DIR__ . '/functions.php';
 startSession();
 requireLogin();
+requireRole(2);
 
 $typeId = isset($_GET['type_id']) ? (int)$_GET['type_id'] : 0;
 $type   = $typeId ? getContentType($typeId) : null;

--- a/content_types.php
+++ b/content_types.php
@@ -10,6 +10,7 @@
 require_once __DIR__ . '/functions.php';
 startSession();
 requireLogin();
+requireRole(2);
 
 // Redirect to the creation form when requested via act=ad for backward compatibility
 $action = isset($_GET['act']) ? $_GET['act'] : '';

--- a/custom_fields.php
+++ b/custom_fields.php
@@ -6,6 +6,7 @@
 require_once __DIR__ . '/functions.php';
 startSession();
 requireLogin();
+requireRole(2);
 
 // Obtém parâmetros básicos
 $typeId = isset($_GET['type_id']) ? (int) $_GET['type_id'] : 0;

--- a/header.php
+++ b/header.php
@@ -62,8 +62,10 @@ $user = currentUser();
                     <div class="menu_section">
                         <ul class="nav side-menu">
                             <li><a href="<?= BASE_URL ?>dashboard"><i class="fa fa-home"></i> Dashboard</a></li>
+<?php if (($user['role'] ?? 3) <= 2): ?>
                             <li><a href="<?= BASE_URL ?>content-types"><i class="fa fa-cubes"></i> Tipos de Conteúdo</a></li>
                             <li><a href="<?= BASE_URL ?>taxonomies"><i class="fa fa-tags"></i> Taxonomias</a></li>
+<?php endif; ?>
 <?php
 // Dynamically list each content type with shortcuts to common actions.
 $sidebarTypes = getContentTypes();
@@ -76,8 +78,10 @@ foreach ($sidebarTypes as $sidebarType):
 
                                     <li><a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($sidebarType['name'])); ?>/add">Adicionar</a></li>
                                     <li><a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($sidebarType['name'])); ?>">Listar</a></li>
+<?php if (($user['role'] ?? 3) <= 2): ?>
                                     <li><a href="<?= BASE_URL . 'fields/' . $sidebarType['id']; ?>">Campos</a></li>
                                     <li><a href="<?= BASE_URL ?>content-type-taxonomies/<?php echo $sidebarType['id']; ?>">Taxonomias</a></li>
+<?php endif; ?>
                                 </ul>
                             </li>
 <?php endforeach; ?>

--- a/taxonomies.php
+++ b/taxonomies.php
@@ -15,6 +15,7 @@
 require_once __DIR__ . '/functions.php';
 startSession();
 requireLogin();
+requireRole(2);
 
  $error = '';
  $taxonomyId = isset($_GET['taxonomy_id']) ? (int)$_GET['taxonomy_id'] : 0;


### PR DESCRIPTION
## Summary
- Hide content type and taxonomy menu items and submenus for non-admin users
- Enforce admin-only access for content type, taxonomy, and custom field management pages

## Testing
- `php -l content_type_form.php`
- `php -l content_type_taxonomies.php`
- `php -l content_types.php`
- `php -l custom_fields.php`
- `php -l header.php`
- `php -l taxonomies.php`


------
https://chatgpt.com/codex/tasks/task_e_68b437d238988320adc51c57e4880da6