### PR TITLE
Scan all PDF pages for QR codes

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -6,10 +6,11 @@ use Zxing\QrReader;
 /**
  * Read a PDF document and extract the text contained in its QR code, if any.
  *
- * The first page of the PDF is converted to a temporary PNG image using the
- * `pdftoppm` utility. The image is then scanned with the `QrReader` from the
- * khanamiryan/qrcode-detector-decoder package. Temporary files are removed
- * after processing.
+ * Pages of the PDF are converted to temporary PNG images using the
+ * `pdftoppm` utility. Each image is scanned for a QR code using the
+ * `zbarimg` command line tool when available, falling back to the PHP
+ * `QrReader` from the khanamiryan/qrcode-detector-decoder package. All
+ * temporary files are removed after processing.
  *
  * @param string $pdfPath Absolute filesystem path to the PDF document.
  * @return string|null Decoded QR code text or null if not found.
@@ -22,21 +23,64 @@ function extractQrStringFromPdf(string $pdfPath): ?string {
     $prefix = $tempBase;
     @unlink($tempBase);
 
-    $cmd = 'pdftoppm -png -singlefile ' . escapeshellarg($pdfPath) . ' ' . escapeshellarg($prefix);
+    $images = [];
+
+    $cmd = 'pdftoppm -png -r 300 ' . escapeshellarg($pdfPath) . ' ' . escapeshellarg($prefix);
     exec($cmd, $output, $status);
-    $imagePath = $prefix . '.png';
-    if ($status !== 0 || !file_exists($imagePath)) {
-        @unlink($imagePath);
-        return null;
+    if ($status === 0) {
+        $page = 1;
+        while (file_exists($path = sprintf('%s-%d.png', $prefix, $page))) {
+            $images[] = $path;
+            $page++;
+        }
     }
 
-    try {
-        $qrcode = new QrReader($imagePath);
-        $text = $qrcode->text();
-    } catch (Throwable $e) {
-        $text = null;
+    if (empty($images)) {
+        try {
+            $imagick = new Imagick();
+            $imagick->setResolution(300, 300);
+            $imagick->readImage($pdfPath);
+            foreach ($imagick as $index => $img) {
+                $img->setImageFormat('png');
+                $imgPath = sprintf('%s-%d.png', $prefix, $index + 1);
+                $img->writeImage($imgPath);
+                $images[] = $imgPath;
+            }
+            $imagick->clear();
+            $imagick->destroy();
+        } catch (Throwable $e) {
+            foreach ($images as $path) {
+                @unlink($path);
+            }
+            return null;
+        }
     }
 
-    @unlink($imagePath);
+    $text = null;
+    foreach ($images as $imagePath) {
+        $decoded = [];
+        $status = 1;
+        exec('zbarimg --quiet --raw ' . escapeshellarg($imagePath), $decoded, $status);
+        if ($status === 0 && !empty($decoded[0])) {
+            $text = trim($decoded[0]);
+            break;
+        }
+
+        try {
+            $qrcode = new QrReader($imagePath);
+            $decodedText = $qrcode->text();
+            if ($decodedText) {
+                $text = $decodedText;
+                break;
+            }
+        } catch (Throwable $e) {
+            // Ignore errors for individual pages
+        }
+    }
+
+    foreach ($images as $path) {
+        @unlink($path);
+    }
+
     return $text ?: null;
 }


### PR DESCRIPTION
## Summary
- convert PDF pages to PNG at 300 DPI and scan sequentially for QR codes
- fall back to Imagick conversion if `pdftoppm` is unavailable, then scan with `zbarimg` or PHP `QrReader`

## Testing
- `php -l contabilidade/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68b979679ac48320892dce4e20193259