### PR TITLE
Avoid duplicate taxonomy fields

### DIFF
--- a/content.php
+++ b/content.php
@@ -344,7 +344,16 @@ $error = '';
 
 if ($action === 'add') {
     $customFields = sortFieldsByGrid(getCustomFields($typeId));
-    $allTaxonomies = getTaxonomiesForContentType($typeId);
+    $usedTaxonomies = [];
+    foreach ($customFields as $field) {
+        if ($field['type'] === 'taxonomy') {
+            $usedTaxonomies[] = (int)$field['options'];
+        }
+    }
+    $allTaxonomies = array_values(array_filter(
+        getTaxonomiesForContentType($typeId),
+        fn($t) => !in_array((int)$t['id'], $usedTaxonomies)
+    ));
     $taxonomyFields = array_map(function ($tax) {
         return [
             'id' => 'tax_' . $tax['id'],
@@ -535,7 +544,16 @@ if ($action === 'edit') {
     }
 
     $customFields = sortFieldsByGrid(getCustomFields($typeId));
-    $allTaxonomies = getTaxonomiesForContentType($typeId);
+    $usedTaxonomies = [];
+    foreach ($customFields as $field) {
+        if ($field['type'] === 'taxonomy') {
+            $usedTaxonomies[] = (int)$field['options'];
+        }
+    }
+    $allTaxonomies = array_values(array_filter(
+        getTaxonomiesForContentType($typeId),
+        fn($t) => !in_array((int)$t['id'], $usedTaxonomies)
+    ));
     $taxonomyFields = array_map(function ($tax) {
         return [
             'id' => 'tax_' . $tax['id'],


### PR DESCRIPTION
## Summary
- filter out taxonomy fields already added as custom fields from add/edit forms

## Testing
- `php -l content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5d4b2a838832090b78e955b5e6b73