### PR TITLE
Include month in content upload path

### DIFF
--- a/content.php
+++ b/content.php
@@ -377,14 +377,15 @@ if ($action === 'add') {
                 if ($field['type'] === 'image') {
                     if (isset($_FILES[$fieldName]) && $_FILES[$fieldName]['error'] === UPLOAD_ERR_OK) {
                         $year = date('Y');
-                        $uploadDir = __DIR__ . '/uploads/' . $year . '/';
+                        $month = date('m');
+                        $uploadDir = __DIR__ . '/uploads/' . $year . '/' . $month . '/';
                         if (!is_dir($uploadDir)) {
                             mkdir($uploadDir, 0777, true);
                         }
                         $filename = uniqid() . '_' . preg_replace('/[^A-Za-z0-9._-]/', '_', $_FILES[$fieldName]['name']);
                         $targetPath = $uploadDir . $filename;
                         if (move_uploaded_file($_FILES[$fieldName]['tmp_name'], $targetPath)) {
-                            $value = 'uploads/' . $year . '/' . $filename;
+                            $value = 'uploads/' . $year . '/' . $month . '/' . $filename;
                         }
                     }
                 } else {
@@ -587,14 +588,15 @@ if ($action === 'edit') {
                     $existing = $customValues[$field['id']] ?? '';
                     if (isset($_FILES[$fieldName]) && $_FILES[$fieldName]['error'] === UPLOAD_ERR_OK) {
                         $year = date('Y');
-                        $uploadDir = __DIR__ . '/uploads/' . $year . '/';
+                        $month = date('m');
+                        $uploadDir = __DIR__ . '/uploads/' . $year . '/' . $month . '/';
                         if (!is_dir($uploadDir)) {
                             mkdir($uploadDir, 0777, true);
                         }
                         $filename = uniqid() . '_' . preg_replace('/[^A-Za-z0-9._-]/', '_', $_FILES[$fieldName]['name']);
                         $targetPath = $uploadDir . $filename;
                         if (move_uploaded_file($_FILES[$fieldName]['tmp_name'], $targetPath)) {
-                            $value = 'uploads/' . $year . '/' . $filename;
+                            $value = 'uploads/' . $year . '/' . $month . '/' . $filename;
                         }
                     } else {
                         $value = $existing;


### PR DESCRIPTION
## Summary
- include month in upload directory for new and edited content images

## Testing
- `php -l content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b612fe4fd08320bd1245e9c11d763b