### PR TITLE
Fix field layout drag-and-drop not saving

### DIFF
--- a/custom_fields.php
+++ b/custom_fields.php
@@ -90,8 +90,12 @@ if ($isLayout) {
         const grid = GridStack.init({float: true});
         grid.on('change', function(event, items) {
             items.forEach(item => {
+                const fieldId = item.id || (item.el ? item.el.getAttribute('gs-id') : '');
+                if (!fieldId) {
+                    return;
+                }
                 const params = new URLSearchParams();
-                params.append('field_id', item.id);
+                params.append('field_id', fieldId);
                 params.append('type_id', <?= $typeId ?>);
                 params.append('row', item.y);
                 params.append('col', item.x);


### PR DESCRIPTION
## Summary
- ensure grid layout updates send the correct field id to server

## Testing
- `php -l custom_fields.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5b2fe5f708320b9da8261a4fd4fb1