### PR TITLE
Improve PDF invoice parsing with OCR and QR extraction

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     ],
     "require": {
         "thiagoalessio/tesseract_ocr": "^2.13",
-        "khanamiryan/qrcode-detector-decoder": "^2.0"
+        "khanamiryan/qrcode-detector-decoder": "^2.0",
+        "smalot/pdfparser": "^2.12"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65f011b74db60df3018e4716e4bd135b",
+    "content-hash": "0b212797a21e9993a3fa4c5ae56ec618",
     "packages": [
         {
             "name": "khanamiryan/qrcode-detector-decoder",
@@ -65,6 +65,142 @@
             "time": "2025-06-10T08:44:02+00:00"
         },
         {
+            "name": "smalot/pdfparser",
+            "version": "v2.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/smalot/pdfparser.git",
+                "reference": "98d31ba34ef5b5a98897ef4b6c3925d502ea53b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/smalot/pdfparser/zipball/98d31ba34ef5b5a98897ef4b6c3925d502ea53b1",
+                "reference": "98d31ba34ef5b5a98897ef4b6c3925d502ea53b1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-zlib": "*",
+                "php": ">=7.1",
+                "symfony/polyfill-mbstring": "^1.18"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Smalot\\PdfParser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastien MALOT",
+                    "email": "sebastien@malot.fr"
+                }
+            ],
+            "description": "Pdf parser library. Can read and extract information from pdf file.",
+            "homepage": "https://www.pdfparser.org",
+            "keywords": [
+                "extract",
+                "parse",
+                "parser",
+                "pdf",
+                "text"
+            ],
+            "support": {
+                "issues": "https://github.com/smalot/pdfparser/issues",
+                "source": "https://github.com/smalot/pdfparser/tree/v2.12.1"
+            },
+            "time": "2025-07-31T06:19:56+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-23T08:48:59+00:00"
+        },
+        {
             "name": "thiagoalessio/tesseract_ocr",
             "version": "2.13.0",
             "source": {
@@ -117,10 +253,10 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -2,16 +2,113 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 
 use Zxing\QrReader;
+use Smalot\PdfParser\Parser;
+use thiagoalessio\TesseractOCR\TesseractOCR;
 
 /**
- * Extract text from a QR code contained in an image.
+ * Convert a PDF into images and scan each page for QR codes.
  *
- * @param string $imagePath Absolute path to the image file.
- * @return string|null Decoded QR code text or null if none was found.
+ * @param string $pdfPath Path to the PDF file.
+ * @return string|null Decoded QR text or null if none found.
  */
-function extractQrStringFromPdf(string $imagePath): ?string {
-    $qrcode = new QrReader($imagePath);
-    $decoded = $qrcode->text();
-    return $decoded !== '' ? $decoded : null;
+function extractQrStringFromPdf(string $pdfPath): ?string {
+    $outputBase = sys_get_temp_dir() . '/' . uniqid('pdfqr_');
+    $cmd = 'pdftoppm -png ' . escapeshellarg($pdfPath) . ' ' . escapeshellarg($outputBase);
+    exec($cmd);
+    $images = glob($outputBase . '-*.png');
+    foreach ($images as $img) {
+        $qrcode = new QrReader($img);
+        $decoded = $qrcode->text();
+        if ($decoded !== '') {
+            foreach ($images as $file) { @unlink($file); }
+            return $decoded;
+        }
+    }
+    foreach ($images as $file) { @unlink($file); }
+    return null;
+}
+
+/**
+ * Extract relevant fields from an invoice PDF.
+ *
+ * @param string $pdfPath Path to the PDF.
+ * @return array Parsed fields including text, nif, iban, etc.
+ */
+function extractInvoiceFields(string $pdfPath): array {
+    $parser = new Parser();
+    try {
+        $pdf = $parser->parseFile($pdfPath);
+        $text = $pdf->getText();
+    } catch (Throwable $e) {
+        $text = '';
+    }
+
+    $minChars = 100;
+    $minWords = 10;
+    $wordList = array_filter(preg_split('/\s+/', strip_tags($text)));
+    $wordCount = count($wordList);
+
+    if (strlen($text) < $minChars || $wordCount < $minWords) {
+        $tempImageBase = sys_get_temp_dir() . '/' . uniqid('page1_');
+        $cmd = 'pdftoppm -f 1 -singlefile -png ' . escapeshellarg($pdfPath) . ' ' . escapeshellarg($tempImageBase);
+        exec($cmd);
+        $tempImage = $tempImageBase . '.png';
+
+        $ocr = new TesseractOCR($tempImage);
+        $ocr->lang('por');
+        $text = $ocr->run();
+        @unlink($tempImage);
+        $source = 'OCR via Tesseract';
+    } else {
+        $source = 'Texto nativo do PDF';
+    }
+
+    $foundNIF = null;
+    if (preg_match('/\b(?:NIF|NIPC|Contribuinte)[\s\:\-]*([1-9]\d{2}[\s]?\d{3}[\s]?\d{3})\b/i', $text, $nifMatch)) {
+        $foundNIF = str_replace(' ', '', $nifMatch[1]);
+    } elseif (preg_match('/\b([1-9]\d{2}[\s]?\d{3}[\s]?\d{3})\b/', $text, $nifMatch)) {
+        $foundNIF = str_replace(' ', '', $nifMatch[1]);
+    }
+
+    preg_match_all('/(?<![A-Z0-9])([A-Z]{2}\d{2}(?:\s?[A-Z0-9]){11,30})(?![A-Z0-9])/i', $text, $ibanMatches);
+    $foundIBANs = [];
+    if (!empty($ibanMatches[1])) {
+        foreach ($ibanMatches[1] as $ibanRaw) {
+            $ibanClean = strtoupper(preg_replace('/\s+/', '', $ibanRaw));
+            if (strlen($ibanClean) >= 15 && strlen($ibanClean) <= 34) {
+                $foundIBANs[] = $ibanClean;
+            }
+        }
+    }
+
+    $foundInvoice = null;
+    if (preg_match('/\b(?:FATURA|FACTURA)[\s\:\-]*(?:N[ºo]{1,2})?[\s\:\-]*([A-Z]{1,5}[\s\-\/]?\d{1,6}(?:\/\d{1,6})?)\b/i', $text, $invoiceMatch)) {
+        $foundInvoice = strtoupper(preg_replace('/\s+/', '', $invoiceMatch[1]));
+    }
+
+    $foundATCUD = null;
+    if (preg_match('/\bATCUD[\s\:\-]*([A-Z0-9]{3,}-\d{4,})\b/i', $text, $atcudMatch)) {
+        $foundATCUD = strtoupper($atcudMatch[1]);
+    }
+
+    $lines = explode("\n", $text);
+    $foundName = null;
+    foreach ($lines as $line) {
+        if (preg_match('/^[A-Z\s&\.\-]{8,}$/', trim($line)) && !preg_match('/\d/', $line)) {
+            $foundName = trim($line);
+            break;
+        }
+    }
+
+    return [
+        'text' => $text,
+        'nif' => $foundNIF,
+        'nome_emissor' => $foundName,
+        'iban' => $foundIBANs,
+        'docnum' => $foundInvoice,
+        'atcud' => $foundATCUD,
+        'linhas' => $lines,
+        'origem' => $source,
+    ];
 }
 

--- a/contabilidade/upload-handler.php
+++ b/contabilidade/upload-handler.php
@@ -56,23 +56,22 @@ if (!move_uploaded_file($_FILES['file']['tmp_name'], $targetPath)) {
     exit;
 }
 
-$text = '';
-try {
-    $ocr = new thiagoalessio\TesseractOCR\TesseractOCR($targetPath);
-    $text = $ocr->run();
-} catch (Throwable $e) {
-    // OCR failed; return empty text
-}
+// Extract text and invoice fields
+$analysis = extractInvoiceFields($targetPath);
+$text = $analysis['text'];
+unset($analysis['text']);
 
 $qrText = extractQrStringFromPdf($targetPath);
 
 $relativePath = 'uploads/' . $slug . '/accounting/' . $year . '/' . $month . '/' . $filename;
+
+$fields = array_merge(['qr_code' => $qrText], $analysis);
 
 echo json_encode([
     'success' => true,
     'file' => $relativePath,
     'text' => $text,
     'qr_text' => $qrText,
-    'fields' => ['qr_code' => $qrText],
+    'fields' => $fields,
     'csrf_token' => $newToken,
 ]);


### PR DESCRIPTION
## Summary
- convert PDF pages to images and scan each for QR codes
- parse invoices for NIF, IBAN, document number and ATCUD with OCR fallback
- expose parsed fields in upload handler and add smalot/pdfparser dependency

## Testing
- `php -l contabilidade/functions.php`
- `php -l contabilidade/upload-handler.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9abc074288320913f26b4fdde90cb