### PR TITLE
Shrink delete and PDF buttons for uploads

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -6480,3 +6480,10 @@ ul.notifications {
     text-align: center;
 }
 
+/* Extra small button size */
+.btn-xs {
+    padding: .125rem .25rem;
+    font-size: .75rem;
+    border-radius: .2rem;
+}
+

--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -44,8 +44,8 @@ window.addEventListener('load', function() {
                 }
                 return value;
             });
-            var actions = '<button type="button" class="btn btn-sm btn-danger delete-row" data-file="' + data.file + '">Eliminar</button> ' +
-                '<a href="' + data.file + '" target="_blank" class="btn btn-sm btn-secondary">Ver PDF</a>';
+            var actions = '<button type="button" class="btn btn-xs btn-danger delete-row" data-file="' + data.file + '">Eliminar</button> ' +
+                '<a href="' + data.file + '" target="_blank" class="btn btn-xs btn-secondary">Ver PDF</a>';
             row.push(actions);
             table.row.add(row).draw();
         } else {


### PR DESCRIPTION
## Summary
- Reduce size of delete and PDF preview buttons by switching to new `btn-xs` style
- Add `.btn-xs` CSS class for extra small padding and font size

## Testing
- `npm test` *(fails: no package.json)*
- `composer test` *(fails: command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68baf8a356c883209d92e6fccb64ba17