### PR TITLE
Integrate invoice parsing into save-analysis workflow

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -1,0 +1,58 @@
+<?php
+
+use thiagoalessio\TesseractOCR\TesseractOCR;
+
+/**
+ * Parse an invoice line from a text string produced by OCR.
+ *
+ * @param string $text OCR text for a single invoice line.
+ * @return array Associative array with extracted fields.
+ * @throws RuntimeException If the text does not contain the expected columns.
+ */
+function parseInvoiceLineText(string $text): array {
+    $text = trim(preg_replace('/\s+/', ' ', $text));
+    $tokens = explode(' ', $text);
+    if (count($tokens) < 10) {
+        throw new RuntimeException('Unexpected OCR output: ' . $text);
+    }
+    // Extract trailing numeric columns
+    $imposto = array_pop($tokens);
+    $valorLiquido = array_pop($tokens);
+    $descontoValor = array_pop($tokens);
+    $percentDesc = array_pop($tokens);
+    $precoUnitario = array_pop($tokens);
+    $unidade = array_pop($tokens);
+    $quantidade = array_pop($tokens);
+    // Remaining tokens contain arm, product code and description
+    $arm = array_shift($tokens);
+    $codigo = array_shift($tokens);
+    $descricao = implode(' ', $tokens);
+    $toFloat = fn(string $value): float => (float) str_replace(',', '.', $value);
+    return [
+        'arm' => (int) $arm,
+        'codigo_artigo' => $codigo,
+        'descricao' => $descricao,
+        'quantidade' => $toFloat($quantidade),
+        'unidade' => $unidade,
+        'preco_unitario' => $toFloat($precoUnitario),
+        'percentagem_desconto' => $toFloat($percentDesc),
+        'desconto_valor' => $toFloat($descontoValor),
+        'valor_liquido' => $toFloat($valorLiquido),
+        'imposto' => $toFloat($imposto),
+    ];
+}
+
+/**
+ * Parse an invoice line directly from an image by running OCR.
+ *
+ * @param string $imagePath Path to the image file containing a single line.
+ * @return array Parsed invoice line data.
+ */
+function parseInvoiceLineImage(string $imagePath): array {
+    $text = (new TesseractOCR($imagePath))
+        ->lang('por')
+        ->run();
+    return parseInvoiceLineText($text);
+}
+
+?>

--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../functions.php';
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/functions.php';
 
 startSession();
 
@@ -125,6 +126,22 @@ if ($action === 'get') {
         $pdo->rollBack();
         http_response_code(500);
         echo json_encode(['error' => 'Erro ao guardar', 'csrf_token' => generateCsrfToken()]);
+    }
+    exit;
+} elseif ($action === 'parse-line') {
+    $token = $_POST['csrf_token'] ?? '';
+    if (!validateCsrfToken($token)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Token CSRF inválido', 'csrf_token' => generateCsrfToken(true)]);
+        exit;
+    }
+    $text = $_POST['text'] ?? '';
+    try {
+        $fields = parseInvoiceLineText($text);
+        echo json_encode(['fields' => $fields, 'csrf_token' => generateCsrfToken()]);
+    } catch (Exception $e) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Linha inválida', 'csrf_token' => generateCsrfToken()]);
     }
     exit;
 } elseif ($action === 'remove') {


### PR DESCRIPTION
## Summary
- remove `InvoiceParser` class and CLI script in favor of functional helpers
- add `contabilidade/functions.php` with `parseInvoiceLineText` and `parseInvoiceLineImage`
- wire `contabilidade/save-analysis.php` to use new helpers via a `parse-line` action

## Testing
- `php -l contabilidade/functions.php`
- `php -l contabilidade/save-analysis.php`
- `composer dump-autoload`


------
https://chatgpt.com/codex/tasks/task_e_68beb825925483209b43c201299608c8