### PR TITLE
Add multi-company session management and DB connection

### DIFF
--- a/data/companies.php
+++ b/data/companies.php
@@ -1,0 +1,18 @@
+<?php
+return [
+    '123456789' => [
+        'db_host' => 'localhost',
+        'db_name' => 'cms_empresa1',
+        'db_user' => 'root',
+        'db_pass' => 'root',
+        'slug'    => 'empresa1',
+    ],
+    '987654321' => [
+        'db_host' => 'localhost',
+        'db_name' => 'cms_empresa2',
+        'db_user' => 'root',
+        'db_pass' => 'root',
+        'slug'    => 'empresa2',
+    ],
+];
+

--- a/data/db.php
+++ b/data/db.php
@@ -1,41 +1,33 @@
 <?php
-// Database configuration. Adjust these constants according to your environment.
-//
-// Create a MySQL database called "cms" and a user with privileges on it.
-// Then update the DB_USER and DB_PASS constants below.  The rest of this
-// application will use these settings to establish a PDO connection.
-
-define('DB_HOST', 'localhost');
-define('DB_NAME', 'cms');
-// Updated database credentials for local development.  In production
-// you should create a dedicated database user with limited privileges.
-define('DB_USER', 'root');
-define('DB_PASS', 'root');
+// Database connection helper using company settings stored in the session.
 
 /**
- * Return a shared PDO connection.
+ * Return a shared PDO connection configured for the selected company.
  *
- * This helper caches the connection in a static variable so that multiple
- * calls in the same request don't open additional connections.  If the
- * connection cannot be established the script will abort with a message.
- *
+ * @throws RuntimeException If no company is selected in the session.
  * @return PDO
  */
 function getPDO() {
     static $pdo;
     if (!$pdo) {
-        $dsn = 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8mb4';
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        if (empty($_SESSION['company'])) {
+            throw new RuntimeException('Empresa não selecionada.');
+        }
+        $cfg = $_SESSION['company'];
+        $dsn = 'mysql:host=' . $cfg['db_host'] . ';dbname=' . $cfg['db_name'] . ';charset=utf8mb4';
         try {
-            $pdo = new PDO($dsn, DB_USER, DB_PASS, [
+            $pdo = new PDO($dsn, $cfg['db_user'], $cfg['db_pass'], [
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
                 PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
             ]);
         } catch (PDOException $e) {
-            // In a real application you might log this error instead of
-            // displaying it.  Aborting here keeps things simple for a demo.
             die('Database connection failed: ' . $e->getMessage());
         }
     }
     return $pdo;
 }
 ?>
+

--- a/functions.php
+++ b/functions.php
@@ -82,6 +82,37 @@ function startSession() {
 }
 
 /**
+ * Store the active company configuration in the session.
+ *
+ * @param array $config
+ * @return void
+ */
+function setCompanyContext(array $config): void {
+    startSession();
+    $_SESSION['company'] = $config;
+}
+
+/**
+ * Retrieve the slug for the currently selected company.
+ *
+ * @return string|null
+ */
+function getCompanySlug(): ?string {
+    startSession();
+    return $_SESSION['company']['slug'] ?? null;
+}
+
+/**
+ * Clear the company configuration from the session.
+ *
+ * @return void
+ */
+function clearCompanyContext(): void {
+    startSession();
+    unset($_SESSION['company']);
+}
+
+/**
  * Generate a CSRF token and store it in the session.
  *
  * @return string


### PR DESCRIPTION
## Summary
- Introduce `data/companies.php` to store database credentials per company
- Replace constant-based DB config with session-driven settings
- Add helper functions to manage company context in the session

## Testing
- `php -l data/db.php`
- `php -l functions.php`
- `php -l data/companies.php`


------
https://chatgpt.com/codex/tasks/task_e_68b70229627083208b7b06d0d8ce8ef4