### PR TITLE
feat: add API activation and token options in settings

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -160,6 +160,27 @@ $(document).ready(function() {
         $BOX_PANEL.remove();
     });
 });
+
+$(document).ready(function() {
+    function toggleApiSettings() {
+        var enabled = $('#api_enabled').is(':checked');
+        $('#api-settings').toggle(enabled);
+    }
+    toggleApiSettings();
+    $('#api_enabled').on('change', toggleApiSettings);
+    $('#generate_token').on('click', function () {
+        if (window.crypto && window.crypto.getRandomValues) {
+            var array = new Uint8Array(20);
+            window.crypto.getRandomValues(array);
+            var token = Array.from(array, function (b) {
+                return ('00' + b.toString(16)).slice(-2);
+            }).join('');
+            $('#api_token').val(token);
+        } else {
+            $('#api_token').val(Math.random().toString(36).substring(2));
+        }
+    });
+});
 // /Panel toolbox
 
 // Tooltip

--- a/definicoes.php
+++ b/definicoes.php
@@ -8,6 +8,8 @@ requireLogin();
 requireRole(2);
 $csrfToken = generateCsrfToken();
 
+$contentTypes = getContentTypes();
+
 $generalSaved = false;
 $emailSaved = false;
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -19,6 +21,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['app_name'])) {
         $appName = trim($_POST['app_name'] ?? '');
         setSetting('app_name', $appName);
+
+        $apiEnabled = isset($_POST['api_enabled']) ? '1' : '0';
+        setSetting('api_enabled', $apiEnabled);
+        $apiToken = trim($_POST['api_token'] ?? '');
+        if ($apiEnabled) {
+            if ($apiToken === '') {
+                $apiToken = bin2hex(random_bytes(20));
+            }
+            setSetting('api_token', $apiToken);
+            foreach ($contentTypes as $type) {
+                $enabled = isset($_POST['api_content'][$type['id']]) ? '1' : '0';
+                setSetting('api_content_' . $type['id'], $enabled);
+            }
+        } else {
+            setSetting('api_token', '');
+            foreach ($contentTypes as $type) {
+                setSetting('api_content_' . $type['id'], '0');
+            }
+        }
+
         $generalSaved = true;
     }
     if (isset($_POST['smtp_host'])) {
@@ -36,6 +58,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 $currentAppName = getSetting('app_name', '');
+$currentApiEnabled = (int)getSetting('api_enabled', '0');
+$currentApiToken = getSetting('api_token', '');
+$contentTypeApi = [];
+foreach ($contentTypes as $type) {
+    $contentTypeApi[$type['id']] = (int)getSetting('api_content_' . $type['id'], '0');
+}
 $currentSmtpHost = getSetting('smtp_host', '');
 $currentSmtpPort = getSetting('smtp_port', '');
 $currentSmtpUser = getSetting('smtp_user', '');
@@ -64,10 +92,40 @@ require_once __DIR__ . '/header.php';
             <form method="post" class="mt-3">
                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken); ?>">
                 <div class="row">
-                <div class="mb-3 col-md-6 col-sm-12">
-                    <label for="app_name" class="form-label">Nome da APP</label>
-                    <input type="text" class="form-control" id="app_name" name="app_name" value="<?= htmlspecialchars($currentAppName); ?>">
+                    <div class="mb-3 col-md-6 col-sm-12">
+                        <label for="app_name" class="form-label">Nome da APP</label>
+                        <input type="text" class="form-control" id="app_name" name="app_name" value="<?= htmlspecialchars($currentAppName); ?>">
+                    </div>
                 </div>
+                <div class="row">
+                    <div class="mb-3 col-md-6 col-sm-12">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="api_enabled" name="api_enabled" value="1" <?= $currentApiEnabled ? 'checked' : ''; ?>>
+                            <label class="form-check-label" for="api_enabled">Ativar API</label>
+                        </div>
+                    </div>
+                </div>
+                <div id="api-settings" style="<?= $currentApiEnabled ? '' : 'display:none;'; ?>">
+                    <div class="row">
+                        <div class="mb-3 col-md-6 col-sm-12">
+                            <label for="api_token" class="form-label">Token</label>
+                            <div class="input-group">
+                                <input type="text" class="form-control" id="api_token" name="api_token" value="<?= htmlspecialchars($currentApiToken); ?>">
+                                <button class="btn btn-outline-secondary" type="button" id="generate_token">Gerar</button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="mb-3 col-md-6 col-sm-12">
+                            <label class="form-label">Endpoints</label>
+                            <?php foreach ($contentTypes as $type): ?>
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="api_content_<?= $type['id']; ?>" name="api_content[<?= $type['id']; ?>]" value="1" <?= !empty($contentTypeApi[$type['id']]) ? 'checked' : ''; ?>>
+                                    <label class="form-check-label" for="api_content_<?= $type['id']; ?>"><?= htmlspecialchars($type['label']); ?></label>
+                                </div>
+                            <?php endforeach; ?>
+                        </div>
+                    </div>
                 </div>
                 <div class="row">
                     <div class="mb-3 col-md-6 col-sm-12">


### PR DESCRIPTION
## Summary
- add API activation checkbox and token field in general settings page
- allow enabling API per content type
- include JavaScript to toggle API settings and generate tokens

## Testing
- `php -l definicoes.php`
- `node --check assets/js/custom.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68b6d6e6d0148320812fcb8e2ef7498b