### PR TITLE
Clear company context on logout

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -197,6 +197,24 @@ function isStrongPassword(string $password): bool {
         && preg_match('/[a-z]/', $password)
         && preg_match('/\d/', $password);
 }
+/**
+ * Clear company-related context stored in the session.
+ *
+ * Removes the generic 'company' entry and any other session variables
+ * prefixed with 'company_'.
+ *
+ * @return void
+ */
+function clearCompanyContext(): void {
+    startSession();
+    unset($_SESSION['company']);
+    foreach (array_keys($_SESSION) as $key) {
+        if (strpos($key, 'company_') === 0) {
+            unset($_SESSION[$key]);
+        }
+    }
+}
+
 
 /**
  * Log out the current user by destroying the session and clearing
@@ -205,6 +223,7 @@ function isStrongPassword(string $password): bool {
  */
 function logoutUser() {
     startSession();
+    clearCompanyContext();
     $_SESSION = [];
     if (ini_get('session.use_cookies')) {
         $params = session_get_cookie_params();


### PR DESCRIPTION
## Summary
- call `clearCompanyContext()` during `logoutUser`
- add `clearCompanyContext` helper to strip company session data

## Testing
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7022b4cbc8320a2485285a91fb2b8