### PR TITLE
Fix Dropzone import error

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -40,7 +40,7 @@
 <script src="vendors/datatables.net-responsive/js/dataTables.responsive.min.js"></script>
 <script src="vendors/datatables.net-responsive-bs5/js/responsive.bootstrap5.min.js"></script>
 
-<script src="vendors/dropzone/src/dropzone.js"></script>
+<script src="vendors/dropzone/dist/dropzone-min.js"></script>
 <script src="assets/js/custom.js"></script>
 <script src="assets/js/ocr-upload.js"></script>
 


### PR DESCRIPTION
## Summary
- Load prebuilt Dropzone script instead of ES module

## Testing
- `php -l footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68b972b23448832094e68d4ed34157b3