### PR TITLE
Capture pdftoppm errors and verify PNG output

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -39,11 +39,14 @@ function extractQrStringFromPdf(string $pdfPath): ?string
                 escapeshellarg($pdfPath),
                 escapeshellarg($tmpDir)
             );
-            exec($cmd, $output, $returnVar);
+            exec($cmd . ' 2>&1', $output, $returnVar);
             if ($returnVar !== 0) {
-                throw new RuntimeException('pdftoppm conversion failed.');
+                throw new RuntimeException('pdftoppm conversion failed: ' . implode("\n", $output));
             }
             $images = glob($tmpDir . '/page*.png');
+            if (!$images) {
+                throw new RuntimeException('pdftoppm did not produce any PNG files.');
+            }
         } else {
             if (!class_exists('Imagick')) {
                 throw new RuntimeException('pdftoppm not found and Imagick extension missing.');


### PR DESCRIPTION
## Summary
- Capture `pdftoppm` stderr output during PDF conversion
- Ensure the utility produced PNG files and raise an exception otherwise

## Testing
- `php -l contabilidade/functions.php`
- `composer validate --no-check-all` *(fails: description and license missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c232ee40832090ffa35204fab917