### PR TITLE
Add descriptions and Dt header to accounting upload

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -2,10 +2,12 @@ window.addEventListener('load', function() {
     var form = document.getElementById('multi-upload');
     var csrfInput = form.querySelector('input[name="csrf_token"]');
 
-
-    var table = $('#qr-table').DataTable();
-
-
+    var table = $('#qr-table').DataTable({
+        orderCellsTop: true,
+        columnDefs: [
+            { targets: [1, 2, 4, 8, 13, 14], visible: false }
+        ]
+    });
 
     var dz = new Dropzone('#multi-upload', {
         url: 'contabilidade/upload-handler.php',
@@ -24,7 +26,7 @@ window.addEventListener('load', function() {
         }
         if (data.qr_text) {
             var qrData = extractQR(data.qr_text);
-            var keys = ['A','B','C','D','E','F','G','H','I1','I7','I8','N','O'];
+            var keys = ['A','B','C','D','E','F','G','H','I1','I7','I8','N','O','Q','R'];
             var row = keys.map(function(key) {
                 return qrData[key] || '';
             });

--- a/contabilidade/upload.php
+++ b/contabilidade/upload.php
@@ -11,16 +11,13 @@ $csrfToken = generateCsrfToken();
 <div id="qr-results">
     <table id="qr-table" class="datatable table table-striped">
         <thead>
-
-
-
             <tr>
                 <th>[A]</th>
                 <th>[B]</th>
                 <th>[C]</th>
                 <th>[D]</th>
                 <th>[E]</th>
-                <th>[F]</th>
+                <th>Dt</th>
                 <th>[G]</th>
                 <th>[H]</th>
                 <th>[I1]</th>
@@ -28,8 +25,26 @@ $csrfToken = generateCsrfToken();
                 <th>[I8]</th>
                 <th>[N]</th>
                 <th>[O]</th>
+                <th>[Q]</th>
+                <th>[R]</th>
             </tr>
-
+            <tr>
+                <th>NIF do emitente (quem emite a fatura).</th>
+                <th>NIF do adquirente (cliente).</th>
+                <th>País do emitente (código ISO, ex.: <code>PT</code>).</th>
+                <th>Tipo de documento.<br><strong>FT</strong> – Fatura<br><strong>FS</strong> – Fatura Simplificada<br><strong>FR</strong> – Fatura/Recibo</th>
+                <th>Estado do documento.<br><strong>N</strong> – Normal<br><strong>A</strong> – Anulado</th>
+                <th>Data do documento no formato <code>YYYYMMDD</code>.</th>
+                <th>Identificação única do documento (série + numeração, ex.: <code>FACDG+232122/990</code>).</th>
+                <th>Retenção na fonte; usar <code>0</code> se não houver.</th>
+                <th>País do adquirente (código ISO, ex.: <code>PT</code>, <code>ES</code>).</th>
+                <th>Total com IVA à taxa normal (base tributável).</th>
+                <th>IVA calculado à taxa normal.</th>
+                <th>Valor total de IVA (soma de todos os tipos de IVA).</th>
+                <th>Total do documento (valor global da fatura).</th>
+                <th>Assinatura/Hash do documento gerado pelo software certificado.</th>
+                <th>Código de validação do software certificado atribuído pela AT.</th>
+            </tr>
         </thead>
         <tbody></tbody>
     </table>


### PR DESCRIPTION
## Summary
- Display QR field descriptions directly beneath headers in the results table
- Configure DataTables to handle multi-row headers

## Testing
- `php -l contabilidade/upload.php`
- `node --check assets/js/accounting_upload.js`


------
https://chatgpt.com/codex/tasks/task_e_68bac6ed5f4883209033ad6fcca35158