### PR TITLE
Enable layout editing for core fields

### DIFF
--- a/content.php
+++ b/content.php
@@ -344,6 +344,22 @@ $error = '';
 
 if ($action === 'add') {
     $customFields = sortFieldsByGrid(getCustomFields($typeId));
+    $fields = sortFieldsByGrid(array_merge([
+        [
+            'id' => 'title',
+            'label' => 'Título',
+            'grid_row' => $contentType['title_grid_row'] ?? 0,
+            'grid_col' => $contentType['title_grid_col'] ?? 0,
+            'grid_width' => $contentType['title_grid_width'] ?? 12,
+        ],
+        [
+            'id' => 'body',
+            'label' => 'Texto',
+            'grid_row' => $contentType['body_grid_row'] ?? 0,
+            'grid_col' => $contentType['body_grid_col'] ?? 0,
+            'grid_width' => $contentType['body_grid_width'] ?? 12,
+        ],
+    ], $customFields));
     $allTaxonomies = getTaxonomiesForContentType($typeId);
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -412,17 +428,9 @@ if ($action === 'add') {
                         <?php endif; ?>
                         <form method="post" enctype="multipart/form-data">
                             <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken); ?>">
-                            <div class="mb-3">
-                                <label for="title" class="form-label">Título</label>
-                                <input type="text" id="title" name="title" class="form-control" required>
-                            </div>
-                            <div class="mb-3">
-                                <label for="body" class="form-label">Texto</label>
-                                <textarea id="body" name="body" class="form-control" rows="4"></textarea>
-                            </div>
                             <?php
                                 $hasGrid = false;
-                                foreach ($customFields as $f) {
+                                foreach ($fields as $f) {
                                     if (!empty($f['grid_row']) || !empty($f['grid_width'])) {
                                         $hasGrid = true;
                                         break;
@@ -430,25 +438,41 @@ if ($action === 'add') {
                                 }
                                 if ($hasGrid) {
                                     $currentRow = null;
-                                    foreach ($customFields as $field) {
-                                        $inputName = 'field_' . $field['id'];
+                                    foreach ($fields as $field) {
                                         $row = $field['grid_row'] ?? null;
                                         $width = $field['grid_width'] ?? 12;
                                         if ($row !== $currentRow) {
                                             if ($currentRow !== null) { echo '</div>'; }
                                             echo '<div class="row custom-field-row">';
-                                            $currentRow = $row;
+        $currentRow = $row;
                                         }
                                         echo '<div class="col-md-' . (int)$width . ' mb-3">';
-                                        renderFieldInput($field, $inputName);
+                                        if ($field['id'] === 'title') {
+                                            echo '<label for="title" class="form-label">Título</label>';
+                                            echo '<input type="text" id="title" name="title" class="form-control" required>';
+                                        } elseif ($field['id'] === 'body') {
+                                            echo '<label for="body" class="form-label">Texto</label>';
+                                            echo '<textarea id="body" name="body" class="form-control" rows="4"></textarea>';
+                                        } else {
+                                            $inputName = 'field_' . $field['id'];
+                                            renderFieldInput($field, $inputName);
+                                        }
                                         echo '</div>';
                                     }
                                     if ($currentRow !== null) { echo '</div>'; }
                                 } else {
-                                    foreach ($customFields as $field) {
-                                        $inputName = 'field_' . $field['id'];
+                                    foreach ($fields as $field) {
                                         echo '<div class="mb-3">';
-                                        renderFieldInput($field, $inputName);
+                                        if ($field['id'] === 'title') {
+                                            echo '<label for="title" class="form-label">Título</label>';
+                                            echo '<input type="text" id="title" name="title" class="form-control" required>';
+                                        } elseif ($field['id'] === 'body') {
+                                            echo '<label for="body" class="form-label">Texto</label>';
+                                            echo '<textarea id="body" name="body" class="form-control" rows="4"></textarea>';
+                                        } else {
+                                            $inputName = 'field_' . $field['id'];
+                                            renderFieldInput($field, $inputName);
+                                        }
                                         echo '</div>';
                                     }
                                 }
@@ -487,6 +511,22 @@ if ($action === 'edit') {
     }
 
     $customFields = sortFieldsByGrid(getCustomFields($typeId));
+    $fields = sortFieldsByGrid(array_merge([
+        [
+            'id' => 'title',
+            'label' => 'Título',
+            'grid_row' => $contentType['title_grid_row'] ?? 0,
+            'grid_col' => $contentType['title_grid_col'] ?? 0,
+            'grid_width' => $contentType['title_grid_width'] ?? 12,
+        ],
+        [
+            'id' => 'body',
+            'label' => 'Texto',
+            'grid_row' => $contentType['body_grid_row'] ?? 0,
+            'grid_col' => $contentType['body_grid_col'] ?? 0,
+            'grid_width' => $contentType['body_grid_width'] ?? 12,
+        ],
+    ], $customFields));
     $allTaxonomies = getTaxonomiesForContentType($typeId);
     $customValues = getCustomValuesForContent($contentId);
     $taxonomyMap = getContentTaxonomy($contentId);
@@ -561,17 +601,9 @@ if ($action === 'edit') {
                         <?php endif; ?>
                         <form method="post" enctype="multipart/form-data">
                             <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken); ?>">
-                            <div class="mb-3">
-                                <label for="title" class="form-label">Título</label>
-                                <input type="text" id="title" name="title" class="form-control" value="<?php echo htmlspecialchars($content['title']); ?>" required>
-                            </div>
-                            <div class="mb-3">
-                                <label for="body" class="form-label">Texto</label>
-                                <textarea id="body" name="body" class="form-control" rows="4"><?php echo htmlspecialchars($content['body']); ?></textarea>
-                            </div>
                             <?php
                                 $hasGrid = false;
-                                foreach ($customFields as $f) {
+                                foreach ($fields as $f) {
                                     if (!empty($f['grid_row']) || !empty($f['grid_width'])) {
                                         $hasGrid = true;
                                         break;
@@ -579,9 +611,7 @@ if ($action === 'edit') {
                                 }
                                 if ($hasGrid) {
                                     $currentRow = null;
-                                    foreach ($customFields as $field) {
-                                        $inputName = 'field_' . $field['id'];
-                                        $value = $customValues[$field['id']] ?? '';
+                                    foreach ($fields as $field) {
                                         $row = $field['grid_row'] ?? null;
                                         $width = $field['grid_width'] ?? 12;
                                         if ($row !== $currentRow) {
@@ -590,16 +620,34 @@ if ($action === 'edit') {
                                             $currentRow = $row;
                                         }
                                         echo '<div class="col-md-' . (int)$width . ' mb-3">';
-                                        renderFieldInput($field, $inputName, $value);
+                                        if ($field['id'] === 'title') {
+                                            echo '<label for="title" class="form-label">Título</label>';
+                                            echo '<input type="text" id="title" name="title" class="form-control" value="' . htmlspecialchars($content['title']) . '" required>';
+                                        } elseif ($field['id'] === 'body') {
+                                            echo '<label for="body" class="form-label">Texto</label>';
+                                            echo '<textarea id="body" name="body" class="form-control" rows="4">' . htmlspecialchars($content['body']) . '</textarea>';
+                                        } else {
+                                            $inputName = 'field_' . $field['id'];
+                                            $value = $customValues[$field['id']] ?? '';
+                                            renderFieldInput($field, $inputName, $value);
+                                        }
                                         echo '</div>';
                                     }
                                     if ($currentRow !== null) { echo '</div>'; }
                                 } else {
-                                    foreach ($customFields as $field) {
-                                        $inputName = 'field_' . $field['id'];
-                                        $value = $customValues[$field['id']] ?? '';
+                                    foreach ($fields as $field) {
                                         echo '<div class="mb-3">';
-                                        renderFieldInput($field, $inputName, $value);
+                                        if ($field['id'] === 'title') {
+                                            echo '<label for="title" class="form-label">Título</label>';
+                                            echo '<input type="text" id="title" name="title" class="form-control" value="' . htmlspecialchars($content['title']) . '" required>';
+                                        } elseif ($field['id'] === 'body') {
+                                            echo '<label for="body" class="form-label">Texto</label>';
+                                            echo '<textarea id="body" name="body" class="form-control" rows="4">' . htmlspecialchars($content['body']) . '</textarea>';
+                                        } else {
+                                            $inputName = 'field_' . $field['id'];
+                                            $value = $customValues[$field['id']] ?? '';
+                                            renderFieldInput($field, $inputName, $value);
+                                        }
                                         echo '</div>';
                                     }
                                 }

--- a/field_layout.php
+++ b/field_layout.php
@@ -12,6 +12,22 @@ if (!$type) {
 }
 
 $fields = getCustomFields($typeId);
+$fields = array_merge([
+    [
+        'id' => 'title',
+        'label' => 'Título',
+        'grid_row' => $type['title_grid_row'] ?? 0,
+        'grid_col' => $type['title_grid_col'] ?? 0,
+        'grid_width' => $type['title_grid_width'] ?? 12,
+    ],
+    [
+        'id' => 'body',
+        'label' => 'Texto',
+        'grid_row' => $type['body_grid_row'] ?? 0,
+        'grid_col' => $type['body_grid_col'] ?? 0,
+        'grid_width' => $type['body_grid_width'] ?? 12,
+    ],
+], $fields);
 
 require_once __DIR__ . '/header.php';
 ?>
@@ -20,7 +36,7 @@ require_once __DIR__ . '/header.php';
     <h2 class="mt-3">Layout de campos para <?= htmlspecialchars($type['label']) ?></h2>
     <div class="grid-stack">
         <?php foreach ($fields as $field): ?>
-            <div class="grid-stack-item" data-gs-id="<?= $field['id'] ?>" data-gs-x="<?= $field['grid_col'] ?>" data-gs-y="<?= $field['grid_row'] ?>" data-gs-width="<?= $field['grid_width'] ?>" data-gs-height="1">
+            <div class="grid-stack-item" gs-id="<?= $field['id'] ?>" gs-x="<?= $field['grid_col'] ?>" gs-y="<?= $field['grid_row'] ?>" gs-w="<?= $field['grid_width'] ?>" gs-h="1">
                 <div class="grid-stack-item-content">
                     <?= htmlspecialchars($field['label']) ?>
                 </div>
@@ -39,6 +55,7 @@ document.addEventListener('DOMContentLoaded', function() {
         items.forEach(item => {
             const params = new URLSearchParams();
             params.append('field_id', item.id);
+            params.append('type_id', <?= $typeId ?>);
             params.append('row', item.y);
             params.append('col', item.x);
             params.append('width', item.w);

--- a/functions.php
+++ b/functions.php
@@ -385,10 +385,22 @@ function getContentType(int $id): ?array {
     $hasAuthor = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_author'")->fetch();
     $hasDate   = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_date'")->fetch();
     $hasOrder  = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'sort_order'")->fetch();
+    $hasTitleRow   = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'title_grid_row'")->fetch();
+    $hasTitleCol   = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'title_grid_col'")->fetch();
+    $hasTitleWidth = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'title_grid_width'")->fetch();
+    $hasBodyRow    = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'body_grid_row'")->fetch();
+    $hasBodyCol    = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'body_grid_col'")->fetch();
+    $hasBodyWidth  = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'body_grid_width'")->fetch();
     $authorExpr = $hasAuthor ? 'show_author' : '1 AS show_author';
     $dateExpr   = $hasDate ? 'show_date' : '1 AS show_date';
     $orderExpr  = $hasOrder ? 'sort_order' : '0 AS sort_order';
-    $stmt = $pdo->prepare("SELECT id, name, label, icon, $authorExpr, $dateExpr, $orderExpr FROM content_types WHERE id = ?");
+    $titleRowExpr   = $hasTitleRow ? 'title_grid_row' : '0 AS title_grid_row';
+    $titleColExpr   = $hasTitleCol ? 'title_grid_col' : '0 AS title_grid_col';
+    $titleWidthExpr = $hasTitleWidth ? 'title_grid_width' : '12 AS title_grid_width';
+    $bodyRowExpr    = $hasBodyRow ? 'body_grid_row' : '0 AS body_grid_row';
+    $bodyColExpr    = $hasBodyCol ? 'body_grid_col' : '0 AS body_grid_col';
+    $bodyWidthExpr  = $hasBodyWidth ? 'body_grid_width' : '12 AS body_grid_width';
+    $stmt = $pdo->prepare("SELECT id, name, label, icon, $authorExpr, $dateExpr, $orderExpr, $titleRowExpr, $titleColExpr, $titleWidthExpr, $bodyRowExpr, $bodyColExpr, $bodyWidthExpr FROM content_types WHERE id = ?");
     $stmt->execute([$id]);
     return $stmt->fetch() ?: null;
 }
@@ -404,10 +416,22 @@ function getContentTypeBySlug(string $slug): ?array {
     $hasAuthor = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_author'")->fetch();
     $hasDate   = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'show_date'")->fetch();
     $hasOrder  = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'sort_order'")->fetch();
+    $hasTitleRow   = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'title_grid_row'")->fetch();
+    $hasTitleCol   = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'title_grid_col'")->fetch();
+    $hasTitleWidth = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'title_grid_width'")->fetch();
+    $hasBodyRow    = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'body_grid_row'")->fetch();
+    $hasBodyCol    = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'body_grid_col'")->fetch();
+    $hasBodyWidth  = $pdo->query("SHOW COLUMNS FROM content_types LIKE 'body_grid_width'")->fetch();
     $authorExpr = $hasAuthor ? 'show_author' : '1 AS show_author';
     $dateExpr   = $hasDate ? 'show_date' : '1 AS show_date';
     $orderExpr  = $hasOrder ? 'sort_order' : '0 AS sort_order';
-    $stmt = $pdo->prepare("SELECT id, name, label, icon, $authorExpr, $dateExpr, $orderExpr FROM content_types WHERE name = ?");
+    $titleRowExpr   = $hasTitleRow ? 'title_grid_row' : '0 AS title_grid_row';
+    $titleColExpr   = $hasTitleCol ? 'title_grid_col' : '0 AS title_grid_col';
+    $titleWidthExpr = $hasTitleWidth ? 'title_grid_width' : '12 AS title_grid_width';
+    $bodyRowExpr    = $hasBodyRow ? 'body_grid_row' : '0 AS body_grid_row';
+    $bodyColExpr    = $hasBodyCol ? 'body_grid_col' : '0 AS body_grid_col';
+    $bodyWidthExpr  = $hasBodyWidth ? 'body_grid_width' : '12 AS body_grid_width';
+    $stmt = $pdo->prepare("SELECT id, name, label, icon, $authorExpr, $dateExpr, $orderExpr, $titleRowExpr, $titleColExpr, $titleWidthExpr, $bodyRowExpr, $bodyColExpr, $bodyWidthExpr FROM content_types WHERE name = ?");
     $stmt->execute([$slug]);
     return $stmt->fetch() ?: null;
 }
@@ -757,14 +781,25 @@ function deleteCustomField(int $id): void {
 /**
  * Update grid layout info for a custom field if columns exist.
  */
-function updateFieldLayout(int $id, int $row, int $col, int $width): void {
+function updateFieldLayout(int|string $id, int $typeId, int $row, int $col, int $width): void {
     $pdo = getPDO();
-    $hasRow = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'grid_row'")->fetch();
-    $hasCol = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'grid_col'")->fetch();
-    $hasWidth = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'grid_width'")->fetch();
-    if ($hasRow && $hasCol && $hasWidth) {
-        $stmt = $pdo->prepare('UPDATE custom_fields SET grid_row = ?, grid_col = ?, grid_width = ? WHERE id = ?');
-        $stmt->execute([$row, $col, $width, $id]);
+    if (is_numeric($id)) {
+        $hasRow = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'grid_row'")->fetch();
+        $hasCol = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'grid_col'")->fetch();
+        $hasWidth = $pdo->query("SHOW COLUMNS FROM custom_fields LIKE 'grid_width'")->fetch();
+        if ($hasRow && $hasCol && $hasWidth) {
+            $stmt = $pdo->prepare('UPDATE custom_fields SET grid_row = ?, grid_col = ?, grid_width = ? WHERE id = ?');
+            $stmt->execute([$row, $col, $width, (int)$id]);
+        }
+    } elseif ($id === 'title' || $id === 'body') {
+        $prefix = $id === 'title' ? 'title' : 'body';
+        $hasRow = $pdo->query("SHOW COLUMNS FROM content_types LIKE '{$prefix}_grid_row'")->fetch();
+        $hasCol = $pdo->query("SHOW COLUMNS FROM content_types LIKE '{$prefix}_grid_col'")->fetch();
+        $hasWidth = $pdo->query("SHOW COLUMNS FROM content_types LIKE '{$prefix}_grid_width'")->fetch();
+        if ($hasRow && $hasCol && $hasWidth) {
+            $stmt = $pdo->prepare("UPDATE content_types SET {$prefix}_grid_row = ?, {$prefix}_grid_col = ?, {$prefix}_grid_width = ? WHERE id = ?");
+            $stmt->execute([$row, $col, $width, $typeId]);
+        }
     }
 }
 

--- a/router.php
+++ b/router.php
@@ -120,7 +120,7 @@ switch (true) {
         break;
     case $path === 'fields/save-layout':
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            updateFieldLayout((int)($_POST['field_id'] ?? 0), (int)($_POST['row'] ?? 0), (int)($_POST['col'] ?? 0), (int)($_POST['width'] ?? 1));
+            updateFieldLayout($_POST['field_id'] ?? 0, (int)($_POST['type_id'] ?? 0), (int)($_POST['row'] ?? 0), (int)($_POST['col'] ?? 0), (int)($_POST['width'] ?? 1));
             echo 'ok';
         }
         break;

--- a/schema.sql
+++ b/schema.sql
@@ -26,6 +26,12 @@ CREATE TABLE IF NOT EXISTS content_types (
     sort_order INT NOT NULL DEFAULT 0,
     show_author TINYINT(1) NOT NULL DEFAULT 0,
     show_date TINYINT(1) NOT NULL DEFAULT 0,
+    title_grid_row INT NOT NULL DEFAULT 0,
+    title_grid_col INT NOT NULL DEFAULT 0,
+    title_grid_width INT NOT NULL DEFAULT 12,
+    body_grid_row INT NOT NULL DEFAULT 0,
+    body_grid_col INT NOT NULL DEFAULT 0,
+    body_grid_width INT NOT NULL DEFAULT 12,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 


### PR DESCRIPTION
## Summary
- allow layout to include built-in Title and Text fields with Gridstack
- persist Title/Text grid positions via new columns and updateFieldLayout
- send type id and fix Gridstack attributes so dragging updates storage

## Testing
- `php -l functions.php`
- `php -l router.php`
- `php -l field_layout.php`
- `php -l content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5884bd5288320b314e3e6f38e631e