### PR TITLE
Add import button for accounting uploads

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -3,6 +3,7 @@ Dropzone.autoDiscover = false;
 window.addEventListener('load', function() {
     var form = document.getElementById('multi-upload');
     var csrfInput = form.querySelector('input[name="csrf_token"]');
+    var importBtn = document.getElementById('import-btn');
 
     var table;
     if ($.fn.dataTable.isDataTable('#qr-table')) {
@@ -116,6 +117,12 @@ window.addEventListener('load', function() {
         dz.removeFile(file);
     });
 
+    dz.on('queuecomplete', function() {
+        if (importBtn && table.rows().data().length) {
+            importBtn.style.display = 'inline-block';
+        }
+    });
+
     $('#qr-table').on('click', '.delete-row', function() {
         if (!confirm('Eliminar ficheiro?')) {
             return;
@@ -152,6 +159,47 @@ window.addEventListener('load', function() {
             }
         });
     });
+
+    if (importBtn) {
+        importBtn.addEventListener('click', function() {
+            var rows = table.rows().data().toArray();
+            if (!rows.length) {
+                alert('Não há dados para importar');
+                return;
+            }
+            var keys = ['A','B','C','D','E','F','G','H','I1','I7','I8','N','O','Q','R'];
+            var payload = rows.map(function(row) {
+                var obj = {};
+                for (var i = 0; i < keys.length; i++) {
+                    obj[keys[i]] = row[i] || '';
+                }
+                return obj;
+            });
+            fetch('contabilidade/import.php', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ rows: payload, csrf_token: csrfInput.value })
+            })
+            .then(function(res) { return res.json(); })
+            .then(function(res) {
+                if (res.csrf_token) {
+                    csrfInput.value = res.csrf_token;
+                }
+                if (res.success) {
+                    alert('Importação concluída');
+                    importBtn.style.display = 'none';
+                    table.clear().draw();
+                } else {
+                    alert(res.error || 'Falha na importação');
+                }
+            })
+            .catch(function() {
+                alert('Falha na importação');
+            });
+        });
+    }
 
 });
 

--- a/contabilidade/import.php
+++ b/contabilidade/import.php
@@ -1,0 +1,62 @@
+<?php
+require_once __DIR__ . '/../functions.php';
+
+startSession();
+header('Content-Type: application/json');
+
+if (!isLoggedIn()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Sessão inválida']);
+    exit;
+}
+
+$raw = file_get_contents('php://input');
+$data = json_decode($raw, true);
+$newToken = generateCsrfToken();
+
+if (!is_array($data)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Dados inválidos', 'csrf_token' => $newToken]);
+    exit;
+}
+
+$token = $data['csrf_token'] ?? '';
+if (!validateCsrfToken($token)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Token CSRF inválido', 'csrf_token' => $newToken]);
+    exit;
+}
+
+$rows = $data['rows'] ?? [];
+if (!is_array($rows)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Dados inválidos', 'csrf_token' => $newToken]);
+    exit;
+}
+
+$slug = getCompanySlug();
+if (!$slug) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Empresa não selecionada', 'csrf_token' => $newToken]);
+    exit;
+}
+
+$year = date('Y');
+$month = date('m');
+$dir = dirname(__DIR__) . '/uploads/' . $slug . '/accounting/' . $year . '/' . $month . '/';
+if (!is_dir($dir) && !mkdir($dir, 0755, true)) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Erro ao criar diretório de importação', 'csrf_token' => $newToken]);
+    exit;
+}
+
+$file = $dir . 'import.json';
+$success = file_put_contents($file, json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)) !== false;
+
+if ($success) {
+    echo json_encode(['success' => true, 'csrf_token' => $newToken]);
+} else {
+    http_response_code(500);
+    echo json_encode(['error' => 'Falha ao gravar o ficheiro', 'csrf_token' => $newToken]);
+}
+

--- a/contabilidade/upload.php
+++ b/contabilidade/upload.php
@@ -8,8 +8,8 @@ $csrfToken = generateCsrfToken();
     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken); ?>">
 </form>
 
-<div id="qr-results">
-    <table id="qr-table" class="table table-striped">
+    <div id="qr-results">
+        <table id="qr-table" class="table table-striped">
         <thead>
             <tr>
 
@@ -32,8 +32,9 @@ $csrfToken = generateCsrfToken();
             </tr>
         </thead>
         <tbody></tbody>
-    </table>
-</div>
+        </table>
+        <button id="import-btn" class="btn btn-success mt-3" style="display: none;">Importar</button>
+    </div>
 
 
 


### PR DESCRIPTION
## Summary
- show hidden **Importar** button after Dropzone uploads finish
- post table rows as JSON to new import handler
- save imported rows server-side with CSRF validation

## Testing
- `php -l contabilidade/upload.php`
- `php -l contabilidade/import.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb11a5ff8c83209967eb40e7ee0148