### PR TITLE
Add dynamic filtering for content selection fields

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -386,3 +386,56 @@ $(document).ready(function() {
         }
     });
 });
+
+$(document).ready(function() {
+    document.querySelectorAll('select.content-select').forEach(function(sel) {
+        var targetType = sel.dataset.targetType;
+        var filterField = sel.dataset.filterField || '';
+        var selected = sel.dataset.selected ? sel.dataset.selected.split(',').filter(Boolean) : [];
+
+        function loadOptions(filterValue) {
+            var params = new URLSearchParams();
+            params.append('type_id', targetType);
+            if (filterField && filterValue !== undefined && filterValue !== '') {
+                params.append('filter_field', filterField);
+                params.append('filter_value', filterValue);
+            }
+            fetch('data/content_options.php?' + params.toString())
+                .then(function(resp) { return resp.json(); })
+                .then(function(data) {
+                    sel.innerHTML = sel.multiple ? '' : '<option value="">-- Select --</option>';
+                    data.entries.forEach(function(entry) {
+                        var opt = document.createElement('option');
+                        opt.value = entry.id;
+                        opt.textContent = entry.title;
+                        if (selected.includes(String(entry.id))) {
+                            opt.selected = true;
+                        }
+                        sel.appendChild(opt);
+                    });
+                });
+        }
+
+        function getFilterInput() {
+            if (!filterField) return null;
+            if (filterField.startsWith('tax_')) {
+                var id = filterField.substring(4);
+                return document.querySelector('[name="taxonomy_' + id + '"],[name="taxonomy_' + id + '[]"]');
+            }
+            return document.querySelector('[name="field_' + filterField + '"],[name="field_' + filterField + '[]"]');
+        }
+
+        var filterInput = getFilterInput();
+        if (filterInput) {
+            var update = function() { loadOptions(filterInput.value); };
+            filterInput.addEventListener('change', update);
+            if (filterInput.value !== '') {
+                update();
+            } else {
+                loadOptions('');
+            }
+        } else {
+            loadOptions('');
+        }
+    });
+});

--- a/content.php
+++ b/content.php
@@ -88,18 +88,28 @@ function renderFieldInput(array $field, string $inputName, $value = null): void
         case 'content':
             $opts = json_decode($options, true);
             if (is_array($opts)) {
-                $targetType = (int)($opts['type_id'] ?? 0);
-                $filters = [];
-
-                if (!empty($opts['filter']['field_id']) && isset($opts['filter']['value'])) {
-                    $filters[$opts['filter']['field_id']] = $opts['filter']['value'];
+                $targetType  = (int)($opts['type_id'] ?? 0);
+                $filterField = $opts['filter']['field_id'] ?? '';
+                $filterValue = $opts['filter']['value'] ?? '';
+                $filters     = [];
+                if ($filterField !== '' && $filterValue !== '') {
+                    $filters[$filterField] = $filterValue;
                 }
             } else {
-                $targetType = (int)$options;
-                $filters = [];
+                $targetType  = (int)$options;
+                $filterField = '';
+                $filters     = [];
             }
-            $entries = getContentList($targetType, $filters);
-            echo '<select name="' . htmlspecialchars($inputName) . '" class="form-select" ' . $isRequired . '>';
+            $entries    = getContentList($targetType, $filters);
+            $selectedId = $value !== null ? (string)$value : '';
+            $dataAttr   = ' data-target-type="' . htmlspecialchars($targetType) . '"';
+            if ($filterField !== '') {
+                $dataAttr .= ' data-filter-field="' . htmlspecialchars($filterField) . '"';
+            }
+            if ($selectedId !== '') {
+                $dataAttr .= ' data-selected="' . htmlspecialchars($selectedId) . '"';
+            }
+            echo '<select name="' . htmlspecialchars($inputName) . '" class="form-select content-select" ' . $isRequired . $dataAttr . '>';
             echo '<option value="">-- Select --</option>';
             foreach ($entries as $entry) {
                 $selected = ($value !== null && $value == $entry['id']) ? ' selected' : '';
@@ -109,23 +119,30 @@ function renderFieldInput(array $field, string $inputName, $value = null): void
             echo '</select>';
             break;
         case 'multicontent':
-
             $opts = json_decode($options, true);
             if (is_array($opts)) {
-                $targetType = (int)($opts['type_id'] ?? 0);
-                $filters = [];
-
-                if (!empty($opts['filter']['field_id']) && isset($opts['filter']['value'])) {
-                    $filters[$opts['filter']['field_id']] = $opts['filter']['value'];
+                $targetType  = (int)($opts['type_id'] ?? 0);
+                $filterField = $opts['filter']['field_id'] ?? '';
+                $filterValue = $opts['filter']['value'] ?? '';
+                $filters     = [];
+                if ($filterField !== '' && $filterValue !== '') {
+                    $filters[$filterField] = $filterValue;
                 }
             } else {
-                $targetType = (int)$options;
-                $filters = [];
+                $targetType  = (int)$options;
+                $filterField = '';
+                $filters     = [];
             }
-            $entries = getContentList($targetType, $filters);
-
+            $entries  = getContentList($targetType, $filters);
             $selected = is_array($value) ? $value : [];
-            echo '<select name="' . htmlspecialchars($inputName) . '[]" class="form-select" multiple ' . $isRequired . '>';
+            $dataAttr = ' data-target-type="' . htmlspecialchars($targetType) . '"';
+            if ($filterField !== '') {
+                $dataAttr .= ' data-filter-field="' . htmlspecialchars($filterField) . '"';
+            }
+            if ($selected) {
+                $dataAttr .= ' data-selected="' . htmlspecialchars(implode(',', $selected)) . '"';
+            }
+            echo '<select name="' . htmlspecialchars($inputName) . '[]" class="form-select content-select" multiple ' . $isRequired . $dataAttr . '>';
             foreach ($entries as $entry) {
                 $sel = in_array($entry['id'], $selected) ? ' selected' : '';
                 echo '<option value="' . htmlspecialchars($entry['id']) . '"' . $sel . '>' .

--- a/data/content_options.php
+++ b/data/content_options.php
@@ -1,0 +1,32 @@
+<?php
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/../functions.php';
+
+startSession();
+requireLogin();
+
+header('Content-Type: application/json');
+
+$typeId = isset($_GET['type_id']) ? (int)$_GET['type_id'] : 0;
+$filterField = $_GET['filter_field'] ?? '';
+$filterValue = $_GET['filter_value'] ?? '';
+
+if (!$typeId) {
+    echo json_encode(['entries' => []]);
+    exit;
+}
+
+$filters = [];
+if ($filterField !== '' && $filterValue !== '') {
+    $filters[$filterField] = $filterValue;
+}
+
+$entries = getContentList($typeId, $filters);
+$result = array_map(function ($entry) {
+    return [
+        'id' => $entry['id'],
+        'title' => $entry['title']
+    ];
+}, $entries);
+
+echo json_encode(['entries' => $result]);


### PR DESCRIPTION
## Summary
- add endpoint to load content options with optional filter
- mark content and multicontent fields with metadata for dynamic loading
- fetch filtered content options on the client when related filter fields change

## Testing
- `php -l data/content_options.php`
- `php -l content.php`
- `node --check assets/js/custom.js`


------
https://chatgpt.com/codex/tasks/task_e_68b76ae3d4c0832081bf46d21fb08bc0