### PR TITLE
fix: import Dict in QR detection script

### DIFF
--- a/contabilidade/detectar_qr.py
+++ b/contabilidade/detectar_qr.py
@@ -11,7 +11,7 @@ the chances of decoding less than ideal scans.
 """
 import sys
 import os
-from typing import Callable, List
+from typing import Callable, Dict, List
 
 try:
     from pdf2image import convert_from_path


### PR DESCRIPTION
## Summary
- fix NameError by importing `Dict` for QR code detection strategies

## Testing
- `python -m py_compile contabilidade/detectar_qr.py`
- `python contabilidade/detectar_qr.py`
- `python contabilidade/detectar_qr.py nonexistent.pdf`

------
https://chatgpt.com/codex/tasks/task_e_68bc4be29c6083209c67622aa38a86e0