### PR TITLE
Fix taxonomy field display in content list

### DIFF
--- a/data/list_content.php
+++ b/data/list_content.php
@@ -37,6 +37,22 @@ foreach ($contents as $content) {
     }
 
     foreach ($customFields as $field) {
+        // Taxonomy-type custom fields store their selections in the
+        // content_taxonomy table rather than custom_values. Fetch the
+        // term name from the preloaded taxonomy assignments.
+        if ($field['type'] === 'taxonomy') {
+            $termName = '';
+            $taxonomyId = (int)$field['options'];
+            foreach ($content['taxonomies'] as $assoc) {
+                if ($assoc['taxonomy_id'] == $taxonomyId) {
+                    $termName = $assoc['term_name'] !== null ? $assoc['term_name'] : 'Removido';
+                    break;
+                }
+            }
+            $row[] = htmlspecialchars($termName);
+            continue;
+        }
+
         $fieldId = $field['id'];
         $fieldValue = '';
         foreach ($content['fields'] as $cv) {
@@ -46,10 +62,7 @@ foreach ($contents as $content) {
             }
         }
 
-        if ($field['type'] === 'taxonomy' && $fieldValue !== '') {
-            $term = getTerm((int)$fieldValue);
-            $fieldValue = $term ? $term['name'] : 'Removido';
-        } elseif ($field['type'] === 'content' && $fieldValue !== '') {
+        if ($field['type'] === 'content' && $fieldValue !== '') {
             $related = getContent((int)$fieldValue);
             $fieldValue = $related ? $related['title'] : 'Removido';
         }


### PR DESCRIPTION
## Summary
- pull taxonomy custom field values from taxonomy assignments instead of custom_values

## Testing
- `php -l data/list_content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5df7d0a8083208ac3ea06e1df3ef6