### PR TITLE
Load component assets on demand

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -349,42 +349,44 @@ function updtCliParam(cliente, params) {
 }
 
 $(document).ready(function() {
-    $('table.datatable').each(function() {
-        var $table = $(this);
-        var source = $table.data('source');
-        var options = { responsive: true };
-        options.language = { url: 'vendors/datatables.net/i18n/pt-PT.json' };
-        var nonSortable = [];
-        $table.find('thead th').each(function(i) {
-            if ($(this).data('orderable') === false) {
-                nonSortable.push(i);
+    if ($.fn.DataTable) {
+        $('table.datatable').each(function() {
+            var $table = $(this);
+            var source = $table.data('source');
+            var options = { responsive: true };
+            options.language = { url: 'vendors/datatables.net/i18n/pt-PT.json' };
+            var nonSortable = [];
+            $table.find('thead th').each(function(i) {
+                if ($(this).data('orderable') === false) {
+                    nonSortable.push(i);
+                }
+            });
+            if (nonSortable.length) {
+                options.columnDefs = options.columnDefs || [];
+                options.columnDefs.push({ targets: nonSortable, orderable: false });
+            }
+            if ($table.data('no-sort-last')) {
+                options.columnDefs = options.columnDefs || [];
+                options.columnDefs.push({ targets: -1, orderable: false });
+            }
+            if (source) {
+                var typeId = $table.data('type-id');
+                options.ajax = {
+                    url: source,
+                    type: 'POST',
+                    data: { type_id: typeId }
+                };
+            }
+            var table = $table.DataTable(options);
+            var $toggles = $table.prev('.column-toggler');
+            if ($toggles.length) {
+                $toggles.find('input[type="checkbox"]').on('change', function() {
+                    var column = table.column($(this).data('column'));
+                    column.visible(this.checked);
+                });
             }
         });
-        if (nonSortable.length) {
-            options.columnDefs = options.columnDefs || [];
-            options.columnDefs.push({ targets: nonSortable, orderable: false });
-        }
-        if ($table.data('no-sort-last')) {
-            options.columnDefs = options.columnDefs || [];
-            options.columnDefs.push({ targets: -1, orderable: false });
-        }
-        if (source) {
-            var typeId = $table.data('type-id');
-            options.ajax = {
-                url: source,
-                type: 'POST',
-                data: { type_id: typeId }
-            };
-        }
-        var table = $table.DataTable(options);
-        var $toggles = $table.prev('.column-toggler');
-        if ($toggles.length) {
-            $toggles.find('input[type="checkbox"]').on('change', function() {
-                var column = table.column($(this).data('column'));
-                column.visible(this.checked);
-            });
-        }
-    });
+    }
 });
 
 $(document).ready(function() {

--- a/contabilidade/upload.php
+++ b/contabilidade/upload.php
@@ -1,9 +1,8 @@
 <?php
+$useDropzone = true;
 require_once __DIR__ . '/../header.php';
 ?>
 <form id="multi-upload" class="dropzone"></form>
-
-<script src="vendors/dropzone/dist/dropzone-min.js"></script>
 
 <script src="assets/js/accounting_upload.js"></script>
 <?php require_once __DIR__ . '/../footer.php'; ?>

--- a/content.php
+++ b/content.php
@@ -7,6 +7,8 @@ requireLogin();
 $csrfToken = generateCsrfToken();
 $slug = getCompanySlug();
 
+$useDataTables = true;
+
 /**
  * Render an individual custom field input.
  *

--- a/custom_fields.php
+++ b/custom_fields.php
@@ -9,6 +9,8 @@ requireLogin();
 requireRole(2);
 $csrfToken = generateCsrfToken();
 
+$useDataTables = true;
+
 // Obtém parâmetros básicos
 $typeId = isset($_GET['type_id']) ? (int) $_GET['type_id'] : 0;
 $act    = $_GET['act'] ?? '';

--- a/footer.php
+++ b/footer.php
@@ -35,14 +35,19 @@
 
 <script src="vendors/jquery/dist/jquery.min.js"></script>
 <script src="vendors/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+<?php if ($useDataTables): ?>
 <script src="vendors/datatables.net/js/dataTables.min.js"></script>
 <script src="vendors/datatables.net-bs5/js/dataTables.bootstrap5.min.js"></script>
 <script src="vendors/datatables.net-responsive/js/dataTables.responsive.min.js"></script>
 <script src="vendors/datatables.net-responsive-bs5/js/responsive.bootstrap5.min.js"></script>
+<?php endif; ?>
 
+<?php if ($useDropzone): ?>
 <script src="vendors/dropzone/dist/dropzone-min.js"></script>
-<script src="assets/js/custom.js"></script>
 <script src="assets/js/ocr-upload.js"></script>
+<?php endif; ?>
+
+<script src="assets/js/custom.js"></script>
 
 </body>
 </html>

--- a/header.php
+++ b/header.php
@@ -17,6 +17,10 @@ requireLogin();
 // Get current user info
 $user = currentUser();
 $appName = getSetting('app_name', 'CMS');
+
+// Flags to control optional assets
+$useDataTables = $useDataTables ?? false;
+$useDropzone   = $useDropzone ?? false;
 ?>
 <!DOCTYPE html>
 <html lang="pt">
@@ -27,8 +31,14 @@ $appName = getSetting('app_name', 'CMS');
     <base href="<?= BASE_URL ?>">
 <link rel="stylesheet" href="vendors/bootstrap/dist/css/bootstrap.min.css">
 <link rel="stylesheet" href="vendors/font-awesome/css/font-awesome.min.css">
+<?php if ($useDataTables): ?>
 <link rel="stylesheet" href="vendors/datatables.net-bs5/css/dataTables.bootstrap5.min.css">
 <link rel="stylesheet" href="vendors/datatables.net-responsive-bs5/css/responsive.bootstrap5.min.css">
+<?php endif; ?>
+
+<?php if ($useDropzone): ?>
+<link rel="stylesheet" href="vendors/dropzone/dist/dropzone.css">
+<?php endif; ?>
 
 <link rel="stylesheet" href="assets/css/custom.css">
 

--- a/taxonomies.php
+++ b/taxonomies.php
@@ -18,6 +18,8 @@ requireLogin();
 requireRole(2);
 $csrfToken = generateCsrfToken();
 
+$useDataTables = true;
+
  $error = '';
  $taxonomyId = isset($_GET['taxonomy_id']) ? (int)$_GET['taxonomy_id'] : 0;
  $act = $_GET['act'] ?? '';


### PR DESCRIPTION
## Summary
- Load DataTables and Dropzone assets only when requested by pages
- Guard DataTables initialization to avoid errors when library absent
- Mark pages that rely on DataTables or Dropzone with flags

## Testing
- `php -l header.php footer.php content.php custom_fields.php taxonomies.php contabilidade/upload.php`
- `composer validate --no-check-all`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/cms-pombaldir/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b9745cec00832085f1537b3a55bfa2