### PR TITLE
Add remove option for accounting imports

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -74,7 +74,34 @@ window.addEventListener('load', function() {
                         }
                     });
                 }
-            });
+        });
+    });
+
+    $('#classify-table').on('click', '.remove-row', function() {
+        var btn = this;
+        if (!confirm('Remover este registo?')) {
+            return;
+        }
+        var body = new URLSearchParams({
+            id: btn.getAttribute('data-id'),
+            csrf_token: csrfInput.value
+        });
+        fetch('contabilidade/save-analysis.php?action=remove', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString()
+        })
+        .then(function(res) { return res.json(); })
+        .then(function(res) {
+            if (res.csrf_token) {
+                csrfInput.value = res.csrf_token;
+            }
+            if (res.success) {
+                table.row($(btn).closest('tr')).remove().draw();
+            } else {
+                alert(res.error || 'Erro ao remover');
+            }
+        });
     });
 });
 

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -58,7 +58,10 @@ require_once __DIR__ . '/../header.php';
                     <td><?= htmlspecialchars($row['field_R']); ?></td>
                     <td><a href="<?= htmlspecialchars($row['filename']); ?>" target="_blank" class="btn btn-xs btn-secondary">Ver PDF</a></td>
                     <?php $btnClass = $row['account'] ? 'btn-success' : 'btn-warning'; ?>
-                    <td><button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-account="<?= htmlspecialchars($row['account']); ?>" data-emitter="<?= htmlspecialchars($row['field_A']); ?>" data-acquirer="<?= htmlspecialchars($row['field_B']); ?>" data-doctype="<?= htmlspecialchars($row['field_D']); ?>">Classificar</button></td>
+                    <td>
+                        <button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-account="<?= htmlspecialchars($row['account']); ?>" data-emitter="<?= htmlspecialchars($row['field_A']); ?>" data-acquirer="<?= htmlspecialchars($row['field_B']); ?>" data-doctype="<?= htmlspecialchars($row['field_D']); ?>">Classificar</button>
+                        <button type="button" class="btn btn-xs btn-danger remove-row" data-id="<?= (int)$row['id']; ?>">Remover</button>
+                    </td>
                 </tr>
             <?php endforeach; ?>
             </tbody>

--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -55,6 +55,24 @@ if ($action === 'get') {
         echo json_encode(['error' => 'Erro ao guardar', 'csrf_token' => generateCsrfToken()]);
     }
     exit;
+} elseif ($action === 'remove') {
+    $token = $_POST['csrf_token'] ?? '';
+    if (!validateCsrfToken($token)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Token CSRF inválido', 'csrf_token' => generateCsrfToken(true)]);
+        exit;
+    }
+    $id = $_POST['id'] ?? '';
+    $pdo = getPDO();
+    try {
+        $stmt = $pdo->prepare('DELETE FROM accounting_imports WHERE id = ?');
+        $stmt->execute([$id]);
+        echo json_encode(['success' => true, 'csrf_token' => generateCsrfToken()]);
+    } catch (Exception $e) {
+        http_response_code(500);
+        echo json_encode(['error' => 'Erro ao remover', 'csrf_token' => generateCsrfToken()]);
+    }
+    exit;
 } else {
     http_response_code(400);
     echo json_encode(['error' => 'Ação inválida', 'csrf_token' => generateCsrfToken()]);


### PR DESCRIPTION
## Summary
- add 'Remover' button beside 'Classificar' to manage import rows
- handle delete action in `save-analysis.php` without removing PDFs
- wire up frontend JS to call new remove endpoint and update table

## Testing
- `php -l contabilidade/classificacao-importacao.php`
- `php -l contabilidade/save-analysis.php`
- `node --check assets/js/classificacao_importacao.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdb267a9788320995f1a0c4c5534d7