### PR TITLE
Add accounting document upload page

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -1,0 +1,7 @@
+document.addEventListener('DOMContentLoaded', function() {
+    new Dropzone('#multi-upload', {
+        url: 'contabilidade/upload-handler.php',
+        acceptedFiles: 'application/pdf',
+        parallelUploads: 1
+    });
+});

--- a/contabilidade/upload.php
+++ b/contabilidade/upload.php
@@ -1,0 +1,7 @@
+<?php
+require_once __DIR__ . '/../header.php';
+?>
+<form id="multi-upload" class="dropzone"></form>
+<script src="vendors/dropzone/dropzone.min.js"></script>
+<script src="assets/js/accounting_upload.js"></script>
+<?php require_once __DIR__ . '/../footer.php'; ?>


### PR DESCRIPTION
## Summary
- Add accounting upload page with Dropzone form
- Initialize Dropzone for single PDF uploads

## Testing
- `php -l contabilidade/upload.php`
- `node --check assets/js/accounting_upload.js`


------
https://chatgpt.com/codex/tasks/task_e_68b96929bcd08320b72aa2878ef149e3