### PR TITLE
Load filter options from custom fields

### DIFF
--- a/custom_fields.php
+++ b/custom_fields.php
@@ -135,14 +135,14 @@ $taxonomies      = getTaxonomies();
 $contentTypesAll = getContentTypes();
 
 $selectedContentType = 0;
-$selectedFilterField = 0;
+$selectedFilterField = '';
 $selectedFilterValue = '';
 if ($editField && ($editField['type'] === 'content' || $editField['type'] === 'multicontent')) {
     $optData = json_decode($editField['options'], true);
     if (is_array($optData)) {
         $selectedContentType = (int)($optData['type_id'] ?? 0);
         if (!empty($optData['filter'])) {
-            $selectedFilterField = (int)($optData['filter']['field_id'] ?? 0);
+            $selectedFilterField = $optData['filter']['field_id'] ?? '';
             $selectedFilterValue = $optData['filter']['value'] ?? '';
         }
     } else {
@@ -445,11 +445,9 @@ document.addEventListener('DOMContentLoaded', function () {
         filterValueSel.innerHTML = '<option value="">-- Selecione --</option>';
         field.options.forEach(v => {
             const opt = document.createElement('option');
-
-
-            opt.value = v;
-            opt.textContent = v;
-            if (String(preFilterValue) === String(v)) {
+            opt.value = v.value;
+            opt.textContent = v.label;
+            if (String(preFilterValue) === String(v.value)) {
                 opt.selected = true;
             }
             filterValueSel.appendChild(opt);

--- a/data/select_fields.php
+++ b/data/select_fields.php
@@ -28,22 +28,20 @@ foreach ($fields as $field) {
             'label' => $field['label'],
             'options' => $options,
         ];
-    }
-}
-
-$taxonomies = getTaxonomiesForContentType($typeId);
-foreach ($taxonomies as $tax) {
-    $terms = getTerms((int)$tax['id']);
-    if ($terms) {
-        $options = [];
-        foreach ($terms as $term) {
-            $options[] = ['value' => (string)$term['id'], 'label' => $term['name']];
+    } elseif ($field['type'] === 'taxonomy' || $field['type'] === 'multitaxonomy') {
+        $taxId = (int)$field['options'];
+        $terms = getTerms($taxId);
+        if ($terms) {
+            $options = [];
+            foreach ($terms as $term) {
+                $options[] = ['value' => (string)$term['id'], 'label' => $term['name']];
+            }
+            $result[] = [
+                'id' => 'tax_' . $taxId,
+                'label' => $field['label'],
+                'options' => $options,
+            ];
         }
-        $result[] = [
-            'id' => 'tax_' . $tax['id'],
-            'label' => $tax['label'],
-            'options' => $options,
-        ];
     }
 }
 


### PR DESCRIPTION
## Summary
- fetch filter values from custom select or taxonomy fields instead of direct taxonomies
- populate filter value dropdown using value/label pairs
- preserve saved filter selection when editing content fields

## Testing
- `php -l custom_fields.php`
- `php -l data/select_fields.php`


------
https://chatgpt.com/codex/tasks/task_e_68b72674bc888320860ad618b5680372