### PR TITLE
feat: add OCR line analysis link

### DIFF
--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -60,6 +60,7 @@ require_once __DIR__ . '/../header.php';
                     <?php $btnClass = $row['account'] ? 'btn-success' : 'btn-warning'; ?>
                     <td>
                         <button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-account="<?= htmlspecialchars($row['account']); ?>" data-emitter="<?= htmlspecialchars($row['field_A']); ?>" data-acquirer="<?= htmlspecialchars($row['field_B']); ?>" data-doctype="<?= htmlspecialchars($row['field_D']); ?>">Classificar</button>
+                        <a href="save-analysis.php?action=lines&id=<?= (int)$row['id']; ?>" class="btn btn-xs btn-info" target="_blank">Analisar</a>
                         <button type="button" class="btn btn-xs btn-danger remove-row" data-id="<?= (int)$row['id']; ?>">Remover</button>
                     </td>
                 </tr>

--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -1,7 +1,53 @@
 <?php
 require_once __DIR__ . '/../functions.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 startSession();
+
+$action = $_GET['action'] ?? $_POST['action'] ?? '';
+
+if ($action === 'lines') {
+    if (!isLoggedIn()) {
+        http_response_code(403);
+        exit;
+    }
+    $id = $_GET['id'] ?? '';
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('SELECT id, filename FROM accounting_imports WHERE id = ?');
+    $stmt->execute([$id]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (! $row) {
+        http_response_code(404);
+        exit;
+    }
+    header('Content-Type: text/csv');
+    header('Content-Disposition: attachment; filename="ocr_lines_' . $row['id'] . '.csv"');
+    $output = fopen('php://output', 'w');
+    fputcsv($output, ['id', 'filename', 'line_number', 'text']);
+    $path = dirname(__DIR__) . '/' . $row['filename'];
+    $ocr = new thiagoalessio\TesseractOCR\TesseractOCR($path);
+    $text = $ocr->run();
+    $lines = explode(PHP_EOL, $text);
+    $inTable = false;
+    foreach ($lines as $i => $line) {
+        if (! $inTable) {
+            if (stripos($line, 'Descrição') !== false
+                && stripos($line, 'Unidade') !== false
+                && stripos($line, 'Taxa') !== false) {
+                $inTable = true;
+            }
+            continue;
+        }
+        if (stripos($line, 'Subtotal') !== false) {
+            $inTable = false;
+            continue;
+        }
+        fputcsv($output, [$row['id'], $row['filename'], $i + 1, $line]);
+    }
+    fclose($output);
+    exit;
+}
+
 header('Content-Type: application/json');
 
 if (!isLoggedIn()) {
@@ -9,8 +55,6 @@ if (!isLoggedIn()) {
     echo json_encode(['error' => 'Sessão inválida']);
     exit;
 }
-
-$action = $_GET['action'] ?? $_POST['action'] ?? '';
 
 if ($action === 'get') {
     $token = $_GET['csrf_token'] ?? '';


### PR DESCRIPTION
## Summary
- integrate OCR article-line export into save-analysis endpoint
- add "Analisar" button next to classification action for each import
- drop standalone export-ocr script

## Testing
- `php -l contabilidade/classificacao-importacao.php`
- `php -l contabilidade/save-analysis.php`


------
https://chatgpt.com/codex/tasks/task_e_68bea7172a688320aec4df4362a92882