### PR TITLE
Handle upload directory creation failures

### DIFF
--- a/contabilidade/upload-handler.php
+++ b/contabilidade/upload-handler.php
@@ -45,7 +45,12 @@ $year = date('Y');
 $month = date('m');
 $uploadDir = dirname(__DIR__) . '/uploads/' . $slug . '/accounting/' . $year . '/' . $month . '/';
 if (!is_dir($uploadDir)) {
-    mkdir($uploadDir, 0755, true);
+    if (!mkdir($uploadDir, 0755, true)) {
+        error_log('Failed to create upload directory: ' . $uploadDir);
+        http_response_code(500);
+        echo json_encode(['error' => 'Erro ao criar diretório de upload']);
+        exit;
+    }
 }
 
 $filename = bin2hex(random_bytes(16)) . '.pdf';


### PR DESCRIPTION
## Summary
- Validate upload directory creation in contabilidade/upload-handler.php
- Return 500 JSON error and log when directory creation fails

## Testing
- `php -l contabilidade/upload-handler.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9bb845b7c8320a15d178bd6ff8ad6