### PR TITLE
Add actions column with PDF controls

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -10,7 +10,8 @@ window.addEventListener('load', function() {
             orderCellsTop: true,
             columnDefs: [
                 { targets: [ 2, 4, 7, 8, 13, 14], visible: false },
-                { targets: [0, 1], className: 'text-start' }
+                { targets: [0, 1], className: 'text-start' },
+                { targets: -1, orderable: false, searchable: false }
             ]
         });
     }
@@ -40,11 +41,36 @@ window.addEventListener('load', function() {
                 }
                 return value;
             });
+            var actions = '<button type="button" class="btn btn-sm btn-danger delete-row" data-file="' + data.file + '">Eliminar</button> ' +
+                '<a href="' + data.file + '" target="_blank" class="btn btn-sm btn-secondary">Ver PDF</a>';
+            row.push(actions);
             table.row.add(row).draw();
         }
         console.log(data);
     });
-    
+
+    $('#qr-table').on('click', '.delete-row', function() {
+        if (!confirm('Eliminar ficheiro?')) {
+            return;
+        }
+        var file = $(this).data('file');
+        var row = table.row($(this).parents('tr'));
+        $.ajax({
+            type: 'POST',
+            url: 'contabilidade/delete-file.php',
+            data: { file: file, csrf_token: csrfInput.value },
+            dataType: 'json',
+            success: function(res) {
+                if (res.csrf_token) {
+                    csrfInput.value = res.csrf_token;
+                }
+                if (res.success) {
+                    row.remove().draw();
+                }
+            }
+        });
+    });
+
 });
 
 function extractQR(str) {

--- a/contabilidade/delete-file.php
+++ b/contabilidade/delete-file.php
@@ -1,0 +1,43 @@
+<?php
+require_once __DIR__ . '/../functions.php';
+
+startSession();
+header('Content-Type: application/json');
+
+if (!isLoggedIn()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Sessão inválida']);
+    exit;
+}
+
+if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit;
+}
+
+$file = $_POST['file'] ?? '';
+$slug = getCompanySlug();
+$baseDir = realpath(dirname(__DIR__) . '/uploads/' . $slug . '/accounting/');
+$newToken = generateCsrfToken();
+
+if ($file === '' || !$baseDir) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Ficheiro inválido', 'csrf_token' => $newToken]);
+    exit;
+}
+
+$fullPath = realpath(dirname(__DIR__) . '/' . ltrim($file, '/'));
+if ($fullPath === false || strpos($fullPath, $baseDir) !== 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Ficheiro inválido', 'csrf_token' => $newToken]);
+    exit;
+}
+
+$success = file_exists($fullPath) && unlink($fullPath);
+if ($success) {
+    echo json_encode(['success' => true, 'csrf_token' => $newToken]);
+} else {
+    http_response_code(500);
+    echo json_encode(['error' => 'Falha ao eliminar o ficheiro', 'csrf_token' => $newToken]);
+}

--- a/contabilidade/upload.php
+++ b/contabilidade/upload.php
@@ -28,6 +28,7 @@ $csrfToken = generateCsrfToken();
                 <th width="8%">Total</th>
                 <th></th>
                 <th></th>
+                <th data-orderable="false">Ações</th>
             </tr>
         </thead>
         <tbody></tbody>


### PR DESCRIPTION
## Summary
- add non-sortable "Ações" column on accounting upload table
- show buttons to view PDF or delete file for each row
- create backend endpoint to remove uploaded files with CSRF validation

## Testing
- `php -l contabilidade/delete-file.php`
- `php -l contabilidade/upload.php`
- `npm test` *(fails: could not read package.json)*
- `composer validate` *(fails: description required)*

------
https://chatgpt.com/codex/tasks/task_e_68bae8b0d9948320aa711c354943960d