### PR TITLE
Fix CSRF token for Dropzone uploads

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -1,3 +1,5 @@
+Dropzone.autoDiscover = false;
+
 window.addEventListener('load', function() {
     var form = document.getElementById('multi-upload');
     var csrfInput = form.querySelector('input[name="csrf_token"]');
@@ -21,6 +23,12 @@ window.addEventListener('load', function() {
         acceptedFiles: 'application/pdf',
         parallelUploads: 1,
         dictDefaultMessage: 'Arraste e solte os ficheiros aqui ou clique para selecionar'
+    });
+
+    dz.on('sending', function(file, xhr, formData) {
+        if (csrfInput) {
+            formData.append('csrf_token', csrfInput.value);
+        }
     });
 
     dz.on('success', function(file, response) {


### PR DESCRIPTION
## Summary
- disable Dropzone auto-discovery to avoid duplicate uploads
- append CSRF token to Dropzone requests

## Testing
- `node --check assets/js/accounting_upload.js`
- `php -l contabilidade/upload-handler.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb0d83ae0c8320aaa39cee23efab4a