### PR TITLE
Include filename in 500 error messages

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -70,7 +70,16 @@ window.addEventListener('load', function() {
 
     dz.on('error', function(file, errorMessage, xhr) {
         if (xhr && xhr.status === 500) {
-            alert('Erro ao processar o ficheiro');
+            var msg = 'Erro ao processar o ficheiro: ' + file.name;
+            if (xhr.responseText) {
+                try {
+                    var errData = JSON.parse(xhr.responseText);
+                    if (errData.error) {
+                        msg = errData.error;
+                    }
+                } catch (e) {}
+            }
+            alert(msg);
             dz.removeFile(file);
         }
     });

--- a/contabilidade/delete-file.php
+++ b/contabilidade/delete-file.php
@@ -39,5 +39,5 @@ if ($success) {
     echo json_encode(['success' => true, 'csrf_token' => $newToken]);
 } else {
     http_response_code(500);
-    echo json_encode(['error' => 'Falha ao eliminar o ficheiro', 'csrf_token' => $newToken]);
+    echo json_encode(['error' => 'Falha ao eliminar o ficheiro ' . $file, 'csrf_token' => $newToken]);
 }

--- a/contabilidade/upload-handler.php
+++ b/contabilidade/upload-handler.php
@@ -37,7 +37,8 @@ if ($mime !== 'application/pdf') {
 $slug = getCompanySlug();
 if (!$slug) {
     http_response_code(500);
-    echo json_encode(['error' => 'Empresa não selecionada']);
+    $fileName = $_FILES['file']['name'] ?? 'desconhecido';
+    echo json_encode(['error' => 'Empresa não selecionada para o ficheiro ' . $fileName]);
     exit;
 }
 
@@ -48,7 +49,8 @@ if (!is_dir($uploadDir)) {
     if (!mkdir($uploadDir, 0755, true)) {
         error_log('Failed to create upload directory: ' . $uploadDir);
         http_response_code(500);
-        echo json_encode(['error' => 'Erro ao criar diretório de upload']);
+        $fileName = $_FILES['file']['name'] ?? 'desconhecido';
+        echo json_encode(['error' => 'Erro ao criar diretório de upload para o ficheiro ' . $fileName]);
         exit;
     }
 }
@@ -57,7 +59,8 @@ $filename = bin2hex(random_bytes(16)) . '.pdf';
 $targetPath = $uploadDir . $filename;
 if (!move_uploaded_file($_FILES['file']['tmp_name'], $targetPath)) {
     http_response_code(500);
-    echo json_encode(['error' => 'Erro ao guardar o ficheiro']);
+    $fileName = $_FILES['file']['name'] ?? 'desconhecido';
+    echo json_encode(['error' => 'Erro ao guardar o ficheiro ' . $fileName]);
     exit;
 }
 


### PR DESCRIPTION
## Summary
- Add original filename to 500 error responses during uploads and deletions
- Surface backend error message (including filename) in Dropzone error handler

## Testing
- `php -l contabilidade/upload-handler.php`
- `php -l contabilidade/delete-file.php`
- `node --check assets/js/accounting_upload.js && echo "JS syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68baf6fd928c83209d11ef5497d832ae