### PR TITLE
Enable hiding all but second column in DataTables

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -369,6 +369,14 @@ $(document).ready(function() {
                 options.columnDefs = options.columnDefs || [];
                 options.columnDefs.push({ targets: -1, orderable: false });
             }
+            if ($table.data('only-second')) {
+                options.columnDefs = options.columnDefs || [];
+                $table.find('thead th').each(function(i) {
+                    if (i !== 1) {
+                        options.columnDefs.push({ targets: i, visible: false });
+                    }
+                });
+            }
             if (source) {
                 var typeId = $table.data('type-id');
                 options.ajax = {

--- a/content.php
+++ b/content.php
@@ -337,7 +337,7 @@ if (isset($_GET['manage_types'])) {
             </div>
         <?php endif; ?>
         <h2>Tipos de Conteúdo</h2>
-        <table class="table table-striped datatable" data-no-sort-last="true">
+        <table class="table table-striped datatable" data-no-sort-last="true" data-only-second="true">
             <thead><tr><th>Ordem</th><th>Rótulo</th><th>Slug</th><th data-orderable="false">Ícone</th><th>Ações</th></tr></thead>
             <tbody>
             <?php foreach ($types as $type): ?>


### PR DESCRIPTION
## Summary
- Allow tables to hide all columns except the second using a `data-only-second` attribute in the DataTables initialization.
- Apply this new attribute to the content types table so only the label column remains visible.

## Testing
- `node --check assets/js/custom.js`
- `php -l content.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68bab6dd79b08320853bd0a621f4a299