### PR TITLE
Add taxonomy API endpoint

### DIFF
--- a/api.php
+++ b/api.php
@@ -1,0 +1,42 @@
+<?php
+require_once __DIR__ . '/functions.php';
+
+header('Content-Type: application/json');
+
+if ((int)getSetting('api_enabled', '0') !== 1) {
+    http_response_code(403);
+    echo json_encode(['error' => 'API desativada']);
+    exit;
+}
+
+$providedToken = $_GET['token'] ?? '';
+$apiToken = getSetting('api_token', '');
+if ($apiToken === '' || !hash_equals($apiToken, $providedToken)) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token inválido']);
+    exit;
+}
+
+$slug = $_GET['taxonomy_slug'] ?? '';
+$taxonomy = $slug !== '' ? getTaxonomyBySlug($slug) : null;
+if (!$taxonomy) {
+    http_response_code(404);
+    echo json_encode(['error' => 'Taxonomia não encontrada']);
+    exit;
+}
+
+$terms = getTerms((int)$taxonomy['id']);
+$terms = array_map(function ($t) {
+    return ['id' => (int)$t['id'], 'name' => $t['name']];
+}, $terms);
+
+$response = [
+    'taxonomy' => [
+        'id' => (int)$taxonomy['id'],
+        'slug' => $taxonomy['name'],
+        'label' => $taxonomy['label'],
+        'terms' => $terms,
+    ],
+];
+
+echo json_encode($response, JSON_UNESCAPED_UNICODE);

--- a/functions.php
+++ b/functions.php
@@ -867,6 +867,19 @@ function getTaxonomy(int $id): ?array {
 }
 
 /**
+ * Fetch a single taxonomy by slug.
+ *
+ * @param string $slug
+ * @return array|null
+ */
+function getTaxonomyBySlug(string $slug): ?array {
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('SELECT id, name, label FROM taxonomies WHERE name = ?');
+    $stmt->execute([$slug]);
+    return $stmt->fetch() ?: null;
+}
+
+/**
  * Create a taxonomy.  Returns new id.
  *
  * @param string $name Slug

--- a/router.php
+++ b/router.php
@@ -27,6 +27,10 @@ switch (true) {
     case $path === 'definicoes':
         require __DIR__ . '/definicoes.php';
         break;
+    case preg_match('#^api/([A-Za-z0-9_-]+)$#', $path, $m):
+        $_GET['taxonomy_slug'] = $m[1];
+        require __DIR__ . '/api.php';
+        break;
     case $path === 'users':
         require __DIR__ . '/users.php';
         break;


### PR DESCRIPTION
## Summary
- add helper to fetch taxonomies by slug
- expose `/api/{taxonomy_slug}` endpoint returning taxonomy details and terms
- route API requests through router and validate token

## Testing
- `php -l functions.php`
- `php -l api.php`
- `php -l router.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6ddc77ac083209316c42ff082eec8