### PR TITLE
Resolve company slug helper conflict

### DIFF
--- a/api.php
+++ b/api.php
@@ -17,7 +17,7 @@ if ($apiToken === '' || !hash_equals($apiToken, $providedToken)) {
     exit;
 }
 
-$companySlug = getCompanySlug();
+$companySlug = getConfiguredCompanySlug();
 $slug = trim($_GET['content_type'] ?? '');
 $contentType = $slug !== '' ? getContentTypeBySlug($slug) : null;
 if (!$contentType || (int)($contentType['api_enabled'] ?? 0) !== 1) {

--- a/companies.php
+++ b/companies.php
@@ -24,24 +24,3 @@ function getCompanyByNif(string $nif): ?array {
     }
 }
 
-/**
- * Store company information in the session so subsequent requests know the current context.
- *
- * @param array $company
- * @return void
- */
-function setCompanyContext(array $company): void {
-    startSession();
-    $_SESSION['company'] = $company;
-}
-
-/**
- * Remove any company information from the current session.
- *
- * @return void
- */
-function clearCompanyContext(): void {
-    startSession();
-    unset($_SESSION['company']);
-}
-

--- a/functions.php
+++ b/functions.php
@@ -62,12 +62,12 @@ function setSetting(string $name, string $value): void {
 }
 
 /**
- * Retrieve the slug identifying the current company.
+ * Retrieve the slug identifying the configured company.
  *
  * This slug is used to isolate uploaded files per company and to expose the
  * company through the public API.
  */
-function getCompanySlug(): string {
+function getConfiguredCompanySlug(): string {
     return getSetting('company_slug', 'default');
 }
 
@@ -117,16 +117,6 @@ function setCompanyContext(array $config): void {
 function getCompanySlug(): ?string {
     startSession();
     return $_SESSION['company']['slug'] ?? null;
-}
-
-/**
- * Clear the company configuration from the session.
- *
- * @return void
- */
-function clearCompanyContext(): void {
-    startSession();
-    unset($_SESSION['company']);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Rename configured company slug helper to `getConfiguredCompanySlug`
- Remove duplicate company context helpers and use enhanced `clearCompanyContext`
- Update API to call the new slug helper

## Testing
- `php -l functions.php`
- `php -l api.php`
- `php -l companies.php`
- `php -l users.php`
- `php -l content.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7049bfce4832097cce6730ada6b29