### PR TITLE
Add SAF-T upload for bank reconciliation

### DIFF
--- a/assets/js/saft_upload.js
+++ b/assets/js/saft_upload.js
@@ -1,0 +1,160 @@
+Dropzone.autoDiscover = false;
+
+window.addEventListener('load', function() {
+    var form = document.getElementById('saft-upload');
+    var csrfInput = form.querySelector('input[name="csrf_token"]');
+    var importBtn = document.getElementById('import-btn');
+
+    var table;
+    if ($.fn.dataTable.isDataTable('#saft-table')) {
+        table = $('#saft-table').DataTable();
+    } else {
+        table = $('#saft-table').DataTable({
+            language: { url: 'vendors/datatables.net/i18n/pt-PT.json' },
+            columnDefs: [
+                { targets: [3], visible: false },
+                { targets: -1, orderable: false, searchable: false }
+            ]
+        });
+    }
+
+    var dz = new Dropzone('#saft-upload', {
+        url: 'contabilidade/saft-handler.php',
+        acceptedFiles: 'text/xml,application/xml',
+        parallelUploads: 1,
+        dictDefaultMessage: 'Arraste e solte o ficheiro SAF-T aqui ou clique para selecionar'
+    });
+
+    dz.on('sending', function(file, xhr, formData) {
+        if (csrfInput) {
+            formData.append('csrf_token', csrfInput.value);
+        }
+    });
+
+    dz.on('success', function(file, response) {
+        var data = response;
+        if (typeof response === 'string') {
+            try { data = JSON.parse(response); } catch (e) { data = {}; }
+        }
+        if (data.csrf_token && csrfInput) {
+            csrfInput.value = data.csrf_token;
+        }
+        if (Array.isArray(data.transactions)) {
+            data.transactions.forEach(function(tx) {
+                var actions = '<button type="button" class="btn btn-xs btn-danger delete-row" data-file="' + data.file + '">Eliminar</button> ' +
+                    '<a href="' + data.file + '" target="_blank" class="btn btn-xs btn-secondary">Ver XML</a>';
+                table.row.add([
+                    tx.date || '',
+                    tx.description || '',
+                    tx.amount || '',
+                    data.file,
+                    actions
+                ]).draw();
+            });
+        }
+    });
+
+    dz.on('error', function(file, errorMessage, xhr) {
+        var msg = 'Erro ao processar o ficheiro ' + file.name;
+        if (xhr && xhr.responseText) {
+            try {
+                var errData = JSON.parse(xhr.responseText);
+                if (errData.error) {
+                    msg = errData.error;
+                }
+                if (errData.csrf_token && csrfInput) {
+                    csrfInput.value = errData.csrf_token;
+                }
+            } catch (e) {}
+        }
+        alert(msg);
+        dz.removeFile(file);
+    });
+
+    dz.on('queuecomplete', function() {
+        if (importBtn && table.rows().data().length) {
+            importBtn.style.display = 'inline-block';
+        }
+    });
+
+    $('#saft-table').on('click', '.delete-row', function() {
+        if (!confirm('Eliminar ficheiro?')) {
+            return;
+        }
+        var file = $(this).data('file');
+        var rows = table.rows(function(idx, data, node) {
+            return data[3] === file;
+        });
+        $.ajax({
+            type: 'POST',
+            url: 'contabilidade/saft.php?action=delete',
+            data: { file: file, csrf_token: csrfInput.value },
+            dataType: 'json',
+            success: function(res) {
+                if (res.csrf_token) {
+                    csrfInput.value = res.csrf_token;
+                }
+                if (res.success) {
+                    rows.remove().draw();
+                    var dzFiles = dz.files;
+                    for (var i = 0; i < dzFiles.length; i++) {
+                        if (dzFiles[i].serverFile === file) {
+                            dz.removeFile(dzFiles[i]);
+                            break;
+                        }
+                    }
+                }
+            },
+            error: function(xhr) {
+                var errData = {};
+                try { errData = JSON.parse(xhr.responseText); } catch (e) {}
+                if (errData.csrf_token && csrfInput) {
+                    csrfInput.value = errData.csrf_token;
+                }
+                alert(errData.error || 'Erro ao eliminar ficheiro');
+            }
+        });
+    });
+
+    if (importBtn) {
+        importBtn.addEventListener('click', function() {
+            var rows = table.rows().data().toArray();
+            if (!rows.length) {
+                alert('Não há dados para importar');
+                return;
+            }
+            var payload = rows.map(function(row) {
+                return {
+                    date: row[0] || '',
+                    description: row[1] || '',
+                    amount: row[2] || ''
+                };
+            });
+            fetch('contabilidade/saft.php?action=import', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ rows: payload, csrf_token: csrfInput.value })
+            })
+            .then(function(res) { return res.json(); })
+            .then(function(res) {
+                if (res.csrf_token) {
+                    csrfInput.value = res.csrf_token;
+                }
+                if (res.success) {
+                    alert('Importação concluída');
+                    importBtn.style.display = 'none';
+                    table.clear().draw();
+                    dz.removeAllFiles(true);
+                } else {
+                    alert(res.error || 'Falha na importação');
+                }
+            })
+            .catch(function() {
+                alert('Falha na importação');
+            });
+        });
+    }
+});
+

--- a/contabilidade/saft-handler.php
+++ b/contabilidade/saft-handler.php
@@ -1,0 +1,102 @@
+<?php
+require_once __DIR__ . '/../functions.php';
+
+startSession();
+header('Content-Type: application/json');
+
+if (!isLoggedIn()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Sessão inválida']);
+    exit;
+}
+
+$newToken = generateCsrfToken();
+
+if (!isset($_FILES['file']) || !is_uploaded_file($_FILES['file']['tmp_name'])) {
+    http_response_code(400);
+    echo json_encode([
+        'error' => 'Ficheiro não enviado',
+        'csrf_token' => $newToken,
+    ]);
+    exit;
+}
+
+$finfo = new finfo(FILEINFO_MIME_TYPE);
+$mime = $finfo->file($_FILES['file']['tmp_name']);
+if ($mime !== 'text/xml' && $mime !== 'application/xml') {
+    http_response_code(400);
+    echo json_encode([
+        'error' => 'Apenas ficheiros XML são permitidos',
+        'csrf_token' => $newToken,
+    ]);
+    exit;
+}
+
+$slug = getCompanySlug();
+if (!$slug) {
+    http_response_code(500);
+    $fileName = $_FILES['file']['name'] ?? 'desconhecido';
+    echo json_encode([
+        'error' => 'Empresa não selecionada para o ficheiro ' . $fileName,
+        'csrf_token' => $newToken,
+    ]);
+    exit;
+}
+
+$year = date('Y');
+$month = date('m');
+$uploadDir = dirname(__DIR__) . '/uploads/' . $slug . '/saft/' . $year . '/' . $month . '/';
+if (!is_dir($uploadDir)) {
+    if (!mkdir($uploadDir, 0755, true)) {
+        http_response_code(500);
+        $fileName = $_FILES['file']['name'] ?? 'desconhecido';
+        echo json_encode([
+            'error' => 'Erro ao criar diretório de upload para o ficheiro ' . $fileName,
+            'csrf_token' => $newToken,
+        ]);
+        exit;
+    }
+}
+
+$filename = bin2hex(random_bytes(16)) . '.xml';
+$targetPath = $uploadDir . $filename;
+if (!move_uploaded_file($_FILES['file']['tmp_name'], $targetPath)) {
+    http_response_code(500);
+    $fileName = $_FILES['file']['name'] ?? 'desconhecido';
+    echo json_encode([
+        'error' => 'Erro ao guardar o ficheiro ' . $fileName,
+        'csrf_token' => $newToken,
+    ]);
+    exit;
+}
+
+$transactions = [];
+try {
+    $xml = simplexml_load_file($targetPath);
+    if ($xml !== false) {
+        if (isset($xml->SourceDocuments->Payments->Payment)) {
+            foreach ($xml->SourceDocuments->Payments->Payment as $payment) {
+                $date = (string) $payment->SystemEntryDate;
+                $desc = (string) ($payment->Description ?? '');
+                $amount = (string) ($payment->DocumentTotals->PaidAmount ?? '');
+                $transactions[] = [
+                    'date' => $date,
+                    'description' => $desc,
+                    'amount' => $amount,
+                ];
+            }
+        }
+    }
+} catch (Throwable $e) {
+    // ignore parse errors
+}
+
+$relativePath = 'uploads/' . $slug . '/saft/' . $year . '/' . $month . '/' . $filename;
+
+echo json_encode([
+    'success' => true,
+    'file' => $relativePath,
+    'transactions' => $transactions,
+    'csrf_token' => $newToken,
+]);
+

--- a/contabilidade/saft.php
+++ b/contabilidade/saft.php
@@ -1,0 +1,130 @@
+<?php
+require_once __DIR__ . '/../functions.php';
+
+startSession();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    header('Content-Type: application/json');
+
+    if (!isLoggedIn()) {
+        http_response_code(403);
+        echo json_encode(['error' => 'Sessão inválida']);
+        exit;
+    }
+
+    $action = $_GET['action'] ?? $_POST['action'] ?? '';
+    $newToken = generateCsrfToken();
+
+    if ($action === 'import') {
+        $raw = file_get_contents('php://input');
+        $data = json_decode($raw, true);
+
+        if (!is_array($data)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Dados inválidos', 'csrf_token' => $newToken]);
+            exit;
+        }
+
+        $token = $data['csrf_token'] ?? '';
+        if (!validateCsrfToken($token)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Token CSRF inválido', 'csrf_token' => $newToken]);
+            exit;
+        }
+
+        $rows = $data['rows'] ?? [];
+        if (!is_array($rows)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Dados inválidos', 'csrf_token' => $newToken]);
+            exit;
+        }
+
+        $slug = getCompanySlug();
+        if (!$slug) {
+            http_response_code(500);
+            echo json_encode(['error' => 'Empresa não selecionada', 'csrf_token' => $newToken]);
+            exit;
+        }
+
+        $year = date('Y');
+        $month = date('m');
+        $dir = dirname(__DIR__) . '/uploads/' . $slug . '/saft/' . $year . '/' . $month . '/';
+        if (!is_dir($dir) && !mkdir($dir, 0755, true)) {
+            http_response_code(500);
+            echo json_encode(['error' => 'Erro ao criar diretório de importação', 'csrf_token' => $newToken]);
+            exit;
+        }
+
+        $file = $dir . 'import.json';
+        $success = file_put_contents($file, json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)) !== false;
+
+        if ($success) {
+            echo json_encode(['success' => true, 'csrf_token' => $newToken]);
+        } else {
+            http_response_code(500);
+            echo json_encode(['error' => 'Falha ao gravar o ficheiro', 'csrf_token' => $newToken]);
+        }
+
+        exit;
+    } elseif ($action === 'delete') {
+        $file = $_POST['file'] ?? '';
+        $slug = getCompanySlug();
+        $baseDir = realpath(dirname(__DIR__) . '/uploads/' . $slug . '/saft/');
+
+        if ($file === '' || !$baseDir) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Ficheiro inválido', 'csrf_token' => $newToken]);
+            exit;
+        }
+
+        $fullPath = realpath(dirname(__DIR__) . '/' . ltrim($file, '/'));
+        if ($fullPath === false || strpos($fullPath, $baseDir) !== 0) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Ficheiro inválido', 'csrf_token' => $newToken]);
+            exit;
+        }
+
+        $success = file_exists($fullPath) && unlink($fullPath);
+        if ($success) {
+            echo json_encode(['success' => true, 'csrf_token' => $newToken]);
+        } else {
+            http_response_code(500);
+            echo json_encode(['error' => 'Falha ao eliminar o ficheiro ' . $file, 'csrf_token' => $newToken]);
+        }
+
+        exit;
+    } else {
+        http_response_code(400);
+        echo json_encode(['error' => 'Ação inválida', 'csrf_token' => $newToken]);
+        exit;
+    }
+}
+
+$useDropzone = true;
+$useDataTables = true;
+$dropzoneScript = 'saft_upload.js';
+require_once __DIR__ . '/../header.php';
+$csrfToken = generateCsrfToken();
+?>
+<form id="saft-upload" class="dropzone">
+    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken); ?>">
+</form>
+
+<div id="saft-results">
+    <table id="saft-table" class="table table-striped">
+        <thead>
+            <tr>
+                <th>Data</th>
+                <th>Descrição</th>
+                <th>Valor</th>
+                <th></th>
+                <th>Ações</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+    <button id="import-btn" class="btn btn-success mt-3" style="display: none;">Importar</button>
+</div>
+
+<?php require_once __DIR__ . '/../footer.php'; ?>
+

--- a/footer.php
+++ b/footer.php
@@ -44,7 +44,11 @@
 
 <?php if ($useDropzone): ?>
 <script src="vendors/dropzone/dist/dropzone-min.js"></script>
+<?php if (!empty($dropzoneScript)): ?>
+<script src="assets/js/<?= htmlspecialchars($dropzoneScript); ?>"></script>
+<?php else: ?>
 <script src="assets/js/accounting_upload.js"></script>
+<?php endif; ?>
 <?php endif; ?>
 
 <script src="assets/js/custom.js"></script>

--- a/header.php
+++ b/header.php
@@ -97,6 +97,7 @@ foreach ($sidebarTypes as $sidebarType):
                                 <a><i class="fa fa-upload"></i> Multi Upload <span class="fa fa-chevron-down"></span></a>
                                 <ul class="nav child_menu">
                                     <li><a href="<?= BASE_URL ?>contabilidade/upload">Compras</a></li>
+                                    <li><a href="<?= BASE_URL ?>contabilidade/saft">SAF-T</a></li>
                                 </ul>
                             </li>
 <?php endif; ?>

--- a/router.php
+++ b/router.php
@@ -160,6 +160,12 @@ switch (true) {
     case $path === 'contabilidade/upload-handler.php':
         require __DIR__ . '/contabilidade/upload-handler.php';
         break;
+    case $path === 'contabilidade/saft':
+        require __DIR__ . '/contabilidade/saft.php';
+        break;
+    case $path === 'contabilidade/saft-handler.php':
+        require __DIR__ . '/contabilidade/saft-handler.php';
+        break;
     case $path === 'contabilidade/save-analysis.php':
         require __DIR__ . '/contabilidade/save-analysis.php';
         break;


### PR DESCRIPTION
## Summary
- add SAF-T submenu option and routing
- implement Dropzone-based SAF-T XML import with DataTables
- support dynamic Dropzone scripts in footer

## Testing
- `php -l header.php footer.php router.php contabilidade/saft.php contabilidade/saft-handler.php`

------
https://chatgpt.com/codex/tasks/task_e_68bb4fa30db08320903dddad6f4a3cf5