### PR TITLE
Prefix uploads with company slug

### DIFF
--- a/api.php
+++ b/api.php
@@ -10,13 +10,14 @@ if ((int)getSetting('api_enabled', '0') !== 1) {
 }
 
 $providedToken = $_GET['token'] ?? '';
-$apiToken = getSetting('api_token', '');
+$apiToken = getApiToken();
 if ($apiToken === '' || !hash_equals($apiToken, $providedToken)) {
     http_response_code(403);
     echo json_encode(['error' => 'Token inválido']);
     exit;
 }
 
+$companySlug = getCompanySlug();
 $slug = trim($_GET['content_type'] ?? '');
 $contentType = $slug !== '' ? getContentTypeBySlug($slug) : null;
 if (!$contentType || (int)($contentType['api_enabled'] ?? 0) !== 1) {
@@ -55,6 +56,7 @@ foreach ($contents as &$c) {
 unset($c);
 
 $response = [
+    'company_slug' => $companySlug,
     'content_type' => [
         'id' => (int)$contentType['id'],
         'slug' => $contentType['name'],

--- a/content.php
+++ b/content.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/functions.php';
 startSession();
 requireLogin();
 $csrfToken = generateCsrfToken();
+$slug = getCompanySlug();
 
 /**
  * Render an individual custom field input.
@@ -42,6 +43,10 @@ function renderFieldInput(array $field, string $inputName, $value = null): void
             break;
         case 'image':
             if ($value) {
+                $slug = getCompanySlug();
+                if (strpos($value, 'uploads/' . $slug . '/') !== 0) {
+                    $value = 'uploads/' . $slug . '/' . ltrim($value, '/');
+                }
                 echo '<div class="mb-2"><img src="' . htmlspecialchars($value) . '" style="max-width:100px;" alt=""></div>';
             }
             $req = $field['required'] && !$value ? 'required' : '';
@@ -378,14 +383,14 @@ if ($action === 'add') {
                     if (isset($_FILES[$fieldName]) && $_FILES[$fieldName]['error'] === UPLOAD_ERR_OK) {
                         $year = date('Y');
                         $month = date('m');
-                        $uploadDir = __DIR__ . '/uploads/' . $year . '/' . $month . '/';
+                        $uploadDir = __DIR__ . '/uploads/' . $slug . '/' . $year . '/' . $month . '/';
                         if (!is_dir($uploadDir)) {
-                            mkdir($uploadDir, 0777, true);
+                            mkdir($uploadDir, 0755, true);
                         }
                         $filename = uniqid() . '_' . preg_replace('/[^A-Za-z0-9._-]/', '_', $_FILES[$fieldName]['name']);
                         $targetPath = $uploadDir . $filename;
                         if (move_uploaded_file($_FILES[$fieldName]['tmp_name'], $targetPath)) {
-                            $value = 'uploads/' . $year . '/' . $month . '/' . $filename;
+                            $value = 'uploads/' . $slug . '/' . $year . '/' . $month . '/' . $filename;
                         }
                     }
                 } else {
@@ -589,17 +594,20 @@ if ($action === 'edit') {
                     if (isset($_FILES[$fieldName]) && $_FILES[$fieldName]['error'] === UPLOAD_ERR_OK) {
                         $year = date('Y');
                         $month = date('m');
-                        $uploadDir = __DIR__ . '/uploads/' . $year . '/' . $month . '/';
+                        $uploadDir = __DIR__ . '/uploads/' . $slug . '/' . $year . '/' . $month . '/';
                         if (!is_dir($uploadDir)) {
-                            mkdir($uploadDir, 0777, true);
+                            mkdir($uploadDir, 0755, true);
                         }
                         $filename = uniqid() . '_' . preg_replace('/[^A-Za-z0-9._-]/', '_', $_FILES[$fieldName]['name']);
                         $targetPath = $uploadDir . $filename;
                         if (move_uploaded_file($_FILES[$fieldName]['tmp_name'], $targetPath)) {
-                            $value = 'uploads/' . $year . '/' . $month . '/' . $filename;
+                            $value = 'uploads/' . $slug . '/' . $year . '/' . $month . '/' . $filename;
                         }
                     } else {
                         $value = $existing;
+                        if ($value !== '' && strpos($value, 'uploads/' . $slug . '/') !== 0) {
+                            $value = 'uploads/' . $slug . '/' . ltrim($value, '/');
+                        }
                     }
                 } else {
                     $value = $_POST[$fieldName] ?? null;

--- a/functions.php
+++ b/functions.php
@@ -62,6 +62,23 @@ function setSetting(string $name, string $value): void {
 }
 
 /**
+ * Retrieve the slug identifying the current company.
+ *
+ * This slug is used to isolate uploaded files per company and to expose the
+ * company through the public API.
+ */
+function getCompanySlug(): string {
+    return getSetting('company_slug', 'default');
+}
+
+/**
+ * Fetch the API token used for authenticating external requests.
+ */
+function getApiToken(): string {
+    return getSetting('api_token', '');
+}
+
+/**
  * Start a session if it hasn't been started yet.  This helper uses
  * session cookies with the HttpOnly flag for security.  It does not
  * change existing session behaviour if a session is already active.

--- a/users.php
+++ b/users.php
@@ -7,6 +7,7 @@ $csrfToken = generateCsrfToken();
 $profileMode = isset($_GET['profile']);
 $action = $_GET['action'] ?? 'list';
 $errors = [];
+$slug = getCompanySlug();
 
 if ($profileMode) {
     requireLogin();
@@ -136,7 +137,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             } else {
                 $year = date('Y');
                 $month = date('m');
-                $uploadDir = __DIR__ . '/uploads/' . $year . '/' . $month . '/';
+                $uploadDir = __DIR__ . '/uploads/' . $slug . '/' . $year . '/' . $month . '/';
                 if (!is_dir($uploadDir)) {
                     mkdir($uploadDir, 0755, true);
                 }
@@ -168,7 +169,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
 
                 if ($saved) {
-                    $photoPath = 'uploads/' . $year . '/' . $month . '/' . $filename;
+                    $photoPath = 'uploads/' . $slug . '/' . $year . '/' . $month . '/' . $filename;
                     $userData['photo'] = $photoPath;
                 } else {
                     $errors[] = 'Erro ao guardar a foto.';
@@ -210,8 +211,13 @@ require_once __DIR__ . '/header.php';
         </div>
         <div class="mb-3">
             <label for="photo" class="form-label">Foto</label><br>
-            <?php if (!empty($userData['photo'])): ?>
-                <img src="<?= htmlspecialchars($userData['photo']); ?>" alt="" class="img-thumbnail mb-2" style="max-width: 150px;">
+            <?php if (!empty($userData['photo'])):
+                $photo = $userData['photo'];
+                if (strpos($photo, 'uploads/' . $slug . '/') !== 0) {
+                    $photo = 'uploads/' . $slug . '/' . ltrim($photo, '/');
+                }
+            ?>
+                <img src="<?= htmlspecialchars($photo); ?>" alt="" class="img-thumbnail mb-2" style="max-width: 150px;">
             <?php endif; ?>
             <input type="file" class="form-control" id="photo" name="photo">
         </div>


### PR DESCRIPTION
## Summary
- Prefix user and content uploads with the company slug and ensure directories are created with correct permissions
- Normalize image display paths and expose the company slug via the API
- Add helpers for retrieving the company slug and API token

## Testing
- `php -l functions.php users.php content.php api.php`


------
https://chatgpt.com/codex/tasks/task_e_68b70223a37883208cc0a5bfc20a2c21