### PR TITLE
Load company configuration from file

### DIFF
--- a/companies.php
+++ b/companies.php
@@ -1,26 +1,18 @@
 <?php
 // Simple company context management for the CMS.
 
-require_once __DIR__ . '/functions.php';
-
 /**
- * Retrieve a company by its NIF.
+ * Retrieve a company configuration by its NIF.
  *
- * This implementation assumes a table `companies` with at least `id` and `nif` columns.
- * Adjust as necessary for your data source.
+ * Company settings are stored in data/companies.php as an associative
+ * array keyed by NIF. This helper returns the matching configuration
+ * or null when the NIF is unknown.
  *
  * @param string $nif
  * @return array|null
  */
 function getCompanyByNif(string $nif): ?array {
-    $pdo = getPDO();
-    try {
-        $stmt = $pdo->prepare('SELECT * FROM companies WHERE nif = ? LIMIT 1');
-        $stmt->execute([$nif]);
-        $company = $stmt->fetch();
-        return $company ?: null;
-    } catch (Exception $e) {
-        return null;
-    }
+    $companies = require __DIR__ . '/data/companies.php';
+    return $companies[$nif] ?? null;
 }
 


### PR DESCRIPTION
## Summary
- Resolve login fatal error by removing database dependence during company lookup
- Load company configuration by NIF from `data/companies.php`

## Testing
- `php -l companies.php`


------
https://chatgpt.com/codex/tasks/task_e_68b707ff218483209c5fc19c1ff8efc2