### PR TITLE
Filter non-item lines from OCR export

### DIFF
--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -71,6 +71,13 @@ if ($action === 'lines') {
             $inTable = false;
             continue;
         }
+        if (trim($line) === '') {
+            continue;
+        }
+        $tokens = preg_split('/\s+/', trim($line));
+        if (count($tokens) < 10) {
+            continue;
+        }
         fputcsv($output, [$row['id'], $row['filename'], $i + 1, $line]);
     }
     fclose($output);


### PR DESCRIPTION
## Summary
- ignore blank lines when exporting OCR analysis
- skip lines with too few tokens to reduce non-item noise

## Testing
- `php -l contabilidade/save-analysis.php`


------
https://chatgpt.com/codex/tasks/task_e_68bebb61fe80832097288c259046d006