### PR TITLE
Fix pdftoppm invocation to output PNG

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -33,7 +33,7 @@ function extractQrStringFromPdf(string $pdfPath): ?string
         $pdftoppm = trim(shell_exec('command -v pdftoppm'));
         if ($pdftoppm !== '') {
             $cmd = sprintf(
-                '%s -r %d %s %s/page',
+                '%s -png -r %d %s %s/page',
                 escapeshellcmd($pdftoppm),
                 150,
                 escapeshellarg($pdfPath),


### PR DESCRIPTION
## Summary
- ensure `pdftoppm` produces PNG pages for QR code scanning

## Testing
- `php -l contabilidade/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9c3ec9e388320a4371eb28a8f064f