### PR TITLE
Remove invalid uploads when QR code missing or server error

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -48,8 +48,31 @@ window.addEventListener('load', function() {
                 '<a href="' + data.file + '" target="_blank" class="btn btn-sm btn-secondary">Ver PDF</a>';
             row.push(actions);
             table.row.add(row).draw();
+        } else {
+            alert('QR code não encontrado');
+            if (data.file) {
+                $.ajax({
+                    type: 'POST',
+                    url: 'contabilidade/delete-file.php',
+                    data: { file: data.file, csrf_token: csrfInput.value },
+                    dataType: 'json',
+                    success: function(res) {
+                        if (res.csrf_token) {
+                            csrfInput.value = res.csrf_token;
+                        }
+                    }
+                });
+            }
+            dz.removeFile(file);
         }
         console.log(data);
+    });
+
+    dz.on('error', function(file, errorMessage, xhr) {
+        if (xhr && xhr.status === 500) {
+            alert('Erro ao processar o ficheiro');
+            dz.removeFile(file);
+        }
     });
 
     $('#qr-table').on('click', '.delete-row', function() {


### PR DESCRIPTION
## Summary
- remove uploaded file and alert user when no QR code is detected
- drop file and notify on 500 errors during upload

## Testing
- `node --check assets/js/accounting_upload.js`


------
https://chatgpt.com/codex/tasks/task_e_68baf293d01c8320ac22d6ae624923b6