### PR TITLE
Parse invoice lines in CSV export

### DIFF
--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -29,7 +29,7 @@ if ($action === 'lines') {
     header('Content-Type: text/csv');
     header('Content-Disposition: attachment; filename="ocr_lines_' . $row['id'] . '.csv"');
     $output = fopen('php://output', 'w');
-    fputcsv($output, ['id', 'filename', 'line_number', 'text']);
+    fputcsv($output, ['id', 'filename', 'line_number', 'text', 'arm', 'codigo_artigo', 'descricao', 'quantidade', 'unidade', 'preco_unitario', 'percentagem_desconto', 'desconto_valor', 'valor_liquido', 'imposto']);
     $path = dirname(__DIR__) . '/' . $row['filename'];
     $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
     $text = '';
@@ -71,7 +71,38 @@ if ($action === 'lines') {
             $inTable = false;
             continue;
         }
-        fputcsv($output, [$row['id'], $row['filename'], $i + 1, $line]);
+        try {
+            $fields = parseInvoiceLineText($line);
+        } catch (RuntimeException $e) {
+            $fields = [
+                'arm' => '',
+                'codigo_artigo' => '',
+                'descricao' => '',
+                'quantidade' => '',
+                'unidade' => '',
+                'preco_unitario' => '',
+                'percentagem_desconto' => '',
+                'desconto_valor' => '',
+                'valor_liquido' => '',
+                'imposto' => '',
+            ];
+        }
+        fputcsv($output, [
+            $row['id'],
+            $row['filename'],
+            $i + 1,
+            $line,
+            $fields['arm'],
+            $fields['codigo_artigo'],
+            $fields['descricao'],
+            $fields['quantidade'],
+            $fields['unidade'],
+            $fields['preco_unitario'],
+            $fields['percentagem_desconto'],
+            $fields['desconto_valor'],
+            $fields['valor_liquido'],
+            $fields['imposto'],
+        ]);
     }
     fclose($output);
     exit;


### PR DESCRIPTION
## Summary
- parse each OCR line with `parseInvoiceLineText` when exporting lines
- include parsed fields in CSV output

## Testing
- `php -l contabilidade/save-analysis.php`


------
https://chatgpt.com/codex/tasks/task_e_68bebbcf7c988320b797ee5739433bf9