### PR TITLE
Guard against deletion of higher-privilege users

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -257,7 +257,29 @@ function updateUser(int $id, ?string $passwordHash, ?string $name, ?string $emai
 /**
  * Delete a user by id.
  */
+/**
+ * Delete a user if the current user has a higher privilege.
+ * Users with an equal or lower privilege level (numerically higher value)
+ * cannot delete accounts with greater privileges.
+ *
+ * @param int $id
+ * @return void
+ */
 function deleteUser(int $id): void {
+    $current = currentUser();
+    $target  = getUserById($id);
+    if (!$current || !$target) {
+        return;
+    }
+    // Prevent deletion if current user role is >= target user's role (less privileged or same level)
+    if ($current['role'] >= $target['role']) {
+        return;
+    }
+    // Prevent deleting oneself for additional safety
+    if ($current['id'] === $id) {
+        return;
+    }
+
     $pdo = getPDO();
     $stmt = $pdo->prepare('DELETE FROM users WHERE id = ?');
     $stmt->execute([$id]);


### PR DESCRIPTION
## Summary
- Prevent deletion of users with higher or equal privilege level
- Add safeguard against self-deletion in deleteUser helper

## Testing
- `php -l functions.php`
- `git commit -am "Prevent lower-privileged users from deleting higher-level accounts"` *(fails: A valid Gruntfile could not be found)*


------
https://chatgpt.com/codex/tasks/task_e_68b4391abe5083208709df34be8065ef