### PR TITLE
Sync classification import accounts

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -10,36 +10,18 @@ window.addEventListener('load', function() {
         ]
     });
 
-    function checkClassification(emitter, acquirer, docType, btn) {
-        var params = new URLSearchParams({
-            action: 'get',
-            A: emitter,
-            B: acquirer,
-            D: docType,
-            csrf_token: csrfInput.value
-        });
-        fetch('contabilidade/save-analysis.php?' + params.toString())
-            .then(function(res) { return res.json(); })
-            .then(function(res) {
-                if (res.csrf_token) {
-                    csrfInput.value = res.csrf_token;
-                }
-                if (res.account) {
-                    btn.classList.remove('btn-warning');
-                    btn.classList.add('btn-success');
-                } else {
-                    btn.classList.remove('btn-success');
-                    btn.classList.add('btn-warning');
-                }
-            });
+    function updateButtonClass(btn) {
+        if (btn.getAttribute('data-account')) {
+            btn.classList.remove('btn-warning');
+            btn.classList.add('btn-success');
+        } else {
+            btn.classList.remove('btn-success');
+            btn.classList.add('btn-warning');
+        }
     }
 
     $('#classify-table').find('.classify-row').each(function() {
-        var btn = this;
-        var emitter = btn.getAttribute('data-emitter');
-        var acquirer = btn.getAttribute('data-acquirer');
-        var docType = btn.getAttribute('data-doctype');
-        checkClassification(emitter, acquirer, docType, btn);
+        updateButtonClass(this);
     });
 
     $('#classify-table').on('click', '.classify-row', function() {
@@ -47,6 +29,7 @@ window.addEventListener('load', function() {
         var emitter = btn.getAttribute('data-emitter');
         var acquirer = btn.getAttribute('data-acquirer');
         var docType = btn.getAttribute('data-doctype');
+        var current = btn.getAttribute('data-account') || '';
         var params = new URLSearchParams({
             action: 'get',
             A: emitter,
@@ -60,10 +43,13 @@ window.addEventListener('load', function() {
                 if (res.csrf_token) {
                     csrfInput.value = res.csrf_token;
                 }
-                var current = res.account || '';
+                if (!current) {
+                    current = res.account || '';
+                }
                 var account = prompt('N\u00ba conta:', current);
                 if (account !== null) {
                     var body = new URLSearchParams({
+                        id: btn.getAttribute('data-id'),
                         A: emitter,
                         B: acquirer,
                         D: docType,
@@ -81,7 +67,8 @@ window.addEventListener('load', function() {
                             csrfInput.value = res.csrf_token;
                         }
                         if (res.success) {
-                            checkClassification(emitter, acquirer, docType, btn);
+                            btn.setAttribute('data-account', account);
+                            updateButtonClass(btn);
                         } else {
                             alert(res.error || 'Erro ao guardar');
                         }

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -57,7 +57,8 @@ require_once __DIR__ . '/../header.php';
                     <td><?= htmlspecialchars($row['field_Q']); ?></td>
                     <td><?= htmlspecialchars($row['field_R']); ?></td>
                     <td><a href="<?= htmlspecialchars($row['filename']); ?>" target="_blank" class="btn btn-xs btn-secondary">Ver PDF</a></td>
-                    <td><button type="button" class="btn btn-xs btn-warning classify-row" data-emitter="<?= htmlspecialchars($row['field_A']); ?>" data-acquirer="<?= htmlspecialchars($row['field_B']); ?>" data-doctype="<?= htmlspecialchars($row['field_D']); ?>">Classificar</button></td>
+                    <?php $btnClass = $row['account'] ? 'btn-success' : 'btn-warning'; ?>
+                    <td><button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-account="<?= htmlspecialchars($row['account']); ?>" data-emitter="<?= htmlspecialchars($row['field_A']); ?>" data-acquirer="<?= htmlspecialchars($row['field_B']); ?>" data-doctype="<?= htmlspecialchars($row['field_D']); ?>">Classificar</button></td>
                 </tr>
             <?php endforeach; ?>
             </tbody>

--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -35,14 +35,25 @@ if ($action === 'get') {
         echo json_encode(['error' => 'Token CSRF inválido', 'csrf_token' => generateCsrfToken(true)]);
         exit;
     }
+    $id = $_POST['id'] ?? '';
     $a = $_POST['A'] ?? '';
     $b = $_POST['B'] ?? '';
     $d = $_POST['D'] ?? '';
     $account = $_POST['account'] ?? '';
     $pdo = getPDO();
-    $stmt = $pdo->prepare('INSERT INTO accounting_classifications (emitter, acquirer, doc_type, account) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE account = VALUES(account)');
-    $stmt->execute([$a, $b, $d, $account]);
-    echo json_encode(['success' => true, 'csrf_token' => generateCsrfToken()]);
+    try {
+        $pdo->beginTransaction();
+        $stmt = $pdo->prepare('UPDATE accounting_imports SET account = ? WHERE id = ?');
+        $stmt->execute([$account, $id]);
+        $stmt2 = $pdo->prepare('INSERT INTO accounting_classifications (emitter, acquirer, doc_type, account) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE account = VALUES(account)');
+        $stmt2->execute([$a, $b, $d, $account]);
+        $pdo->commit();
+        echo json_encode(['success' => true, 'csrf_token' => generateCsrfToken()]);
+    } catch (Exception $e) {
+        $pdo->rollBack();
+        http_response_code(500);
+        echo json_encode(['error' => 'Erro ao guardar', 'csrf_token' => generateCsrfToken()]);
+    }
     exit;
 } else {
     http_response_code(400);


### PR DESCRIPTION
## Summary
- mark classify button green only when accounting import has an account
- update both accounting_imports and accounting_classifications on save
- keep button state in sync on the client

## Testing
- `php -l contabilidade/classificacao-importacao.php`
- `php -l contabilidade/save-analysis.php`
- `node --check assets/js/classificacao_importacao.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdadb613488320bb269ab18c324fe4