### PR TITLE
Fix CSRF token renewal in classification endpoint

### DIFF
--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -11,12 +11,11 @@ if (!isLoggedIn()) {
 }
 
 $action = $_GET['action'] ?? $_POST['action'] ?? '';
-$newToken = generateCsrfToken();
 
 $slug = getCompanySlug();
 if (!$slug) {
     http_response_code(400);
-    echo json_encode(['error' => 'Empresa não selecionada', 'csrf_token' => $newToken]);
+    echo json_encode(['error' => 'Empresa não selecionada', 'csrf_token' => generateCsrfToken(true)]);
     exit;
 }
 
@@ -24,7 +23,7 @@ if ($action === 'get') {
     $token = $_GET['csrf_token'] ?? '';
     if (!validateCsrfToken($token)) {
         http_response_code(400);
-        echo json_encode(['error' => 'Token CSRF inválido', 'csrf_token' => $newToken]);
+        echo json_encode(['error' => 'Token CSRF inválido', 'csrf_token' => generateCsrfToken(true)]);
         exit;
     }
     $a = $_GET['A'] ?? '';
@@ -34,13 +33,13 @@ if ($action === 'get') {
     $stmt = $pdo->prepare('SELECT account FROM accounting_classifications WHERE company_slug = ? AND emitter = ? AND acquirer = ? AND doc_type = ? LIMIT 1');
     $stmt->execute([$slug, $a, $b, $d]);
     $account = $stmt->fetchColumn() ?: '';
-    echo json_encode(['account' => $account, 'csrf_token' => $newToken]);
+    echo json_encode(['account' => $account, 'csrf_token' => generateCsrfToken()]);
     exit;
 } elseif ($action === 'save') {
     $token = $_POST['csrf_token'] ?? '';
     if (!validateCsrfToken($token)) {
         http_response_code(400);
-        echo json_encode(['error' => 'Token CSRF inválido', 'csrf_token' => $newToken]);
+        echo json_encode(['error' => 'Token CSRF inválido', 'csrf_token' => generateCsrfToken(true)]);
         exit;
     }
     $a = $_POST['A'] ?? '';
@@ -50,10 +49,10 @@ if ($action === 'get') {
     $pdo = getPDO();
     $stmt = $pdo->prepare('INSERT INTO accounting_classifications (company_slug, emitter, acquirer, doc_type, account) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE account = VALUES(account)');
     $stmt->execute([$slug, $a, $b, $d, $account]);
-    echo json_encode(['success' => true, 'csrf_token' => $newToken]);
+    echo json_encode(['success' => true, 'csrf_token' => generateCsrfToken()]);
     exit;
 } else {
     http_response_code(400);
-    echo json_encode(['error' => 'Ação inválida', 'csrf_token' => $newToken]);
+    echo json_encode(['error' => 'Ação inválida', 'csrf_token' => generateCsrfToken()]);
     exit;
 }


### PR DESCRIPTION
## Summary
- regenerate CSRF token for each response in classification endpoint
- ensure invalid token errors return a fresh token

## Testing
- `php -l contabilidade/save-analysis.php`

------
https://chatgpt.com/codex/tasks/task_e_68bd9abc0a108320a92f09947716bad9