### PR TITLE
Allow regenerating CSRF tokens

### DIFF
--- a/contabilidade/delete-file.php
+++ b/contabilidade/delete-file.php
@@ -11,10 +11,11 @@ if (!isLoggedIn()) {
 }
 
 if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
+    $newToken = generateCsrfToken(true);
     http_response_code(400);
     echo json_encode([
         'error' => 'Token CSRF inválido',
-        'csrf_token' => generateCsrfToken(),
+        'csrf_token' => $newToken,
     ]);
     exit;
 }

--- a/contabilidade/upload-handler.php
+++ b/contabilidade/upload-handler.php
@@ -13,10 +13,11 @@ if (!isLoggedIn()) {
 }
 
 if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
+    $newToken = generateCsrfToken(true);
     http_response_code(400);
     echo json_encode([
         'error' => 'Token CSRF inválido',
-        'csrf_token' => generateCsrfToken(),
+        'csrf_token' => $newToken,
     ]);
     exit;
 }

--- a/functions.php
+++ b/functions.php
@@ -165,21 +165,28 @@ function getCompanySlug(): ?string {
 /**
  * Generate a CSRF token and store it in the session.
  *
+ * Tokens are single-use. Pass `$renew = true` to force generation of a
+ * new token even if one already exists (useful after a failed
+ * validation attempt).
+ *
+ * @param bool $renew Whether to force creation of a fresh token
  * @return string
  */
-function generateCsrfToken(): string {
+function generateCsrfToken(bool $renew = false): string {
     startSession();
-    if (empty($_SESSION['csrf_token'])) {
+    if ($renew || empty($_SESSION['csrf_token'])) {
         $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
     }
     return $_SESSION['csrf_token'];
 }
 
 /**
- * Validate a CSRF token against the session and invalidate it.
+ * Validate a CSRF token against the session.
  *
- * @param string $token
- * @return bool
+ * On success the stored token is cleared to enforce single-use.
+ *
+ * @param string $token Token supplied by the client
+ * @return bool True if the token matches the session value
  */
 function validateCsrfToken(string $token): bool {
     startSession();


### PR DESCRIPTION
## Summary
- document `$renew` flag on `generateCsrfToken` and clarify validation docs
- reuse regenerated CSRF tokens in accounting upload/delete failures

## Testing
- `php -l functions.php`
- `php -l contabilidade/upload-handler.php`
- `php -l contabilidade/delete-file.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb08190d688320a18748578a7bec7d