### PR TITLE
Fix GridStack loading by using CDN

### DIFF
--- a/field_layout.php
+++ b/field_layout.php
@@ -15,7 +15,7 @@ $fields = getCustomFields($typeId);
 
 require_once __DIR__ . '/header.php';
 ?>
-<link rel="stylesheet" href="<?= BASE_URL ?>vendors/gridstack/gridstack.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridstack@9.2.2/dist/gridstack.min.css">
 <div class="container-fluid">
     <h2 class="mt-3">Layout de campos para <?= htmlspecialchars($type['label']) ?></h2>
     <div class="grid-stack">
@@ -30,7 +30,7 @@ require_once __DIR__ . '/header.php';
     <a href="<?= BASE_URL . 'fields/' . $typeId; ?>" class="btn btn-secondary mt-3"><i class="fa fa-arrow-left"></i> Voltar</a>
 </div>
 
-<script src="<?= BASE_URL ?>vendors/gridstack/gridstack.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gridstack@9.2.2/dist/gridstack-all.js"></script>
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {

--- a/footer.php
+++ b/footer.php
@@ -11,7 +11,6 @@
 </div> <!-- /container body -->
 
 <script src="vendors/jquery/dist/jquery.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/0.2.4/gridstack.min.js" integrity="sha512-WdDxKC+6+SRQzYUVYtrdh+PT4SQ+E83xpb6xZUwrayWdWaq38iqFTYytMmIt6rJPra9vXwlNOAWIjmO5bR65NA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="vendors/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 <script src="vendors/datatables.net/js/dataTables.min.js"></script>
 <script src="vendors/datatables.net-bs5/js/dataTables.bootstrap5.min.js"></script>


### PR DESCRIPTION
## Summary
- Load GridStack CSS and script from jsDelivr CDN instead of local vendors files.
- Remove outdated GridStack 0.2.4 script from global footer.

## Testing
- `php -l field_layout.php footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68b582c1d328832085b2675740a46f88