### PR TITLE
Prevent username edits

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -228,11 +228,14 @@ function createUser(string $username, string $passwordHash, ?string $name, ?stri
 
 /**
  * Update an existing user.
+ *
+ * The username cannot be modified once a user is created, so this function
+ * only updates the remaining profile fields.
  */
-function updateUser(int $id, string $username, ?string $passwordHash, ?string $name, ?string $email, ?string $phone, int $role, ?string $photoPath = null): void {
+function updateUser(int $id, ?string $passwordHash, ?string $name, ?string $email, ?string $phone, int $role, ?string $photoPath = null): void {
     $pdo = getPDO();
-    $sql = 'UPDATE users SET username = ?, name = ?, email = ?, phone = ?';
-    $params = [$username, $name, $email, $phone];
+    $sql = 'UPDATE users SET name = ?, email = ?, phone = ?';
+    $params = [$name, $email, $phone];
     if ($id !== 1) {
         $sql .= ', role = ?';
         $params[] = $role;

--- a/user_form.php
+++ b/user_form.php
@@ -19,7 +19,7 @@ $selfEdit = $profileMode;
 $errors = [];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $username = trim($_POST['username'] ?? '');
+    $username = $editing ? $userData['username'] : trim($_POST['username'] ?? '');
     $name = trim($_POST['name'] ?? '');
     $email = trim($_POST['email'] ?? '');
     $phone = trim($_POST['phone'] ?? '');
@@ -66,7 +66,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!$errors) {
         if ($editing) {
             $hash = $password !== '' ? password_hash($password, PASSWORD_DEFAULT) : null;
-            updateUser($id, $username, $hash, $name, $email, $phone, $role, $photoPath);
+            updateUser($id, $hash, $name, $email, $phone, $role, $photoPath);
         } else {
             $hash = password_hash($password, PASSWORD_DEFAULT);
             createUser($username, $hash, $name, $email, $phone, $role, $photoPath);
@@ -87,7 +87,11 @@ require_once __DIR__ . '/header.php';
     <form method="post" enctype="multipart/form-data" class="w-50">
         <div class="mb-3">
             <label for="username" class="form-label">Utilizador</label>
-            <input type="text" class="form-control" id="username" name="username" value="<?= htmlspecialchars($userData['username']); ?>" required>
+            <?php if ($editing): ?>
+                <input type="text" class="form-control" id="username" value="<?= htmlspecialchars($userData['username']); ?>" disabled>
+            <?php else: ?>
+                <input type="text" class="form-control" id="username" name="username" value="<?= htmlspecialchars($userData['username']); ?>" required>
+            <?php endif; ?>
         </div>
         <div class="mb-3">
             <label for="photo" class="form-label">Foto</label><br>


### PR DESCRIPTION
## Summary
- Disallow changing usernames by removing username updates from user profile logic
- Disable username field on edit forms

## Testing
- `php -l functions.php`
- `php -l user_form.php`


------
https://chatgpt.com/codex/tasks/task_e_68b438c87a948320bd8b91dcdbf7eff9