### PR TITLE
Refine Dropzone styling and default messages

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -6272,7 +6272,27 @@ ul.notifications {
 
 .dropzone {
     min-height: 300px;
-    border: 1px solid #e5e5e5;
+    border: 2px dashed #d9d9d9;
+    border-radius: 6px;
+    background: #f7f7f7;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 20px;
+    color: #6c757d;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.dropzone .dz-message {
+    font-size: 1.2rem;
+    font-weight: 500;
+}
+
+.dropzone.dz-drag-hover {
+    background: #e6f4ff;
+    border-color: #007bff;
+    color: #007bff;
 }
 
 

--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -5,7 +5,8 @@ document.addEventListener('DOMContentLoaded', function() {
     var dz = new Dropzone('#multi-upload', {
         url: 'contabilidade/upload-handler.php',
         acceptedFiles: 'application/pdf',
-        parallelUploads: 1
+        parallelUploads: 1,
+        dictDefaultMessage: 'Arraste e solte os ficheiros aqui ou clique para selecionar'
     });
 
     dz.on('success', function(file, response) {

--- a/assets/js/ocr-upload.js
+++ b/assets/js/ocr-upload.js
@@ -2,7 +2,9 @@
 Dropzone.autoDiscover = false;
 
 function initOcrUpload(selector) {
-    var dz = new Dropzone(selector);
+    var dz = new Dropzone(selector, {
+        dictDefaultMessage: 'Arraste e solte os ficheiros aqui ou clique para selecionar'
+    });
     var queue = [];
 
     function showNext() {


### PR DESCRIPTION
## Summary
- Enhance Dropzone CSS with dashed border, centered layout, and hover feedback
- Customize Dropzone default messages for accounting and OCR uploads

## Testing
- `php -l contabilidade/upload.php && echo "syntax OK"`
- `node --check assets/js/accounting_upload.js && echo "syntax OK"`
- `node --check assets/js/ocr-upload.js && echo "syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68b975fd28408320a3736d8fa7b38b2f