### PR TITLE
Fix custom field column order in content lists

### DIFF
--- a/content.php
+++ b/content.php
@@ -7,34 +7,6 @@ requireLogin();
 $csrfToken = generateCsrfToken();
 
 /**
- * Sort custom fields by grid_row and grid_col while preserving the
- * original order for fields without layout information.
- */
-function sortFieldsByGrid(array $fields): array
-{
-    foreach ($fields as $index => &$field) {
-        $field['_index'] = $index;
-    }
-    usort($fields, function ($a, $b) {
-        $rowA = $a['grid_row'] ?? PHP_INT_MAX;
-        $rowB = $b['grid_row'] ?? PHP_INT_MAX;
-        if ($rowA === $rowB) {
-            $colA = $a['grid_col'] ?? PHP_INT_MAX;
-            $colB = $b['grid_col'] ?? PHP_INT_MAX;
-            if ($colA === $colB) {
-                return $a['_index'] <=> $b['_index'];
-            }
-            return $colA <=> $colB;
-        }
-        return $rowA <=> $rowB;
-    });
-    foreach ($fields as &$field) {
-        unset($field['_index']);
-    }
-    return $fields;
-}
-
-/**
  * Render an individual custom field input.
  *
  * @param array $field Field definition.

--- a/data/list_content.php
+++ b/data/list_content.php
@@ -20,9 +20,12 @@ if (!$contentType) {
 }
 $typeSlug = $contentType['name'];
 
-$customFields = array_values(array_filter(getCustomFields($typeId), function ($f) {
-    return !empty($f['show_in_list']);
-}));
+$customFields = array_values(array_filter(
+    sortFieldsByGrid(getCustomFields($typeId)),
+    function ($f) {
+        return !empty($f['show_in_list']);
+    }
+));
 $allTaxonomies = getTaxonomiesForContentType($typeId);
 $contents = getContentList($typeId);
 

--- a/functions.php
+++ b/functions.php
@@ -596,6 +596,36 @@ function getCustomFields(int $content_type_id): array {
 }
 
 /**
+ * Sort custom fields by grid position while preserving original order
+ * for fields without layout information.
+ *
+ * @param array $fields
+ * @return array
+ */
+function sortFieldsByGrid(array $fields): array {
+    foreach ($fields as $index => &$field) {
+        $field['_index'] = $index;
+    }
+    usort($fields, function ($a, $b) {
+        $rowA = $a['grid_row'] ?? PHP_INT_MAX;
+        $rowB = $b['grid_row'] ?? PHP_INT_MAX;
+        if ($rowA === $rowB) {
+            $colA = $a['grid_col'] ?? PHP_INT_MAX;
+            $colB = $b['grid_col'] ?? PHP_INT_MAX;
+            if ($colA === $colB) {
+                return $a['_index'] <=> $b['_index'];
+            }
+            return $colA <=> $colB;
+        }
+        return $rowA <=> $rowB;
+    });
+    foreach ($fields as &$field) {
+        unset($field['_index']);
+    }
+    return $fields;
+}
+
+/**
  * Create a custom field for a content type.
  *
  * @param int $content_type_id


### PR DESCRIPTION
## Summary
- centralize grid-based custom field sorting
- keep custom field columns aligned with headers in content lists

## Testing
- `php -l functions.php && php -l content.php && php -l data/list_content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5f4df18bc8320ad57c46021f428bb