### PR TITLE
Improve QR requirement checks in accounting upload

### DIFF
--- a/contabilidade/upload.php
+++ b/contabilidade/upload.php
@@ -11,21 +11,37 @@ $csrfToken = generateCsrfToken();
 
 <?php
 
-function checkQrRequirements() {
+function checkQrRequirements(array &$messages): bool {
+    $messages = [];
     $ok = true;
 
     // 1. Extensão Imagick ou GD
     $hasImagick = extension_loaded('imagick');
     $hasGd      = extension_loaded('gd');
     if (!$hasImagick && !$hasGd) {
-        echo "Falta Imagick ou GD. Pelo menos um é necessário.<br>";
+        $messages[] = 'Falta Imagick ou GD. Pelo menos um é necessário.';
         $ok = false;
     }
 
-    // 2. Extensão Imagick para leitura de PDF, caso o pdftoppm não exista
-    $hasPdftoppm = !empty(shell_exec('which pdftoppm'));
+    // 2. Verificar a existência do pdftoppm
+    $hasPdftoppm = false;
+    if (function_exists('proc_open')) {
+        $descriptor = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+        $process = proc_open('command -v pdftoppm', $descriptor, $pipes);
+        if (is_resource($process)) {
+            $output = stream_get_contents($pipes[1]);
+            foreach ($pipes as $pipe) {
+                fclose($pipe);
+            }
+            $status = proc_close($process);
+            $hasPdftoppm = ($status === 0 && !empty(trim($output)));
+        }
+    } elseif (function_exists('shell_exec')) {
+        $hasPdftoppm = !empty(shell_exec('command -v pdftoppm'));
+    }
+
     if (!$hasPdftoppm && !$hasImagick) {
-        echo "Nem pdftoppm nem Imagick estão disponíveis para converter PDFs.<br>";
+        $messages[] = 'Nem pdftoppm nem Imagick estão disponíveis para converter PDFs.';
         $ok = false;
     }
 
@@ -33,9 +49,13 @@ function checkQrRequirements() {
 }
 
 
-if (!checkQrRequirements()) {
-    echo "Dependências ausentes. Verifique seu ambiente MAMP.";
-} 
+$messages = [];
+if (!checkQrRequirements($messages)) {
+    foreach ($messages as $message) {
+        echo $message . '<br>';
+    }
+    echo 'Dependências ausentes. Verifique seu ambiente MAMP.';
+}
 
 ?>
 


### PR DESCRIPTION
## Summary
- Safely check environment dependencies for QR processing
- Use `command -v` via `proc_open` to detect `pdftoppm`
- Return detailed messages instead of echoing inside the requirement check

## Testing
- `php -l contabilidade/upload.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9bb8182788320af88b7ff9edae052