### PR TITLE
Corrige atualização do token CSRF após erro de upload

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -93,6 +93,14 @@ window.addEventListener('load', function() {
                     if (res.csrf_token) {
                         csrfInput.value = res.csrf_token;
                     }
+                },
+                error: function(xhr) {
+                    try {
+                        var errData = JSON.parse(xhr.responseText);
+                        if (errData.csrf_token) {
+                            csrfInput.value = errData.csrf_token;
+                        }
+                    } catch (e) {}
                 }
             });
         }


### PR DESCRIPTION
## Summary
- Refresh CSRF token even when upload handler returns an error status

## Testing
- `node --check assets/js/accounting_upload.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb0c9fa6448320a280f11ed9486094