### PR TITLE
Handle CSRF errors on delete

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -125,6 +125,14 @@ window.addEventListener('load', function() {
                         }
                     }
                 }
+            },
+            error: function(xhr) {
+                var errData = {};
+                try { errData = JSON.parse(xhr.responseText); } catch (e) {}
+                if (errData.csrf_token && csrfInput) {
+                    csrfInput.value = errData.csrf_token;
+                }
+                alert(errData.error || 'Erro ao eliminar ficheiro');
             }
         });
     });


### PR DESCRIPTION
## Summary
- Refresh CSRF token when deleting files fails

## Testing
- `php -l contabilidade/delete-file.php`
- `php -l contabilidade/upload-handler.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb0144cc2883209fbbcd3f8ed07930