### PR TITLE
Add CSRF protection to CMS forms

### DIFF
--- a/content.php
+++ b/content.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/functions.php';
 
 startSession();
 requireLogin();
+$csrfToken = generateCsrfToken();
 
 // If the request is for content type management (formerly handled by
 // content_types.php) delegate to that logic and exit early.
@@ -47,6 +48,11 @@ if (isset($_GET['manage_types'])) {
         $current = array_map(fn($t) => (int)$t['id'], getTaxonomiesForContentType($typeTax));
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
+                http_response_code(400);
+                exit('Token CSRF inválido');
+            }
+            $csrfToken = generateCsrfToken();
             $selected = isset($_POST['taxonomies']) ? array_map('intval', (array)$_POST['taxonomies']) : [];
             setContentTypeTaxonomies($typeTax, $selected);
             header('Location: ' . BASE_URL . 'content-types/taxonomies/' . $typeTax);
@@ -58,6 +64,7 @@ if (isset($_GET['manage_types'])) {
         <div class="container-fluid">
             <h2 class="mt-3">Taxonomias para <?php echo htmlspecialchars($type['label']); ?></h2>
             <form method="post">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken); ?>">
                 <?php foreach ($allTaxonomies as $tax): ?>
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="tax_<?php echo $tax['id']; ?>" name="taxonomies[]" value="<?php echo $tax['id']; ?>" <?php echo in_array($tax['id'], $current) ? 'checked' : ''; ?>>
@@ -79,6 +86,11 @@ if (isset($_GET['manage_types'])) {
         $editing = $id ? getContentType($id) : null;
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
+                http_response_code(400);
+                exit('Token CSRF inválido');
+            }
+            $csrfToken = generateCsrfToken();
             $name  = trim($_POST['name'] ?? '');
             $label = trim($_POST['label'] ?? '');
             $icon  = trim($_POST['icon'] ?? 'fa fa-file-text');
@@ -108,6 +120,7 @@ if (isset($_GET['manage_types'])) {
                 <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
             <?php endif; ?>
             <form method="post" action="">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken); ?>">
                 <div class="mb-3">
                     <label class="form-label" for="name">Slug</label>
                     <input type="text" class="form-control" id="name" name="name" value="<?php echo htmlspecialchars($editing['name'] ?? ''); ?>" required>
@@ -228,6 +241,11 @@ if ($action === 'add') {
     $allTaxonomies = getTaxonomiesForContentType($typeId);
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            exit('Token CSRF inválido');
+        }
+        $csrfToken = generateCsrfToken();
         $title = trim($_POST['title'] ?? '');
         $body  = trim($_POST['body'] ?? '');
         if ($title === '') {
@@ -287,6 +305,7 @@ if ($action === 'add') {
                             <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
                         <?php endif; ?>
                         <form method="post" enctype="multipart/form-data">
+                            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken); ?>">
                             <div class="mb-3">
                                 <label for="title" class="form-label">Title</label>
                                 <input type="text" id="title" name="title" class="form-control" required>
@@ -380,6 +399,11 @@ if ($action === 'edit') {
     $taxonomyMap = getContentTaxonomy($contentId);
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            exit('Token CSRF inválido');
+        }
+        $csrfToken = generateCsrfToken();
         $title = trim($_POST['title'] ?? '');
         $body  = trim($_POST['body'] ?? '');
         if ($title === '') {
@@ -443,6 +467,7 @@ if ($action === 'edit') {
                             <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
                         <?php endif; ?>
                         <form method="post" enctype="multipart/form-data">
+                            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken); ?>">
                             <div class="mb-3">
                                 <label for="title" class="form-label">Title</label>
                                 <input type="text" id="title" name="title" class="form-control" value="<?php echo htmlspecialchars($content['title']); ?>" required>

--- a/custom_fields.php
+++ b/custom_fields.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/functions.php';
 startSession();
 requireLogin();
 requireRole(2);
+$csrfToken = generateCsrfToken();
 
 // Obtém parâmetros básicos
 $typeId = isset($_GET['type_id']) ? (int) $_GET['type_id'] : 0;
@@ -51,6 +52,11 @@ if ($deleteId) {
 // Processa submissão do formulário para criar ou atualizar um campo
 $error = '';
 if (($_SERVER['REQUEST_METHOD'] === 'POST') && ($act === 'ad' || $editField)) {
+    if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
+        http_response_code(400);
+        exit('Token CSRF inválido');
+    }
+    $csrfToken = generateCsrfToken();
     $fieldId   = isset($_POST['field_id']) ? (int) $_POST['field_id'] : 0;
     $name      = isset($_POST['name']) ? trim($_POST['name']) : '';
     $label     = isset($_POST['label']) ? trim($_POST['label']) : '';
@@ -98,6 +104,7 @@ require_once __DIR__ . '/header.php';
     <div class="card p-3 mt-4">
 
         <form method="post" action="<?php echo $editField ? BASE_URL . 'fields/edit-field/' . $editField['id'] : BASE_URL . 'fields/' . $typeId . '/ad'; ?>">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken); ?>">
             <?php if ($editField): ?>
                 <input type="hidden" name="field_id" value="<?php echo $editField['id']; ?>">
             <?php endif; ?>

--- a/definicoes.php
+++ b/definicoes.php
@@ -5,10 +5,16 @@
 require_once __DIR__ . '/functions.php';
 startSession();
 requireLogin();
+$csrfToken = generateCsrfToken();
 
 $generalSaved = false;
 $emailSaved = false;
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
+        http_response_code(400);
+        exit('Token CSRF inválido');
+    }
+    $csrfToken = generateCsrfToken();
     if (isset($_POST['app_name'])) {
         $appName = trim($_POST['app_name'] ?? '');
         setSetting('app_name', $appName);
@@ -55,6 +61,7 @@ require_once __DIR__ . '/header.php';
                 <div class="alert alert-success mt-3">Definições guardadas.</div>
             <?php endif; ?>
             <form method="post" class="mt-3">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken); ?>">
                 <div class="row">
                 <div class="mb-3 col-md-6 col-sm-12">
                     <label for="app_name" class="form-label">Nome da APP</label>
@@ -74,6 +81,7 @@ require_once __DIR__ . '/header.php';
                 <div class="alert alert-success mt-3">Definições de e-mail guardadas.</div>
             <?php endif; ?>
             <form method="post" class="mt-3">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken); ?>">
                 <div class="row">
                 <div class="mb-3 col-md-3 col-sm-12">
                     <label for="smtp_host" class="form-label">Servidor SMTP</label>

--- a/functions.php
+++ b/functions.php
@@ -66,6 +66,34 @@ function startSession() {
 }
 
 /**
+ * Generate a CSRF token and store it in the session.
+ *
+ * @return string
+ */
+function generateCsrfToken(): string {
+    startSession();
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+/**
+ * Validate a CSRF token against the session and invalidate it.
+ *
+ * @param string $token
+ * @return bool
+ */
+function validateCsrfToken(string $token): bool {
+    startSession();
+    if (empty($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $token)) {
+        return false;
+    }
+    unset($_SESSION['csrf_token']);
+    return true;
+}
+
+/**
  * Check whether the current request is associated with a logged in user.
  *
  * @return bool

--- a/login.php
+++ b/login.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/data/db.php';
 require_once __DIR__ . '/functions.php';
 
 startSession();
+$csrfToken = generateCsrfToken();
 
 if (($_GET['action'] ?? '') === 'logout') {
     logoutUser();
@@ -17,6 +18,11 @@ if (($_GET['action'] ?? '') === 'logout') {
 $error = '';
 // If the form is posted attempt to authenticate the user.
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
+        http_response_code(400);
+        exit('Token CSRF inválido');
+    }
+    $csrfToken = generateCsrfToken();
     $username = trim($_POST['username'] ?? '');
     $password = trim($_POST['password'] ?? '');
     if ($username !== '' && $password !== '') {
@@ -56,6 +62,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <div class="animate form login_form">
           <section class="login_content">
             <form method="post" action="">
+              <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken); ?>">
               <h1>Login</h1>
               <?php if ($error): ?>
                 <div class="alert alert-danger" role="alert">

--- a/taxonomies.php
+++ b/taxonomies.php
@@ -16,6 +16,7 @@ require_once __DIR__ . '/functions.php';
 startSession();
 requireLogin();
 requireRole(2);
+$csrfToken = generateCsrfToken();
 
  $error = '';
  $taxonomyId = isset($_GET['taxonomy_id']) ? (int)$_GET['taxonomy_id'] : 0;
@@ -37,6 +38,11 @@ if ($taxonomyId) {
     }
 
     if ($act === 'ad' && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['term_name'])) {
+        if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            exit('Token CSRF inválido');
+        }
+        $csrfToken = generateCsrfToken();
         $termName = trim($_POST['term_name']);
         if ($termName !== '') {
             if ($editingTerm) {
@@ -74,6 +80,11 @@ if ($taxonomyId) {
     }
 
     if (($act === 'ad' || $editing) && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['name'])) {
+        if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            exit('Token CSRF inválido');
+        }
+        $csrfToken = generateCsrfToken();
         $name  = trim($_POST['name']);
         $label = trim($_POST['label'] ?? '');
         if ($name !== '' && $label !== '') {
@@ -104,6 +115,7 @@ require_once __DIR__ . '/header.php';
         <h2 class="mt-3"><?php echo $editingTerm ? 'Editar termo' : 'Adicionar novo termo a ' . htmlspecialchars($taxonomy['label']); ?></h2>
         <div class="card p-3 mt-4">
             <form method="post" action="">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken); ?>">
                 <div class="mb-3">
                     <label class="form-label" for="term_name">Nome</label>
                     <input type="text" class="form-control" id="term_name" name="term_name" value="<?php echo htmlspecialchars($editingTerm['name'] ?? ''); ?>" required>
@@ -142,6 +154,7 @@ require_once __DIR__ . '/header.php';
         <?php endif; ?>
         <div class="card p-3 mt-4">
             <form method="post" action="">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken); ?>">
                 <div class="mb-3">
                     <label class="form-label" for="name">Slug</label>
                     <input type="text" class="form-control" id="name" name="name" value="<?php echo htmlspecialchars($editing['name'] ?? ''); ?>" required>

--- a/users.php
+++ b/users.php
@@ -2,6 +2,7 @@
 // Unified user management: list users, add/edit users, and edit profile.
 require_once __DIR__ . '/functions.php';
 startSession();
+$csrfToken = generateCsrfToken();
 
 $profileMode = isset($_GET['profile']);
 $action = $_GET['action'] ?? 'list';
@@ -82,6 +83,11 @@ $editing = $id !== null;
 $userData = $editing ? getUserById($id) : ['username' => '', 'name' => '', 'email' => '', 'phone' => '', 'role' => 3, 'photo' => ''];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
+        http_response_code(400);
+        exit('Token CSRF inválido');
+    }
+    $csrfToken = generateCsrfToken();
     $username = $editing ? $userData['username'] : trim($_POST['username'] ?? '');
     $name = trim($_POST['name'] ?? '');
     $email = trim($_POST['email'] ?? '');
@@ -147,6 +153,7 @@ require_once __DIR__ . '/header.php';
         <div class="alert alert-danger" role="alert"><?= htmlspecialchars($err); ?></div>
     <?php endforeach; ?>
     <form method="post" enctype="multipart/form-data" class="w-50">
+        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken); ?>">
         <div class="mb-3">
             <label for="username" class="form-label">Utilizador</label>
             <?php if ($editing): ?>


### PR DESCRIPTION
## Summary
- add CSRF token generation and validation helpers
- embed CSRF tokens and checks across login, user management, content, taxonomy, settings, and custom field forms

## Testing
- `php -l functions.php`
- `php -l login.php`
- `php -l users.php`
- `php -l content.php`
- `php -l taxonomies.php`
- `php -l definicoes.php`
- `php -l custom_fields.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4db0a1278832098cb721787798b47