### PR TITLE
Prevent DataTable from reinitializing on uploads

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -2,12 +2,17 @@ window.addEventListener('load', function() {
     var form = document.getElementById('multi-upload');
     var csrfInput = form.querySelector('input[name="csrf_token"]');
 
-    var table = $('#qr-table').DataTable({
-        orderCellsTop: true,
-        columnDefs: [
-            { targets: [1, 2, 4, 8, 13, 14], visible: false }
-        ]
-    });
+    var table;
+    if ($.fn.dataTable.isDataTable('#qr-table')) {
+        table = $('#qr-table').DataTable();
+    } else {
+        table = $('#qr-table').DataTable({
+            orderCellsTop: true,
+            columnDefs: [
+                { targets: [1, 2, 4, 8, 13, 14], visible: false }
+            ]
+        });
+    }
 
     var dz = new Dropzone('#multi-upload', {
         url: 'contabilidade/upload-handler.php',


### PR DESCRIPTION
## Summary
- guard DataTable setup for qr-table, reusing existing instance when present to avoid reinitialization warnings

## Testing
- `node --check assets/js/accounting_upload.js && echo 'Syntax OK'`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68bae08d857c83208e32ef455eb0daed