### PR TITLE
Enable grid layout for title and body fields

### DIFF
--- a/content.php
+++ b/content.php
@@ -344,6 +344,17 @@ $error = '';
 
 if ($action === 'add') {
     $customFields = sortFieldsByGrid(getCustomFields($typeId));
+    $allTaxonomies = getTaxonomiesForContentType($typeId);
+    $taxonomyFields = array_map(function ($tax) {
+        return [
+            'id' => 'tax_' . $tax['id'],
+            'label' => $tax['label'],
+            'taxonomy_id' => $tax['id'],
+            'grid_row' => $tax['grid_row'] ?? 0,
+            'grid_col' => $tax['grid_col'] ?? 0,
+            'grid_width' => $tax['grid_width'] ?? 12,
+        ];
+    }, $allTaxonomies);
     $fields = sortFieldsByGrid(array_merge([
         [
             'id' => 'title',
@@ -359,8 +370,7 @@ if ($action === 'add') {
             'grid_col' => $contentType['body_grid_col'] ?? 0,
             'grid_width' => $contentType['body_grid_width'] ?? 12,
         ],
-    ], $customFields));
-    $allTaxonomies = getTaxonomiesForContentType($typeId);
+    ], $customFields, $taxonomyFields));
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
@@ -461,6 +471,14 @@ if ($action === 'add') {
                                         } elseif ($field['id'] === 'body') {
                                             echo '<label for="body" class="form-label">Texto</label>';
                                             echo '<textarea id="body" name="body" class="form-control" rows="4"></textarea>';
+                                        } elseif (isset($field['taxonomy_id'])) {
+                                            $terms = getTerms($field['taxonomy_id']);
+                                            echo '<label class="form-label">' . htmlspecialchars($field['label']) . '</label>';
+                                            echo '<select name="taxonomy_' . htmlspecialchars($field['taxonomy_id']) . '[]" class="form-select" multiple>';
+                                            foreach ($terms as $term) {
+                                                echo '<option value="' . htmlspecialchars($term['id']) . '">' . htmlspecialchars($term['name']) . '</option>';
+                                            }
+                                            echo '</select>';
                                         } else {
                                             $inputName = 'field_' . $field['id'];
                                             renderFieldInput($field, $inputName);
@@ -478,6 +496,14 @@ if ($action === 'add') {
                                         } elseif ($field['id'] === 'body') {
                                             echo '<label for="body" class="form-label">Texto</label>';
                                             echo '<textarea id="body" name="body" class="form-control" rows="4"></textarea>';
+                                        } elseif (isset($field['taxonomy_id'])) {
+                                            $terms = getTerms($field['taxonomy_id']);
+                                            echo '<label class="form-label">' . htmlspecialchars($field['label']) . '</label>';
+                                            echo '<select name="taxonomy_' . htmlspecialchars($field['taxonomy_id']) . '[]" class="form-select" multiple>';
+                                            foreach ($terms as $term) {
+                                                echo '<option value="' . htmlspecialchars($term['id']) . '">' . htmlspecialchars($term['name']) . '</option>';
+                                            }
+                                            echo '</select>';
                                         } else {
                                             $inputName = 'field_' . $field['id'];
                                             renderFieldInput($field, $inputName);
@@ -486,17 +512,6 @@ if ($action === 'add') {
                                     }
                                 }
                             ?>
-                            <?php foreach ($allTaxonomies as $taxonomy): ?>
-                                <div class="mb-3">
-                                    <label class="form-label"><?php echo htmlspecialchars($taxonomy['label']); ?></label>
-                                    <?php $terms = getTerms($taxonomy['id']); ?>
-                                    <select name="taxonomy_<?php echo htmlspecialchars($taxonomy['id']); ?>[]" class="form-select" multiple>
-                                        <?php foreach ($terms as $term): ?>
-                                            <option value="<?php echo htmlspecialchars($term['id']); ?>"><?php echo htmlspecialchars($term['name']); ?></option>
-                                        <?php endforeach; ?>
-                                    </select>
-                                </div>
-                            <?php endforeach; ?>
                                                         <a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($typeSlug)); ?>" class="btn btn-secondary"><i class="fa fa-arrow-left"></i> Cancelar</a>
 
                             <button type="submit" class="btn btn-success"><i class="fa fa-save"></i> Guardar</button>
@@ -520,6 +535,17 @@ if ($action === 'edit') {
     }
 
     $customFields = sortFieldsByGrid(getCustomFields($typeId));
+    $allTaxonomies = getTaxonomiesForContentType($typeId);
+    $taxonomyFields = array_map(function ($tax) {
+        return [
+            'id' => 'tax_' . $tax['id'],
+            'label' => $tax['label'],
+            'taxonomy_id' => $tax['id'],
+            'grid_row' => $tax['grid_row'] ?? 0,
+            'grid_col' => $tax['grid_col'] ?? 0,
+            'grid_width' => $tax['grid_width'] ?? 12,
+        ];
+    }, $allTaxonomies);
     $fields = sortFieldsByGrid(array_merge([
         [
             'id' => 'title',
@@ -535,8 +561,7 @@ if ($action === 'edit') {
             'grid_col' => $contentType['body_grid_col'] ?? 0,
             'grid_width' => $contentType['body_grid_width'] ?? 12,
         ],
-    ], $customFields));
-    $allTaxonomies = getTaxonomiesForContentType($typeId);
+    ], $customFields, $taxonomyFields));
     $customValues = getCustomValuesForContent($contentId);
     $taxonomyMap = getContentTaxonomy($contentId);
 
@@ -628,8 +653,8 @@ if ($action === 'edit') {
                                         if ($row !== $currentRow) {
                                             if ($currentRow !== null) { echo '</div>'; }
                                             echo '<div class="row custom-field-row">';
-                                            $currentRow = $row;
-                                            $currentCol = 0;
+                        $currentRow = $row;
+                        $currentCol = 0;
                                         }
                                         $offset = max(0, $col - $currentCol);
                                         $classes = 'col-md-' . (int)$width . ' mb-3';
@@ -639,10 +664,20 @@ if ($action === 'edit') {
                                         echo '<div class="' . $classes . '">';
                                         if ($field['id'] === 'title') {
                                             echo '<label for="title" class="form-label">Título</label>';
-                        echo '<input type="text" id="title" name="title" class="form-control" value="' . htmlspecialchars($content['title']) . '" required>';
+                                            echo '<input type="text" id="title" name="title" class="form-control" value="' . htmlspecialchars($content['title']) . '" required>';
                                         } elseif ($field['id'] === 'body') {
                                             echo '<label for="body" class="form-label">Texto</label>';
                                             echo '<textarea id="body" name="body" class="form-control" rows="4">' . htmlspecialchars($content['body']) . '</textarea>';
+                                        } elseif (isset($field['taxonomy_id'])) {
+                                            $terms = getTerms($field['taxonomy_id']);
+                                            $selected = $taxonomyMap[$field['taxonomy_id']] ?? [];
+                                            echo '<label class="form-label">' . htmlspecialchars($field['label']) . '</label>';
+                                            echo '<select name="taxonomy_' . htmlspecialchars($field['taxonomy_id']) . '[]" class="form-select" multiple>';
+                                            foreach ($terms as $term) {
+                                                $sel = in_array($term['id'], $selected) ? ' selected' : '';
+                                                echo '<option value="' . htmlspecialchars($term['id']) . '"' . $sel . '>' . htmlspecialchars($term['name']) . '</option>';
+                                            }
+                                            echo '</select>';
                                         } else {
                                             $inputName = 'field_' . $field['id'];
                                             $value = $customValues[$field['id']] ?? '';
@@ -661,6 +696,16 @@ if ($action === 'edit') {
                                         } elseif ($field['id'] === 'body') {
                                             echo '<label for="body" class="form-label">Texto</label>';
                                             echo '<textarea id="body" name="body" class="form-control" rows="4">' . htmlspecialchars($content['body']) . '</textarea>';
+                                        } elseif (isset($field['taxonomy_id'])) {
+                                            $terms = getTerms($field['taxonomy_id']);
+                        $selected = $taxonomyMap[$field['taxonomy_id']] ?? [];
+                        echo '<label class="form-label">' . htmlspecialchars($field['label']) . '</label>';
+                        echo '<select name="taxonomy_' . htmlspecialchars($field['taxonomy_id']) . '[]" class="form-select" multiple>';
+                        foreach ($terms as $term) {
+                            $sel = in_array($term['id'], $selected) ? ' selected' : '';
+                            echo '<option value="' . htmlspecialchars($term['id']) . '"' . $sel . '>' . htmlspecialchars($term['name']) . '</option>';
+                        }
+                        echo '</select>';
                                         } else {
                                             $inputName = 'field_' . $field['id'];
                                             $value = $customValues[$field['id']] ?? '';
@@ -670,17 +715,6 @@ if ($action === 'edit') {
                                     }
                                 }
                             ?>
-                            <?php foreach ($allTaxonomies as $taxonomy): ?>
-                                <?php $terms = getTerms($taxonomy['id']); $selected = $taxonomyMap[$taxonomy['id']] ?? []; ?>
-                                <div class="mb-3">
-                                    <label class="form-label"><?php echo htmlspecialchars($taxonomy['label']); ?></label>
-                                    <select name="taxonomy_<?php echo htmlspecialchars($taxonomy['id']); ?>[]" class="form-select" multiple>
-                                        <?php foreach ($terms as $term): ?>
-                                            <option value="<?php echo htmlspecialchars($term['id']); ?>" <?php echo in_array($term['id'], $selected) ? 'selected' : ''; ?>><?php echo htmlspecialchars($term['name']); ?></option>
-                                        <?php endforeach; ?>
-                                    </select>
-                                </div>
-                            <?php endforeach; ?>
                                                         <a href="<?= BASE_URL ?><?php echo htmlspecialchars(rawurlencode($typeSlug)); ?>" class="btn btn-secondary"><i class="fa fa-arrow-left"></i> Cancelar</a>
 
                             <button type="submit" class="btn btn-success"><i class="fa fa-save"></i> Guardar</button>

--- a/custom_fields.php
+++ b/custom_fields.php
@@ -39,6 +39,16 @@ if (!$type) {
 
 if ($isLayout) {
     $fields = getCustomFields($typeId);
+    $taxonomies = getTaxonomiesForContentType($typeId);
+    $taxonomyFields = array_map(function ($tax) {
+        return [
+            'id' => 'tax_' . $tax['id'],
+            'label' => $tax['label'],
+            'grid_row' => $tax['grid_row'] ?? 0,
+            'grid_col' => $tax['grid_col'] ?? 0,
+            'grid_width' => $tax['grid_width'] ?? 12,
+        ];
+    }, $taxonomies);
     $fields = array_merge([
         [
             'id' => 'title',
@@ -54,7 +64,7 @@ if ($isLayout) {
             'grid_col' => $type['body_grid_col'] ?? 0,
             'grid_width' => $type['body_grid_width'] ?? 12,
         ],
-    ], $fields);
+    ], $fields, $taxonomyFields);
 
     require_once __DIR__ . '/header.php';
     ?>

--- a/functions.php
+++ b/functions.php
@@ -800,6 +800,15 @@ function updateFieldLayout(int|string $id, int $typeId, int $row, int $col, int 
             $stmt = $pdo->prepare("UPDATE content_types SET {$prefix}_grid_row = ?, {$prefix}_grid_col = ?, {$prefix}_grid_width = ? WHERE id = ?");
             $stmt->execute([$row, $col, $width, $typeId]);
         }
+    } elseif (is_string($id) && str_starts_with($id, 'tax_')) {
+        $taxId = (int) substr($id, 4);
+        $hasRow = $pdo->query("SHOW COLUMNS FROM content_type_taxonomy LIKE 'grid_row'")->fetch();
+        $hasCol = $pdo->query("SHOW COLUMNS FROM content_type_taxonomy LIKE 'grid_col'")->fetch();
+        $hasWidth = $pdo->query("SHOW COLUMNS FROM content_type_taxonomy LIKE 'grid_width'")->fetch();
+        if ($hasRow && $hasCol && $hasWidth) {
+            $stmt = $pdo->prepare('UPDATE content_type_taxonomy SET grid_row = ?, grid_col = ?, grid_width = ? WHERE taxonomy_id = ? AND content_type_id = ?');
+            $stmt->execute([$row, $col, $width, $taxId, $typeId]);
+        }
     }
 }
 
@@ -953,7 +962,13 @@ function deleteTerm(int $term_id): void {
  */
 function getTaxonomiesForContentType(int $content_type_id): array {
     $pdo = getPDO();
-    $stmt = $pdo->prepare('SELECT t.id, t.name, t.label FROM taxonomies t JOIN content_type_taxonomy ctt ON t.id = ctt.taxonomy_id WHERE ctt.content_type_id = ? ORDER BY t.id ASC');
+    $hasRow = $pdo->query("SHOW COLUMNS FROM content_type_taxonomy LIKE 'grid_row'")->fetch();
+    $hasCol = $pdo->query("SHOW COLUMNS FROM content_type_taxonomy LIKE 'grid_col'")->fetch();
+    $hasWidth = $pdo->query("SHOW COLUMNS FROM content_type_taxonomy LIKE 'grid_width'")->fetch();
+    $rowExpr = $hasRow ? 'ctt.grid_row' : '0 AS grid_row';
+    $colExpr = $hasCol ? 'ctt.grid_col' : '0 AS grid_col';
+    $widthExpr = $hasWidth ? 'ctt.grid_width' : '12 AS grid_width';
+    $stmt = $pdo->prepare("SELECT t.id, t.name, t.label, $rowExpr, $colExpr, $widthExpr FROM taxonomies t JOIN content_type_taxonomy ctt ON t.id = ctt.taxonomy_id WHERE ctt.content_type_id = ? ORDER BY t.id ASC");
     $stmt->execute([$content_type_id]);
     return $stmt->fetchAll();
 }

--- a/schema.sql
+++ b/schema.sql
@@ -94,6 +94,9 @@ CREATE TABLE IF NOT EXISTS custom_values (
 CREATE TABLE IF NOT EXISTS content_type_taxonomy (
     content_type_id INT NOT NULL,
     taxonomy_id INT NOT NULL,
+    grid_row INT NOT NULL DEFAULT 0,
+    grid_col INT NOT NULL DEFAULT 0,
+    grid_width INT NOT NULL DEFAULT 12,
     PRIMARY KEY (content_type_id, taxonomy_id),
     FOREIGN KEY (content_type_id) REFERENCES content_types(id) ON DELETE CASCADE,
     FOREIGN KEY (taxonomy_id) REFERENCES taxonomies(id) ON DELETE CASCADE


### PR DESCRIPTION
## Summary
- store grid metadata for taxonomies
- include taxonomy, title and body fields in layout grid builder
- render title and body through the grid alongside taxonomy selects

## Testing
- `php -l functions.php`
- `php -l custom_fields.php`
- `php -l content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5b00053f48320ab9c9bff16a1819d