### PR TITLE
Add SAF-T upload for bank reconciliation

### DIFF
--- a/contabilidade/saft-handler.php
+++ b/contabilidade/saft-handler.php
@@ -12,6 +12,17 @@ if (!isLoggedIn()) {
 
 $newToken = generateCsrfToken();
 
+// Validate CSRF token before processing the upload
+$token = $_POST['csrf_token'] ?? '';
+if (!validateCsrfToken($token)) {
+    http_response_code(400);
+    echo json_encode([
+        'error' => 'Token CSRF inválido',
+        'csrf_token' => $newToken,
+    ]);
+    exit;
+}
+
 if (!isset($_FILES['file']) || !is_uploaded_file($_FILES['file']['tmp_name'])) {
     http_response_code(400);
     echo json_encode([

--- a/contabilidade/saft.php
+++ b/contabilidade/saft.php
@@ -67,6 +67,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         exit;
     } elseif ($action === 'delete') {
+        $token = $_POST['csrf_token'] ?? '';
+        if (!validateCsrfToken($token)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Token CSRF inválido', 'csrf_token' => $newToken]);
+            exit;
+        }
+
         $file = $_POST['file'] ?? '';
         $slug = getCompanySlug();
         $baseDir = realpath(dirname(__DIR__) . '/uploads/' . $slug . '/saft/');


### PR DESCRIPTION
## Summary
- validate CSRF token on SAF-T uploads
- enforce CSRF check before SAF-T file deletion

## Testing
- `php -l header.php footer.php router.php contabilidade/saft.php contabilidade/saft-handler.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc3a08ea848320bce3c3589ef96c89