### PR TITLE
Preserve custom field layout on update

### DIFF
--- a/custom_fields.php
+++ b/custom_fields.php
@@ -81,6 +81,7 @@ if ($isLayout) {
             'grid_width' => $type['body_grid_width'] ?? 12,
         ],
     ], $fields, $taxonomyFields);
+    $fields = sortFieldsByGrid($fields);
 
     require_once __DIR__ . '/header.php';
     ?>
@@ -200,7 +201,19 @@ if (($_SERVER['REQUEST_METHOD'] === 'POST') && ($act === 'ad' || $editField)) {
             $existing = getCustomField($fieldId);
 
             if ($existing && (int)$existing['content_type_id'] === $typeId) {
-                updateCustomField($fieldId, $name, $label, $fieldType, $options, $required, $showInList, $sortable);
+                updateCustomField(
+                    $fieldId,
+                    $name,
+                    $label,
+                    $fieldType,
+                    $options,
+                    $required,
+                    $showInList,
+                    $sortable,
+                    (int) $existing['grid_row'],
+                    (int) $existing['grid_col'],
+                    (int) $existing['grid_width']
+                );
             }
         } else {
             createCustomField($typeId, $name, $label, $fieldType, $options, $required, $showInList, $sortable);


### PR DESCRIPTION
## Summary
- ensure editing a custom field keeps its grid layout by passing existing layout data to `updateCustomField`
- append new fields to the end of layout by sorting items by grid coordinates

## Testing
- `php -l custom_fields.php`


------
https://chatgpt.com/codex/tasks/task_e_68b76dd27fa08320944bb4860bed6269