### PR TITLE
Respect static content field filters

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -391,19 +391,26 @@ $(document).ready(function() {
     document.querySelectorAll('select.content-select').forEach(function(sel) {
         var targetType = sel.dataset.targetType;
         var filterField = sel.dataset.filterField || '';
+        var staticFilterValue = sel.dataset.filterValue || '';
         var selected = sel.dataset.selected ? sel.dataset.selected.split(',').filter(Boolean) : [];
 
         function loadOptions(filterValue) {
-            if (filterField && (filterValue === undefined || filterValue === '')) {
-                sel.innerHTML = sel.multiple ? '' : '<option value="">-- Select --</option>';
-                return;
+            var fv = filterValue;
+            if (filterField) {
+                if (fv === undefined || fv === '') {
+                    fv = staticFilterValue;
+                    if (fv === '') {
+                        sel.innerHTML = sel.multiple ? '' : '<option value="">-- Select --</option>';
+                        return;
+                    }
+                }
             }
 
             var params = new URLSearchParams();
             params.append('type_id', targetType);
             if (filterField) {
                 params.append('filter_field', filterField);
-                params.append('filter_value', filterValue);
+                params.append('filter_value', fv);
             }
 
             fetch('data/content_options.php?' + params.toString())
@@ -438,10 +445,10 @@ $(document).ready(function() {
             if (filterInput.value !== '') {
                 update();
             } else {
-                loadOptions('');
+                loadOptions(staticFilterValue);
             }
         } else {
-            loadOptions('');
+            loadOptions(staticFilterValue);
         }
     });
 });

--- a/content.php
+++ b/content.php
@@ -87,6 +87,7 @@ function renderFieldInput(array $field, string $inputName, $value = null): void
             break;
         case 'content':
             $opts = json_decode($options, true);
+            $filterValue = '';
             if (is_array($opts)) {
                 $targetType  = (int)($opts['type_id'] ?? 0);
                 $filterField = $opts['filter']['field_id'] ?? '';
@@ -106,6 +107,9 @@ function renderFieldInput(array $field, string $inputName, $value = null): void
             if ($filterField !== '') {
                 $dataAttr .= ' data-filter-field="' . htmlspecialchars($filterField) . '"';
             }
+            if ($filterValue !== '') {
+                $dataAttr .= ' data-filter-value="' . htmlspecialchars($filterValue) . '"';
+            }
             if ($selectedId !== '') {
                 $dataAttr .= ' data-selected="' . htmlspecialchars($selectedId) . '"';
             }
@@ -120,6 +124,7 @@ function renderFieldInput(array $field, string $inputName, $value = null): void
             break;
         case 'multicontent':
             $opts = json_decode($options, true);
+            $filterValue = '';
             if (is_array($opts)) {
                 $targetType  = (int)($opts['type_id'] ?? 0);
                 $filterField = $opts['filter']['field_id'] ?? '';
@@ -138,6 +143,9 @@ function renderFieldInput(array $field, string $inputName, $value = null): void
             $dataAttr = ' data-target-type="' . htmlspecialchars($targetType) . '"';
             if ($filterField !== '') {
                 $dataAttr .= ' data-filter-field="' . htmlspecialchars($filterField) . '"';
+            }
+            if ($filterValue !== '') {
+                $dataAttr .= ' data-filter-value="' . htmlspecialchars($filterValue) . '"';
             }
             if ($selected) {
                 $dataAttr .= ' data-selected="' . htmlspecialchars(implode(',', $selected)) . '"';


### PR DESCRIPTION
## Summary
- Pass static filter values to content and multi-content fields
- Apply fixed filter values when loading content options

## Testing
- `php -l content.php`
- `node -c assets/js/custom.js`


------
https://chatgpt.com/codex/tasks/task_e_68b77afebdf08320875ad671b7a9ef7a