### PR TITLE
Return field names as keys in API response

### DIFF
--- a/api.php
+++ b/api.php
@@ -42,8 +42,7 @@ foreach ($taxDefs as $t) {
 foreach ($contents as &$c) {
     $c['fields'] = array_map(function ($f) use ($fieldMap) {
         return [
-            'name' => $fieldMap[$f['field_id']] ?? $f['field_id'],
-            'value' => $f['value'],
+            $fieldMap[$f['field_id']] ?? $f['field_id'] => $f['value'],
         ];
     }, $c['fields']);
     $c['taxonomies'] = array_map(function ($t) use ($taxMap) {


### PR DESCRIPTION
## Summary
- present fields in API responses as single-key objects keyed by field name

## Testing
- `php -l api.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6feab26548320baac5df817d84898