### PR TITLE
feat: show accounting menu from active modules

### DIFF
--- a/header.php
+++ b/header.php
@@ -82,7 +82,7 @@ foreach ($sidebarTypes as $sidebarType):
                                 </ul>
                             </li>
 <?php endforeach; ?>
-<?php if (getSetting('accounting_enabled', '0') === '1'): ?>
+<?php if (isModuleActive('contabilidade')): ?>
                             <li><a href="<?= BASE_URL ?>contabilidade/upload"><i class="fa fa-upload"></i> Multi Upload</a></li>
 <?php endif; ?>
                         </ul>


### PR DESCRIPTION
## Summary
- only display accounting upload menu when 'contabilidade' module is active

## Testing
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b96ea901c88320b80e4e9d710ad4d3