### PR TITLE
Ensure pdftoppm outputs PNG images

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -32,7 +32,7 @@ function extractQrStringFromPdf(string $pdfPath): ?string
         $pdftoppm = trim(shell_exec('command -v pdftoppm'));
         if ($pdftoppm !== '') {
             $cmd = sprintf(
-                '%s -r %d %s %s/page',
+                '%s -png -r %d %s %s/page',
                 escapeshellcmd($pdftoppm),
                 150,
                 escapeshellarg($pdfPath),


### PR DESCRIPTION
## Summary
- ensure pdftoppm converts PDF pages to PNG images by adding the -png flag

## Testing
- `php -l contabilidade/functions.php`
- `composer validate --no-check-all --strict`
- `composer install --no-interaction --no-progress`


------
https://chatgpt.com/codex/tasks/task_e_68b9bd9d8244832095866c7c63fee1c8