### PR TITLE
Disable sorting on actions column for custom fields table

### DIFF
--- a/custom_fields.php
+++ b/custom_fields.php
@@ -166,7 +166,7 @@ require_once __DIR__ . '/header.php';
     <h2 class="mt-3">Campos personalizados para <?php echo htmlspecialchars($type['label']); ?></h2>
     <table class="table table-striped datatable">
         <thead>
-            <tr><th>Slug</th><th>Rótulo</th><th>Tipo</th><th>Opções</th><th>Obrigatório</th><th>Listagem</th><th>Ações</th></tr>
+            <tr><th>Slug</th><th>Rótulo</th><th>Tipo</th><th>Opções</th><th>Obrigatório</th><th>Listagem</th><th data-orderable="false">Ações</th></tr>
         </thead>
         <tbody>
         <?php foreach ($fields as $field): ?>


### PR DESCRIPTION
## Summary
- prevent sorting for the actions column in custom fields datatable

## Testing
- `php -l custom_fields.php`


------
https://chatgpt.com/codex/tasks/task_e_68b44f0355e4832097363fa7ebb4a0d5