### PR TITLE
Remove CSRF validation from accounting file endpoints

### DIFF
--- a/contabilidade/delete-file.php
+++ b/contabilidade/delete-file.php
@@ -10,16 +10,6 @@ if (!isLoggedIn()) {
     exit;
 }
 
-if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
-    $newToken = generateCsrfToken(true);
-    http_response_code(400);
-    echo json_encode([
-        'error' => 'Token CSRF inválido',
-        'csrf_token' => generateCsrfToken(true),
-    ]);
-    exit;
-}
-
 $file = $_POST['file'] ?? '';
 $slug = getCompanySlug();
 $baseDir = realpath(dirname(__DIR__) . '/uploads/' . $slug . '/accounting/');

--- a/contabilidade/upload-handler.php
+++ b/contabilidade/upload-handler.php
@@ -12,16 +12,6 @@ if (!isLoggedIn()) {
     exit;
 }
 
-if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
-    $newToken = generateCsrfToken(true);
-    http_response_code(400);
-    echo json_encode([
-        'error' => 'Token CSRF inválido',
-        'csrf_token' => $newToken,
-    ]);
-    exit;
-}
-
 $newToken = generateCsrfToken();
 
 if (!isset($_FILES['file']) || !is_uploaded_file($_FILES['file']['tmp_name'])) {


### PR DESCRIPTION
## Summary
- allow accounting file uploads without CSRF checks
- allow deleting accounting files without CSRF checks

## Testing
- `php -l contabilidade/upload-handler.php`
- `php -l contabilidade/delete-file.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb0f5a12a883208343f64a269446ab