### PR TITLE
Restrict settings to admin roles

### DIFF
--- a/definicoes.php
+++ b/definicoes.php
@@ -5,6 +5,7 @@
 require_once __DIR__ . '/functions.php';
 startSession();
 requireLogin();
+requireRole(2);
 $csrfToken = generateCsrfToken();
 
 $generalSaved = false;

--- a/header.php
+++ b/header.php
@@ -120,10 +120,12 @@ foreach ($sidebarTypes as $sidebarType):
       
         <?php endif; ?>
 
+        <?php if (($user['role'] ?? 3) <= 2): ?>
             <a class="dropdown-item" href="<?= BASE_URL ?>definicoes">
               <span class="badge bg-red float-end">50%</span>
               <i class="fa fa-cog"></i> <span>Definições</span>
-            </a>    
+            </a>
+        <?php endif; ?>
             <a class="dropdown-item" href="<?= BASE_URL ?>terminar-sessao">
               <i class="fa fa-sign-out float-end"></i> Terminar Sessão
             </a>


### PR DESCRIPTION
## Summary
- Hide the "Definições" dropdown item from regular users
- Require admin role to access the settings page

## Testing
- `php -l header.php`
- `php -l definicoes.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5dc4644ac8320b6e9696acce5d5c4