### PR TITLE
Handle QR detection failures gracefully

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -117,7 +117,13 @@ function detectarQr_safe(string $arquivo, float $scaleInicial = 1.0, bool $debug
     }
 
     // 2) se $dados vazio, então chama a tua função robusta
-    return detectarQr($arquivo, $scaleInicial, $debug, $maxTentativas);
+    try {
+        return detectarQr($arquivo, $scaleInicial, $debug, $maxTentativas);
+    } catch (Throwable $e) {
+        // log opcional e retorna null se a detecção falhar
+        error_log('detectarQr failed: ' . $e->getMessage());
+        return null;
+    }
 }
 
 

--- a/contabilidade/upload-handler.php
+++ b/contabilidade/upload-handler.php
@@ -69,7 +69,13 @@ try {
     // OCR failed; return empty text
 }
 
-$qrText = detectarQr_safe($targetPath);
+$qrText = null;
+try {
+    $qrText = detectarQr_safe($targetPath);
+} catch (Throwable $e) {
+    // Se a deteção de QR falhar, continua com qr_text = null
+    error_log('detectarQr_safe failed: ' . $e->getMessage());
+}
 
 $relativePath = 'uploads/' . $slug . '/accounting/' . $year . '/' . $month . '/' . $filename;
 


### PR DESCRIPTION
## Summary
- Safely invoke robust QR detection and return null on failure
- Keep upload handler running when QR extraction fails, returning null text

## Testing
- `php -l contabilidade/functions.php`
- `php -l contabilidade/upload-handler.php`


------
https://chatgpt.com/codex/tasks/task_e_68baf0fd93c48320b5b5ea2910c7d656