### PR TITLE
Align settings tabs to the right

### DIFF
--- a/definicoes.php
+++ b/definicoes.php
@@ -10,22 +10,22 @@ require_once __DIR__ . '/header.php';
 ?>
 <div class="container-fluid">
     <h2>Definições</h2>
-    <div class="row mt-4">
-        <div class="col-md-3">
-            <div class="nav flex-column nav-pills" id="settings-tab" role="tablist" aria-orientation="vertical">
-                <button class="nav-link active" id="geral-tab" data-bs-toggle="pill" data-bs-target="#geral" type="button" role="tab" aria-controls="geral" aria-selected="true">Geral</button>
-                <button class="nav-link" id="email-tab" data-bs-toggle="pill" data-bs-target="#email" type="button" role="tab" aria-controls="email" aria-selected="false">E-mail</button>
-            </div>
+
+    <ul class="nav nav-tabs bar_tabs right" id="settings-tab" role="tablist">
+        <li class="nav-item">
+            <a class="nav-link active" id="geral-tab" data-bs-toggle="tab" href="#geral" role="tab" aria-controls="geral" aria-selected="true">Geral</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" id="email-tab" data-bs-toggle="tab" href="#email" role="tab" aria-controls="email" aria-selected="false">E-mail</a>
+        </li>
+    </ul>
+
+    <div class="tab-content" id="settings-tabContent">
+        <div class="tab-pane fade show active" id="geral" role="tabpanel" aria-labelledby="geral-tab">
+            <!-- Conteúdo Geral -->
         </div>
-        <div class="col-md-9">
-            <div class="tab-content" id="settings-tabContent">
-                <div class="tab-pane fade show active" id="geral" role="tabpanel" aria-labelledby="geral-tab">
-                    <!-- Conteúdo Geral -->
-                </div>
-                <div class="tab-pane fade" id="email" role="tabpanel" aria-labelledby="email-tab">
-                    <!-- Conteúdo E-mail -->
-                </div>
-            </div>
+        <div class="tab-pane fade" id="email" role="tabpanel" aria-labelledby="email-tab">
+            <!-- Conteúdo E-mail -->
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- convert settings page to use horizontal nav tabs
- align tabs to the right with existing `bar_tabs` styles

## Testing
- `php -l definicoes.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4614a62188320a08a20ab06f37594