### PR TITLE
Include CSRF token in Dropzone uploads

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -1,7 +1,20 @@
 document.addEventListener('DOMContentLoaded', function() {
-    new Dropzone('#multi-upload', {
+    var form = document.getElementById('multi-upload');
+    var csrfInput = form.querySelector('input[name="csrf_token"]');
+
+    var dz = new Dropzone('#multi-upload', {
         url: 'contabilidade/upload-handler.php',
         acceptedFiles: 'application/pdf',
         parallelUploads: 1
+    });
+
+    dz.on('success', function(file, response) {
+        var data = response;
+        if (typeof response === 'string') {
+            try { data = JSON.parse(response); } catch (e) { data = {}; }
+        }
+        if (data.csrf_token && csrfInput) {
+            csrfInput.value = data.csrf_token;
+        }
     });
 });

--- a/contabilidade/upload-handler.php
+++ b/contabilidade/upload-handler.php
@@ -17,6 +17,8 @@ if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
     exit;
 }
 
+$newToken = generateCsrfToken();
+
 if (!isset($_FILES['file']) || !is_uploaded_file($_FILES['file']['tmp_name'])) {
     http_response_code(400);
     echo json_encode(['error' => 'Ficheiro não enviado']);
@@ -67,4 +69,5 @@ echo json_encode([
     'success' => true,
     'file' => $relativePath,
     'text' => $text,
+    'csrf_token' => $newToken,
 ]);

--- a/contabilidade/upload.php
+++ b/contabilidade/upload.php
@@ -1,7 +1,10 @@
 <?php
 require_once __DIR__ . '/../header.php';
+$csrfToken = generateCsrfToken();
 ?>
-<form id="multi-upload" class="dropzone"></form>
+<form id="multi-upload" class="dropzone">
+    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken); ?>">
+</form>
 
 <script src="vendors/dropzone/dist/dropzone-min.js"></script>
 


### PR DESCRIPTION
## Summary
- add CSRF token field to accounting upload form
- refresh CSRF token in upload handler and client script to allow sequential uploads

## Testing
- `php -l contabilidade/upload.php`
- `php -l contabilidade/upload-handler.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68b9748427f483209ed0232c2255bbdc