### PR TITLE
Enable Portuguese localization for accounting DataTable

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -11,6 +11,7 @@ window.addEventListener('load', function() {
     } else {
         table = $('#qr-table').DataTable({
             orderCellsTop: true,
+            language: { url: 'vendors/datatables.net/i18n/pt-PT.json' },
             columnDefs: [
                 { targets: [ 2, 4, 7, 8, 13, 14], visible: false },
                 { targets: [0, 1], className: 'text-start' },


### PR DESCRIPTION
## Summary
- Load Portuguese language pack when initializing the QR table DataTable

## Testing
- `composer validate --no-check-publish`

------
https://chatgpt.com/codex/tasks/task_e_68bb39799fb4832091b1f2c62ce91f40