### PR TITLE
Display QR data in accounting uploader

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
     var form = document.getElementById('multi-upload');
     var csrfInput = form.querySelector('input[name="csrf_token"]');
+    var resultsDiv = document.getElementById('qr-results');
 
     var dz = new Dropzone('#multi-upload', {
         url: 'contabilidade/upload-handler.php',
@@ -17,6 +18,50 @@ document.addEventListener('DOMContentLoaded', function() {
         if (data.csrf_token && csrfInput) {
             csrfInput.value = data.csrf_token;
         }
-        console.log(data);
+        if (data.qr_text && resultsDiv) {
+            var qrData = extractQR(data.qr_text);
+            var table = document.createElement('table');
+            var tbody = document.createElement('tbody');
+
+            if (qrData['B']) {
+                var trB = document.createElement('tr');
+                var thB = document.createElement('th');
+                thB.textContent = '[B]';
+                var tdB = document.createElement('td');
+                tdB.textContent = qrData['B'];
+                trB.appendChild(thB);
+                trB.appendChild(tdB);
+                tbody.appendChild(trB);
+            }
+
+            Object.keys(qrData).forEach(function(key) {
+                if (key === 'B') return;
+                var tr = document.createElement('tr');
+                var th = document.createElement('th');
+                th.textContent = '[' + key + ']';
+                var td = document.createElement('td');
+                td.textContent = qrData[key];
+                tr.appendChild(th);
+                tr.appendChild(td);
+                tbody.appendChild(tr);
+            });
+
+            table.appendChild(tbody);
+            resultsDiv.appendChild(table);
+        }
     });
 });
+
+function extractQR(str) {
+    var parts = str.split('*');
+    var obj = {};
+    parts.forEach(function(part) {
+        var del = part.split(':', 2);
+        if (del.length === 2) {
+            var key = del[0].trim();
+            var val = del[1].trim();
+            obj[key] = val;
+        }
+    });
+    return obj;
+}

--- a/contabilidade/upload.php
+++ b/contabilidade/upload.php
@@ -7,6 +7,8 @@ $csrfToken = generateCsrfToken();
     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken); ?>">
 </form>
 
+<div id="qr-results"></div>
+
 
 
 <?php


### PR DESCRIPTION
## Summary
- Render a table of decoded QR fields for each uploaded accounting file
- Parse server-provided QR text in the browser and prioritise field B in the output

## Testing
- `php -l contabilidade/upload.php`
- `node --check assets/js/accounting_upload.js && echo "syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68bab2e0bb4c83208d0777d5c4c3f916