### PR TITLE
feat: add OCR review step after upload

### DIFF
--- a/assets/js/ocr-upload.js
+++ b/assets/js/ocr-upload.js
@@ -1,0 +1,65 @@
+// Handles OCR analysis workflow after each upload
+Dropzone.autoDiscover = false;
+
+function initOcrUpload(selector) {
+    var dz = new Dropzone(selector);
+    var queue = [];
+
+    function showNext() {
+        if (!queue.length) {
+            dz.processQueue();
+            return;
+        }
+        var item = queue.shift();
+        var data = item.data || {};
+        var $modal = $('#ocrModal');
+        $modal.data('file', item.file);
+        $modal.find('textarea[name="ocr_text"]').val(data.text || '');
+        var fields = data.fields || {};
+        var $fields = $modal.find('.analysis-fields').empty();
+        Object.keys(fields).forEach(function(key) {
+            var group = $('<div class="mb-3"></div>');
+            $('<label class="form-label"></label>').text(key).appendTo(group);
+            $('<input type="text" class="form-control">').attr('name', key).val(fields[key]).appendTo(group);
+            $fields.append(group);
+        });
+        $modal.modal('show');
+    }
+
+    dz.on('success', function(file, response) {
+        var data = response;
+        if (typeof response === 'string') {
+            try { data = JSON.parse(response); } catch (e) { data = {}; }
+        }
+        queue.push({file: file, data: data});
+        if (!$('#ocrModal').hasClass('show')) {
+            showNext();
+        }
+    });
+
+    $('#analysisConfirm').on('click', function() {
+        var $modal = $('#ocrModal');
+        var file = $modal.data('file');
+        var payload = {
+            filename: file.name,
+            text: $modal.find('textarea[name="ocr_text"]').val(),
+            fields: {}
+        };
+        $modal.find('.analysis-fields input').each(function() {
+            payload.fields[this.name] = $(this).val();
+        });
+        $.post('contabilidade/save-analysis.php', payload).always(function() {
+            $modal.modal('hide');
+            dz.removeFile(file);
+            showNext();
+        });
+    });
+
+    $('#analysisCancel').on('click', function() {
+        var $modal = $('#ocrModal');
+        var file = $modal.data('file');
+        $modal.modal('hide');
+        dz.removeFile(file);
+        showNext();
+    });
+}

--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -1,0 +1,22 @@
+<?php
+require_once __DIR__ . '/../functions.php';
+
+startSession();
+requireLogin();
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'Método inválido']);
+    exit;
+}
+
+$text = $_POST['text'] ?? '';
+$fields = $_POST['fields'] ?? [];
+$filename = $_POST['filename'] ?? '';
+
+// Placeholder: persist analysis data as needed.
+// For now, simply return success.
+
+echo json_encode(['success' => true]);

--- a/footer.php
+++ b/footer.php
@@ -10,6 +10,29 @@
     </div> <!-- /main_container -->
 </div> <!-- /container body -->
 
+<!-- OCR Review Modal -->
+<div class="modal fade" id="ocrModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Revisar OCR</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <label class="form-label">Texto</label>
+                    <textarea class="form-control" name="ocr_text" rows="5"></textarea>
+                </div>
+                <div class="analysis-fields"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" id="analysisCancel" data-bs-dismiss="modal">Cancelar</button>
+                <button type="button" class="btn btn-primary" id="analysisConfirm">Confirmar</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <script src="vendors/jquery/dist/jquery.min.js"></script>
 <script src="vendors/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 <script src="vendors/datatables.net/js/dataTables.min.js"></script>
@@ -17,9 +40,9 @@
 <script src="vendors/datatables.net-responsive/js/dataTables.responsive.min.js"></script>
 <script src="vendors/datatables.net-responsive-bs5/js/responsive.bootstrap5.min.js"></script>
 
-
-
+<script src="vendors/dropzone/src/dropzone.js"></script>
 <script src="assets/js/custom.js"></script>
+<script src="assets/js/ocr-upload.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show OCR text in a modal after each file upload so values can be reviewed
- allow submitting edited OCR data to `contabilidade/save-analysis.php`
- include placeholder endpoint for saving analysis results

## Testing
- `php -l contabilidade/save-analysis.php`
- `php -l footer.php`
- `node --check assets/js/ocr-upload.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68b9692fc8f48320a972cc0e6ee7d360