### PR TITLE
Add mobile camera upload for accounting

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -20,6 +20,8 @@ window.addEventListener('load', function() {
         });
     }
 
+    window.accountingTable = table;
+
     var dz = new Dropzone('#multi-upload', {
         url: 'contabilidade/upload-handler.php',
         acceptedFiles: 'application/pdf',

--- a/assets/js/mobile_capture.js
+++ b/assets/js/mobile_capture.js
@@ -1,0 +1,105 @@
+// Mobile camera capture and upload
+
+document.addEventListener('DOMContentLoaded', function () {
+    var ua = navigator.userAgent || '';
+    var isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(ua);
+    if (!isMobile) {
+        return;
+    }
+
+    var cameraBtn = document.getElementById('camera-btn');
+    var fileBtn = document.getElementById('mobile-file-btn');
+    var csrfInput = document.querySelector('#multi-upload input[name="csrf_token"]');
+    var importBtn = document.getElementById('import-btn');
+    var table = window.accountingTable;
+
+    if (!cameraBtn || !fileBtn) {
+        return;
+    }
+
+    var fileInput = document.createElement('input');
+    fileInput.type = 'file';
+    fileInput.accept = 'application/pdf';
+    fileInput.style.display = 'none';
+    document.body.appendChild(fileInput);
+
+    var camInput = document.createElement('input');
+    camInput.type = 'file';
+    camInput.accept = 'image/*';
+    camInput.capture = 'environment';
+    camInput.style.display = 'none';
+    document.body.appendChild(camInput);
+
+    fileBtn.addEventListener('click', function () {
+        fileInput.click();
+    });
+
+    cameraBtn.addEventListener('click', function () {
+        camInput.click();
+    });
+
+    fileInput.addEventListener('change', function () {
+        if (fileInput.files[0]) {
+            uploadFile(fileInput.files[0]);
+            fileInput.value = '';
+        }
+    });
+
+    camInput.addEventListener('change', function () {
+        if (camInput.files[0]) {
+            uploadFile(camInput.files[0]);
+            camInput.value = '';
+        }
+    });
+
+    function uploadFile(file) {
+        var formData = new FormData();
+        formData.append('file', file);
+        if (csrfInput) {
+            formData.append('csrf_token', csrfInput.value);
+        }
+
+        fetch('contabilidade/upload-handler.php', {
+            method: 'POST',
+            body: formData
+        })
+        .then(function (res) { return res.json(); })
+        .then(function (data) {
+            if (data.csrf_token && csrfInput) {
+                csrfInput.value = data.csrf_token;
+            }
+            if (data.error) {
+                alert(data.error);
+                return;
+            }
+            if (data.qr_texts && data.qr_texts.length) {
+                var keys = ['A','B','C','D','E','F','G','H','I1','I7','I8','N','O','Q','R'];
+                data.qr_texts.forEach(function(qrText){
+                    var qrData = extractQR(qrText);
+                    var row = keys.map(function(key){
+                        var value = qrData[key] || '';
+                        if (key === 'F') {
+                            value = formatDate(value);
+                        }
+                        return value;
+                    });
+                    var actions = '<button type="button" class="btn btn-xs btn-danger delete-row" data-file="' + data.file + '">Eliminar</button> '
+                        + '<a href="' + data.file + '" target="_blank" class="btn btn-xs btn-secondary">Ver PDF</a>';
+                    row.push(actions);
+                    if (table) {
+                        table.row.add(row).draw();
+                    }
+                });
+                if (importBtn && table && table.rows().data().length) {
+                    importBtn.style.display = 'inline-block';
+                }
+            } else {
+                alert('QR code não encontrado');
+            }
+        })
+        .catch(function () {
+            alert('Erro ao enviar ficheiro');
+        });
+    }
+});
+

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "thiagoalessio/tesseract_ocr": "^2.13",
         "khanamiryan/qrcode-detector-decoder": "^2.0",
-        "smalot/pdfparser": "^2.12"
+        "smalot/pdfparser": "^2.12",
+        "setasign/fpdf": "^1.8"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b212797a21e9993a3fa4c5ae56ec618",
+    "content-hash": "041be79d55ef404a32da7df6c95db854",
     "packages": [
         {
             "name": "khanamiryan/qrcode-detector-decoder",
@@ -63,6 +63,52 @@
                 "source": "https://github.com/khanamiryan/php-qrcode-detector-decoder/tree/2.0.3"
             },
             "time": "2025-06-10T08:44:02+00:00"
+        },
+        {
+            "name": "setasign/fpdf",
+            "version": "1.8.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Setasign/FPDF.git",
+                "reference": "0838e0ee4925716fcbbc50ad9e1799b5edfae0a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Setasign/FPDF/zipball/0838e0ee4925716fcbbc50ad9e1799b5edfae0a0",
+                "reference": "0838e0ee4925716fcbbc50ad9e1799b5edfae0a0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gd": "*",
+                "ext-zlib": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "fpdf.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Olivier Plathey",
+                    "email": "oliver@fpdf.org",
+                    "homepage": "http://fpdf.org/"
+                }
+            ],
+            "description": "FPDF is a PHP class which allows to generate PDF files with pure PHP. F from FPDF stands for Free: you may use it for any kind of usage and modify it to suit your needs.",
+            "homepage": "http://www.fpdf.org",
+            "keywords": [
+                "fpdf",
+                "pdf"
+            ],
+            "support": {
+                "source": "https://github.com/Setasign/FPDF/tree/1.8.6"
+            },
+            "time": "2023-06-26T14:44:25+00:00"
         },
         {
             "name": "smalot/pdfparser",

--- a/contabilidade/upload-handler.php
+++ b/contabilidade/upload-handler.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../functions.php';
 require_once __DIR__ . '/../vendor/autoload.php';
+use setasign\FPDF\FPDF;
 //ini_set('max_execution_time', 120); set_time_limit(120);
 startSession();
 header('Content-Type: application/json');
@@ -24,10 +25,11 @@ if (!isset($_FILES['file']) || !is_uploaded_file($_FILES['file']['tmp_name'])) {
 
 $finfo = new finfo(FILEINFO_MIME_TYPE);
 $mime = $finfo->file($_FILES['file']['tmp_name']);
-if ($mime !== 'application/pdf') {
+$allowed = ['application/pdf', 'image/jpeg', 'image/png'];
+if (!in_array($mime, $allowed, true)) {
     http_response_code(400);
     echo json_encode([
-        'error' => 'Apenas ficheiros PDF são permitidos',
+        'error' => 'Tipo de ficheiro inválido',
         'csrf_token' => $newToken,
     ]);
     exit;
@@ -62,14 +64,43 @@ if (!is_dir($uploadDir)) {
 
 $filename = bin2hex(random_bytes(16)) . '.pdf';
 $targetPath = $uploadDir . $filename;
-if (!move_uploaded_file($_FILES['file']['tmp_name'], $targetPath)) {
-    http_response_code(500);
-    $fileName = $_FILES['file']['name'] ?? 'desconhecido';
-    echo json_encode([
-        'error' => 'Erro ao guardar o ficheiro ' . $fileName,
-        'csrf_token' => $newToken,
-    ]);
-    exit;
+
+if ($mime === 'application/pdf') {
+    if (!move_uploaded_file($_FILES['file']['tmp_name'], $targetPath)) {
+        http_response_code(500);
+        $fileName = $_FILES['file']['name'] ?? 'desconhecido';
+        echo json_encode([
+            'error' => 'Erro ao guardar o ficheiro ' . $fileName,
+            'csrf_token' => $newToken,
+        ]);
+        exit;
+    }
+} else {
+    $imgInfo = getimagesize($_FILES['file']['tmp_name']);
+    if ($imgInfo === false) {
+        http_response_code(400);
+        echo json_encode([
+            'error' => 'Imagem inválida',
+            'csrf_token' => $newToken,
+        ]);
+        exit;
+    }
+    $width = $imgInfo[0] * 0.264583; // px to mm
+    $height = $imgInfo[1] * 0.264583;
+    $orientation = $width > $height ? 'L' : 'P';
+    $pdf = new FPDF($orientation, 'mm', [$width, $height]);
+    $pdf->AddPage();
+    $pdf->Image($_FILES['file']['tmp_name'], 0, 0, $width, $height);
+    $pdf->Output('F', $targetPath);
+    if (!file_exists($targetPath)) {
+        http_response_code(500);
+        $fileName = $_FILES['file']['name'] ?? 'desconhecido';
+        echo json_encode([
+            'error' => 'Erro ao converter a imagem ' . $fileName,
+            'csrf_token' => $newToken,
+        ]);
+        exit;
+    }
 }
 
 $text = '';

--- a/contabilidade/upload.php
+++ b/contabilidade/upload.php
@@ -105,9 +105,14 @@ $useDataTables = true;
 require_once __DIR__ . '/../header.php';
 $csrfToken = generateCsrfToken();
 ?>
-<form id="multi-upload" class="dropzone">
+<form id="multi-upload" class="dropzone d-none d-md-block">
     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken); ?>">
 </form>
+
+<div id="mobile-upload-actions" class="d-flex gap-2 mb-3 d-md-none">
+    <button id="camera-btn" class="btn btn-secondary">Usar câmara</button>
+    <button id="mobile-file-btn" class="btn btn-primary">Selecionar PDF</button>
+</div>
 
     <div id="qr-results">
         <table id="qr-table" class="table table-striped">
@@ -137,7 +142,6 @@ $csrfToken = generateCsrfToken();
         <button id="import-btn" class="btn btn-success mt-3" style="display: none;">Importar</button>
     </div>
 
-
-
+<script src="assets/js/mobile_capture.js"></script>
 
 <?php require_once __DIR__ . '/../footer.php'; ?>


### PR DESCRIPTION
## Summary
- Show camera and upload buttons on mobile accounting upload page
- Add JS handler for mobile capture and upload
- Allow upload-handler to accept images and convert to PDF

## Testing
- `php -l contabilidade/upload-handler.php`
- `php -l contabilidade/upload.php`
- `node --check assets/js/mobile_capture.js`
- `node --check assets/js/accounting_upload.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc54dbbac88320a8380b9dc9d6d1d0