### PR TITLE
Add multiselect content and taxonomy custom fields

### DIFF
--- a/content.php
+++ b/content.php
@@ -74,6 +74,17 @@ function renderFieldInput(array $field, string $inputName, $value = null): void
             }
             echo '</select>';
             break;
+        case 'multitaxonomy':
+            $terms = getTerms((int)$options);
+            $selected = is_array($value) ? $value : [];
+            echo '<select name="' . htmlspecialchars($inputName) . '[]" class="form-select" multiple ' . $isRequired . '>';
+            foreach ($terms as $term) {
+                $sel = in_array($term['id'], $selected) ? ' selected' : '';
+                echo '<option value="' . htmlspecialchars($term['id']) . '"' . $sel . '>' .
+                     htmlspecialchars($term['name']) . '</option>';
+            }
+            echo '</select>';
+            break;
         case 'content':
             $entries = getContentList((int)$options);
             echo '<select name="' . htmlspecialchars($inputName) . '" class="form-select" ' . $isRequired . '>';
@@ -81,6 +92,17 @@ function renderFieldInput(array $field, string $inputName, $value = null): void
             foreach ($entries as $entry) {
                 $selected = ($value !== null && $value == $entry['id']) ? ' selected' : '';
                 echo '<option value="' . htmlspecialchars($entry['id']) . '"' . $selected . '>' .
+                     htmlspecialchars($entry['title']) . '</option>';
+            }
+            echo '</select>';
+            break;
+        case 'multicontent':
+            $entries = getContentList((int)$options);
+            $selected = is_array($value) ? $value : [];
+            echo '<select name="' . htmlspecialchars($inputName) . '[]" class="form-select" multiple ' . $isRequired . '>';
+            foreach ($entries as $entry) {
+                $sel = in_array($entry['id'], $selected) ? ' selected' : '';
+                echo '<option value="' . htmlspecialchars($entry['id']) . '"' . $sel . '>' .
                      htmlspecialchars($entry['title']) . '</option>';
             }
             echo '</select>';
@@ -122,7 +144,7 @@ if (isset($_GET['manage_types'])) {
         $fields = sortFieldsByGrid(getCustomFields($typeTax));
         $usedTaxonomies = [];
         foreach ($fields as $field) {
-            if ($field['type'] === 'taxonomy') {
+            if ($field['type'] === 'taxonomy' || $field['type'] === 'multitaxonomy') {
                 $usedTaxonomies[] = (int)$field['options'];
             }
         }
@@ -323,7 +345,7 @@ if ($action === 'add') {
     $customFields = sortFieldsByGrid(getCustomFields($typeId));
     $usedTaxonomies = [];
     foreach ($customFields as $field) {
-        if ($field['type'] === 'taxonomy') {
+        if ($field['type'] === 'taxonomy' || $field['type'] === 'multitaxonomy') {
             $usedTaxonomies[] = (int)$field['options'];
         }
     }
@@ -373,9 +395,13 @@ if ($action === 'add') {
             foreach ($customFields as $field) {
                 $fieldName = 'field_' . $field['id'];
                 $value = null;
-                if ($field['type'] === 'taxonomy') {
-                    $value = $_POST[$fieldName] ?? '';
-                    $termIds = $value !== '' ? [(int)$value] : [];
+                if ($field['type'] === 'taxonomy' || $field['type'] === 'multitaxonomy') {
+                    if ($field['type'] === 'taxonomy') {
+                        $single = $_POST[$fieldName] ?? '';
+                        $termIds = $single !== '' ? [(int)$single] : [];
+                    } else {
+                        $termIds = isset($_POST[$fieldName]) ? array_map('intval', (array)$_POST[$fieldName]) : [];
+                    }
                     setContentTaxonomyTerms($contentId, (int)$field['options'], $termIds);
                     continue;
                 }
@@ -397,6 +423,12 @@ if ($action === 'add') {
                     $value = $_POST[$fieldName] ?? null;
                     if ($value !== null && $field['type'] === 'datetime' && $value !== '') {
                         $value = str_replace('T', ' ', substr($value, 0, 16));
+                    }
+                    if ($field['type'] === 'multicontent') {
+                        foreach ((array)$value as $val) {
+                            saveCustomValue($contentId, $field['id'], (string)$val);
+                        }
+                        continue;
                     }
                 }
                 if ($value !== null) {
@@ -530,7 +562,7 @@ if ($action === 'edit') {
     $customFields = sortFieldsByGrid(getCustomFields($typeId));
     $usedTaxonomies = [];
     foreach ($customFields as $field) {
-        if ($field['type'] === 'taxonomy') {
+        if ($field['type'] === 'taxonomy' || $field['type'] === 'multitaxonomy') {
             $usedTaxonomies[] = (int)$field['options'];
         }
     }
@@ -583,14 +615,18 @@ if ($action === 'edit') {
             foreach ($customFields as $field) {
                 $fieldName = 'field_' . $field['id'];
                 $value = null;
-                if ($field['type'] === 'taxonomy') {
-                    $value = $_POST[$fieldName] ?? '';
-                    $termIds = $value !== '' ? [(int)$value] : [];
+                if ($field['type'] === 'taxonomy' || $field['type'] === 'multitaxonomy') {
+                    if ($field['type'] === 'taxonomy') {
+                        $single = $_POST[$fieldName] ?? '';
+                        $termIds = $single !== '' ? [(int)$single] : [];
+                    } else {
+                        $termIds = isset($_POST[$fieldName]) ? array_map('intval', (array)$_POST[$fieldName]) : [];
+                    }
                     setContentTaxonomyTerms($contentId, (int)$field['options'], $termIds);
                     continue;
                 }
                 if ($field['type'] === 'image') {
-                    $existing = $customValues[$field['id']] ?? '';
+                    $existing = $customValues[$field['id']][0] ?? '';
                     if (isset($_FILES[$fieldName]) && $_FILES[$fieldName]['error'] === UPLOAD_ERR_OK) {
                         $year = date('Y');
                         $month = date('m');
@@ -613,6 +649,12 @@ if ($action === 'edit') {
                     $value = $_POST[$fieldName] ?? null;
                     if ($value !== null && $field['type'] === 'datetime' && $value !== '') {
                         $value = str_replace('T', ' ', substr($value, 0, 16));
+                    }
+                    if ($field['type'] === 'multicontent') {
+                        foreach ((array)$value as $val) {
+                            saveCustomValue($contentId, $field['id'], (string)$val);
+                        }
+                        continue;
                     }
                 }
                 if ($value !== null) {
@@ -695,8 +737,12 @@ if ($action === 'edit') {
                                             if ($field['type'] === 'taxonomy') {
                                                 $taxonomyId = (int)$field['options'];
                                                 $value = $taxonomyMap[$taxonomyId][0] ?? '';
+                                            } elseif ($field['type'] === 'multitaxonomy') {
+                                                $taxonomyId = (int)$field['options'];
+                                                $value = $taxonomyMap[$taxonomyId] ?? [];
                                             } else {
-                                                $value = $customValues[$field['id']] ?? '';
+                                                $raw = $customValues[$field['id']] ?? [];
+                                                $value = $field['type'] === 'multicontent' ? $raw : ($raw[0] ?? '');
                                             }
                                             renderFieldInput($field, $inputName, $value);
                                         }
@@ -728,8 +774,12 @@ if ($action === 'edit') {
                                             if ($field['type'] === 'taxonomy') {
                                                 $taxonomyId = (int)$field['options'];
                                                 $value = $taxonomyMap[$taxonomyId][0] ?? '';
+                                            } elseif ($field['type'] === 'multitaxonomy') {
+                                                $taxonomyId = (int)$field['options'];
+                                                $value = $taxonomyMap[$taxonomyId] ?? [];
                                             } else {
-                                                $value = $customValues[$field['id']] ?? '';
+                                                $raw = $customValues[$field['id']] ?? [];
+                                                $value = $field['type'] === 'multicontent' ? $raw : ($raw[0] ?? '');
                                             }
                                             renderFieldInput($field, $inputName, $value);
                                         }

--- a/custom_fields.php
+++ b/custom_fields.php
@@ -47,7 +47,7 @@ if ($isLayout) {
             return (int) $f['options'];
         },
         array_filter($fields, function ($f) {
-            return $f['type'] === 'taxonomy' && !empty($f['options']);
+            return ($f['type'] === 'taxonomy' || $f['type'] === 'multitaxonomy') && !empty($f['options']);
         })
     );
 
@@ -159,9 +159,9 @@ if (($_SERVER['REQUEST_METHOD'] === 'POST') && ($act === 'ad' || $editField)) {
     $options   = '';
     if ($fieldType === 'select') {
         $options = isset($_POST['options_text']) ? trim($_POST['options_text']) : '';
-    } elseif ($fieldType === 'taxonomy') {
+    } elseif ($fieldType === 'taxonomy' || $fieldType === 'multitaxonomy') {
         $options = isset($_POST['options_taxonomy']) ? trim($_POST['options_taxonomy']) : '';
-    } elseif ($fieldType === 'content') {
+    } elseif ($fieldType === 'content' || $fieldType === 'multicontent') {
         $options = isset($_POST['options_content']) ? trim($_POST['options_content']) : '';
     }
     $required   = isset($_POST['required']);
@@ -222,7 +222,9 @@ require_once __DIR__ . '/header.php';
                     <option value="image" <?php echo isset($editField['type']) && $editField['type'] === 'image' ? 'selected' : ''; ?>>Imagem</option>
                     <option value="select" <?php echo isset($editField['type']) && $editField['type'] === 'select' ? 'selected' : ''; ?>>Select (opções separadas por vírgula)</option>
                     <option value="taxonomy" <?php echo isset($editField['type']) && $editField['type'] === 'taxonomy' ? 'selected' : ''; ?>>Select Taxonomia</option>
+                    <option value="multitaxonomy" <?php echo isset($editField['type']) && $editField['type'] === 'multitaxonomy' ? 'selected' : ''; ?>>Multi-select Taxonomia</option>
                     <option value="content" <?php echo isset($editField['type']) && $editField['type'] === 'content' ? 'selected' : ''; ?>>Select Conteúdo</option>
+                    <option value="multicontent" <?php echo isset($editField['type']) && $editField['type'] === 'multicontent' ? 'selected' : ''; ?>>Multi-select Conteúdo</option>
                 </select>
             </div>
             <div class="mb-3" id="options_text_wrapper">
@@ -234,7 +236,7 @@ require_once __DIR__ . '/header.php';
                 <select class="form-select" id="options_taxonomy" name="options_taxonomy">
                     <option value="">-- Selecione --</option>
                     <?php foreach ($taxonomies as $tax): ?>
-                        <option value="<?php echo $tax['id']; ?>" <?php echo isset($editField) && $editField['type'] === 'taxonomy' && $editField['options'] == $tax['id'] ? 'selected' : ''; ?>><?php echo htmlspecialchars($tax['label']); ?></option>
+                        <option value="<?php echo $tax['id']; ?>" <?php echo isset($editField) && ($editField['type'] === 'taxonomy' || $editField['type'] === 'multitaxonomy') && $editField['options'] == $tax['id'] ? 'selected' : ''; ?>><?php echo htmlspecialchars($tax['label']); ?></option>
                     <?php endforeach; ?>
                 </select>
             </div>
@@ -243,7 +245,7 @@ require_once __DIR__ . '/header.php';
                 <select class="form-select" id="options_content" name="options_content">
                     <option value="">-- Selecione --</option>
                     <?php foreach ($contentTypesAll as $ct): ?>
-                        <option value="<?php echo $ct['id']; ?>" <?php echo isset($editField) && $editField['type'] === 'content' && $editField['options'] == $ct['id'] ? 'selected' : ''; ?>><?php echo htmlspecialchars($ct['label']); ?></option>
+                        <option value="<?php echo $ct['id']; ?>" <?php echo isset($editField) && ($editField['type'] === 'content' || $editField['type'] === 'multicontent') && $editField['options'] == $ct['id'] ? 'selected' : ''; ?>><?php echo htmlspecialchars($ct['label']); ?></option>
                     <?php endforeach; ?>
                 </select>
             </div>
@@ -278,7 +280,7 @@ require_once __DIR__ . '/header.php';
                 <td><?php echo htmlspecialchars($field['label']); ?></td>
                 <td><?php echo htmlspecialchars($field['type']); ?></td>
                 <td>
-                    <?php if ($field['type'] === 'taxonomy'): ?>
+                    <?php if ($field['type'] === 'taxonomy' || $field['type'] === 'multitaxonomy'): ?>
                         <?php
                             $opt = '';
                             foreach ($taxonomies as $tax) {
@@ -286,7 +288,7 @@ require_once __DIR__ . '/header.php';
                             }
                             echo htmlspecialchars($opt);
                         ?>
-                    <?php elseif ($field['type'] === 'content'): ?>
+                    <?php elseif ($field['type'] === 'content' || $field['type'] === 'multicontent'): ?>
                         <?php
                             $opt = '';
                             foreach ($contentTypesAll as $ct) {
@@ -324,8 +326,8 @@ document.addEventListener('DOMContentLoaded', function () {
     const contentWrap = document.getElementById('options_content_wrapper');
     function updateOpts() {
         textWrap.style.display = typeSel.value === 'select' ? 'block' : 'none';
-        taxWrap.style.display = typeSel.value === 'taxonomy' ? 'block' : 'none';
-        contentWrap.style.display = typeSel.value === 'content' ? 'block' : 'none';
+        taxWrap.style.display = (typeSel.value === 'taxonomy' || typeSel.value === 'multitaxonomy') ? 'block' : 'none';
+        contentWrap.style.display = (typeSel.value === 'content' || typeSel.value === 'multicontent') ? 'block' : 'none';
     }
     typeSel.addEventListener('change', updateOpts);
     updateOpts();

--- a/data/list_content.php
+++ b/data/list_content.php
@@ -55,19 +55,38 @@ foreach ($contents as $content) {
             $row[] = htmlspecialchars($termName);
             continue;
         }
+        if ($field['type'] === 'multitaxonomy') {
+            $taxonomyId = (int)$field['options'];
+            $termsList = [];
+            foreach ($content['taxonomies'] as $assoc) {
+                if ($assoc['taxonomy_id'] == $taxonomyId) {
+                    $termsList[] = $assoc['term_name'] !== null ? $assoc['term_name'] : 'Removido';
+                }
+            }
+            $row[] = htmlspecialchars(implode(', ', $termsList));
+            continue;
+        }
 
         $fieldId = $field['id'];
-        $fieldValue = '';
+        $values = [];
         foreach ($content['fields'] as $cv) {
             if ($cv['field_id'] == $fieldId) {
-                $fieldValue = $cv['value'];
-                break;
+                $values[] = $cv['value'];
             }
         }
+        $fieldValue = $values[0] ?? '';
 
         if ($field['type'] === 'content' && $fieldValue !== '') {
             $related = getContent((int)$fieldValue);
             $fieldValue = $related ? $related['title'] : 'Removido';
+        }
+        if ($field['type'] === 'multicontent' && !empty($values)) {
+            $titles = [];
+            foreach ($values as $val) {
+                $related = getContent((int)$val);
+                $titles[] = $related ? $related['title'] : 'Removido';
+            }
+            $fieldValue = implode(', ', $titles);
         }
 
         if ($field['type'] === 'image' && $fieldValue !== '') {

--- a/functions.php
+++ b/functions.php
@@ -1260,7 +1260,11 @@ function getCustomValuesForContent(int $content_id): array {
     $stmt->execute([$content_id]);
     $values = [];
     foreach ($stmt->fetchAll() as $row) {
-        $values[(int)$row['field_id']] = $row['value'];
+        $fid = (int)$row['field_id'];
+        if (!isset($values[$fid])) {
+            $values[$fid] = [];
+        }
+        $values[$fid][] = $row['value'];
     }
     return $values;
 }

--- a/schema.sql
+++ b/schema.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS custom_fields (
     content_type_id INT NOT NULL,
     name VARCHAR(100) NOT NULL,
     label VARCHAR(100) NOT NULL,
-    type ENUM('text','textarea','number','date','datetime','select','taxonomy','content','image') NOT NULL,
+    type ENUM('text','textarea','number','date','datetime','select','taxonomy','content','image','multitaxonomy','multicontent') NOT NULL,
     options TEXT,
     required TINYINT(1) NOT NULL DEFAULT 0,
     show_in_list TINYINT(1) NOT NULL DEFAULT 0,


### PR DESCRIPTION
## Summary
- add `multitaxonomy` and `multicontent` field types
- support multi-select rendering, saving and listing of these fields
- extend schema enum for new field types

## Testing
- `php -l content.php custom_fields.php functions.php data/list_content.php`

------
https://chatgpt.com/codex/tasks/task_e_68b70fec5a98832092cffe86fa921315