### PR TITLE
Use image conversion to read PDF QR codes

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -6,16 +6,89 @@ use Zxing\QrReader;
 /**
  * Read a PDF document and extract the text contained in its QR code, if any.
  *
- * Pages of the PDF are converted to temporary PNG images using the
- * `pdftoppm` utility. Each image is scanned with the `QrReader` from the
+ * Each page of the PDF is converted to a temporary PNG image using the
+ * `pdftoppm` command when available, falling back to the Imagick extension
+ * otherwise. Images are generated at a constrained resolution to avoid
+ * exhausting resources. Every image is scanned with the `QrReader` from the
  * khanamiryan/qrcode-detector-decoder package until a QR code is found. All
  * temporary files are removed after processing.
  *
  * @param string $pdfPath Absolute filesystem path to the PDF document.
  * @return string|null Decoded QR code text or null if not found.
+ * @throws RuntimeException When conversion of the PDF fails or when neither
+ *                          `pdftoppm` nor Imagick are available.
  */
-function extractQrStringFromPdf(string $pdfPath): ?string {
-    $qrcode = new QrReader($pdfPath);
-    $decoded = $qrcode->text();
-    return $decoded;
+function extractQrStringFromPdf(string $pdfPath): ?string
+{
+    $tmpDir = sys_get_temp_dir() . '/qr_' . uniqid();
+    if (!mkdir($concurrentDirectory = $tmpDir) && !is_dir($concurrentDirectory)) {
+        throw new RuntimeException('Unable to create temporary directory.');
+    }
+
+    try {
+        $images = [];
+
+        // Try using pdftoppm if available
+        $pdftoppm = trim(shell_exec('command -v pdftoppm'));
+        if ($pdftoppm !== '') {
+            $cmd = sprintf(
+                '%s -r %d %s %s/page',
+                escapeshellcmd($pdftoppm),
+                150,
+                escapeshellarg($pdfPath),
+                escapeshellarg($tmpDir)
+            );
+            exec($cmd, $output, $returnVar);
+            if ($returnVar !== 0) {
+                throw new RuntimeException('pdftoppm conversion failed.');
+            }
+            $images = glob($tmpDir . '/page*.png');
+        } else {
+            if (!class_exists('Imagick')) {
+                throw new RuntimeException('pdftoppm not found and Imagick extension missing.');
+            }
+
+            // Limit Imagick resources to avoid exhausting the system
+            \Imagick::setResourceLimit(\Imagick::RESOURCETYPE_MEMORY, 32 * 1024 * 1024);
+            \Imagick::setResourceLimit(\Imagick::RESOURCETYPE_MAP, 32 * 1024 * 1024);
+
+            $imagick = new \Imagick();
+            $imagick->setResolution(150, 150);
+
+            try {
+                $imagick->readImage($pdfPath);
+            } catch (\Exception $e) {
+                throw new RuntimeException('Imagick failed to read PDF: ' . $e->getMessage());
+            }
+
+            foreach ($imagick as $index => $page) {
+                /** @var \Imagick $page */
+                $page->setImageFormat('png');
+                $filename = sprintf('%s/page-%d.png', $tmpDir, $index);
+                if (!$page->writeImage($filename)) {
+                    throw new RuntimeException('Imagick failed to write image: ' . $filename);
+                }
+                $images[] = $filename;
+            }
+
+            $imagick->clear();
+            $imagick->destroy();
+        }
+
+        foreach ($images as $image) {
+            $qr = new QrReader($image);
+            $text = $qr->text();
+            if (!empty($text)) {
+                return $text;
+            }
+        }
+
+        return null;
+    } finally {
+        // Cleanup temporary files
+        foreach (glob($tmpDir . '/*.png') as $file) {
+            @unlink($file);
+        }
+        @rmdir($tmpDir);
+    }
 }


### PR DESCRIPTION
## Summary
- convert PDF pages to temporary PNGs via `pdftoppm` or Imagick
- scan images for QR codes and return first decoded value
- clean up temporary files and limit Imagick resource usage

## Testing
- `php -l contabilidade/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9bb5152a88320a0fc23be350d1068