### PR TITLE
Store user profile images in common uploads directory

### DIFF
--- a/users.php
+++ b/users.php
@@ -134,7 +134,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if (!in_array($extension, $allowedExt, true) || !array_key_exists($mimeType, $allowedMime)) {
                 $errors[] = 'Formato de imagem inválido.';
             } else {
-                $uploadDir = __DIR__ . '/assets/uploads/';
+                $uploadDir = __DIR__ . '/uploads/';
                 if (!is_dir($uploadDir)) {
                     mkdir($uploadDir, 0755, true);
                 }
@@ -166,7 +166,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
 
                 if ($saved) {
-                    $photoPath = 'assets/uploads/' . $filename;
+                    $photoPath = 'uploads/' . $filename;
                     $userData['photo'] = $photoPath;
                 } else {
                     $errors[] = 'Erro ao guardar a foto.';

--- a/users.php
+++ b/users.php
@@ -134,7 +134,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if (!in_array($extension, $allowedExt, true) || !array_key_exists($mimeType, $allowedMime)) {
                 $errors[] = 'Formato de imagem inválido.';
             } else {
-                $uploadDir = __DIR__ . '/uploads/';
+                $year = date('Y');
+                $month = date('m');
+                $uploadDir = __DIR__ . '/uploads/' . $year . '/' . $month . '/';
                 if (!is_dir($uploadDir)) {
                     mkdir($uploadDir, 0755, true);
                 }
@@ -166,7 +168,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
 
                 if ($saved) {
-                    $photoPath = 'uploads/' . $filename;
+                    $photoPath = 'uploads/' . $year . '/' . $month . '/' . $filename;
                     $userData['photo'] = $photoPath;
                 } else {
                     $errors[] = 'Erro ao guardar a foto.';


### PR DESCRIPTION
## Summary
- save user profile photos alongside other uploads under `/uploads`

## Testing
- `php -l users.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6145bc7dc83209cd04ed3ba1eec39