### PR TITLE
Clear dropzone after successful import

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -191,6 +191,7 @@ window.addEventListener('load', function() {
                     alert('Importação concluída');
                     importBtn.style.display = 'none';
                     table.clear().draw();
+                    dz.removeAllFiles(true);
                 } else {
                     alert(res.error || 'Falha na importação');
                 }


### PR DESCRIPTION
## Summary
- Clear Dropzone uploads once the import completes successfully

## Testing
- `node --check assets/js/accounting_upload.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb3052ce9483208f4e50bdfbb3535d