### PR TITLE
Fix CSRF token regeneration in upload handler

### DIFF
--- a/contabilidade/upload-handler.php
+++ b/contabilidade/upload-handler.php
@@ -17,7 +17,7 @@ if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
     http_response_code(400);
     echo json_encode([
         'error' => 'Token CSRF inválido',
-        'csrf_token' => generateCsrfToken(true),
+        'csrf_token' => $newToken,
     ]);
     exit;
 }


### PR DESCRIPTION
## Summary
- ensure CSRF token error response returns the regenerated token only once

## Testing
- `php -l contabilidade/upload-handler.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb0b52ea1883209996a52c0d433ce1