### PR TITLE
Allow regenerating CSRF tokens

### DIFF
--- a/contabilidade/delete-file.php
+++ b/contabilidade/delete-file.php
@@ -14,7 +14,7 @@ if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
     http_response_code(400);
     echo json_encode([
         'error' => 'Token CSRF inválido',
-        'csrf_token' => generateCsrfToken(),
+        'csrf_token' => generateCsrfToken(true),
     ]);
     exit;
 }

--- a/contabilidade/upload-handler.php
+++ b/contabilidade/upload-handler.php
@@ -16,7 +16,7 @@ if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
     http_response_code(400);
     echo json_encode([
         'error' => 'Token CSRF inválido',
-        'csrf_token' => generateCsrfToken(),
+        'csrf_token' => generateCsrfToken(true),
     ]);
     exit;
 }

--- a/functions.php
+++ b/functions.php
@@ -167,9 +167,9 @@ function getCompanySlug(): ?string {
  *
  * @return string
  */
-function generateCsrfToken(): string {
+function generateCsrfToken(bool $renew = false): string {
     startSession();
-    if (empty($_SESSION['csrf_token'])) {
+    if ($renew || empty($_SESSION['csrf_token'])) {
         $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
     }
     return $_SESSION['csrf_token'];


### PR DESCRIPTION
## Summary
- add `$renew` flag to `generateCsrfToken` to force token regeneration
- refresh CSRF token on accounting upload/delete failure

## Testing
- `php -l functions.php`
- `php -l contabilidade/upload-handler.php`
- `php -l contabilidade/delete-file.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb08190d688320a18748578a7bec7d