### PR TITLE
Prevent sorting on actions column in taxonomies DataTables

### DIFF
--- a/taxonomies.php
+++ b/taxonomies.php
@@ -127,7 +127,7 @@ require_once __DIR__ . '/header.php';
     <?php else: ?>
         <h2 class="mt-3">Termos de <?php echo htmlspecialchars($taxonomy['label']); ?></h2>
         <table class="table table-striped datatable">
-            <thead><tr><th>Nome</th><th>Ações</th></tr></thead>
+            <thead><tr><th>Nome</th><th data-orderable="false">Ações</th></tr></thead>
             <tbody>
             <?php foreach ($terms as $term): ?>
                 <tr>
@@ -179,7 +179,7 @@ require_once __DIR__ . '/header.php';
         <?php endif; ?>
         <h2 class="mt-3">Taxonomias</h2>
         <table class="table table-striped datatable">
-            <thead><tr><th>Rótulo</th><th>Slug</th><th>Ações</th></tr></thead>
+            <thead><tr><th>Rótulo</th><th>Slug</th><th data-orderable="false">Ações</th></tr></thead>
             <tbody>
             <?php foreach ($taxonomies as $tax): ?>
                 <?php


### PR DESCRIPTION
## Summary
- Disable column sorting for the Ações column in taxonomy and term lists by marking header cells as not orderable

## Testing
- `php -l taxonomies.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5f1a8db7483208b0b5d2bcad5d442