### PR TITLE
Parse invoice lines during analysis export

### DIFF
--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -79,7 +79,29 @@ if ($action === 'lines') {
         if (count($tokens) < 10) {
             continue;
         }
-        fputcsv($output, [$row['id'], $row['filename'], $i + 1, $line]);
+        try {
+            $fields = parseInvoiceLineText($line);
+        } catch (RuntimeException $e) {
+            $fields = [
+                'arm' => '',
+                'codigo_artigo' => '',
+                'descricao' => '',
+                'quantidade' => '',
+                'unidade' => '',
+                'preco_unitario' => '',
+                'percentagem_desconto' => '',
+                'desconto_valor' => '',
+                'valor_liquido' => '',
+                'imposto' => '',
+            ];
+        }
+        fputcsv(
+            $output,
+            array_merge(
+                [$row['id'], $row['filename'], $i + 1, $line],
+                array_values($fields)
+            )
+        );
     }
     fclose($output);
     exit;
@@ -134,22 +156,6 @@ if ($action === 'get') {
         $pdo->rollBack();
         http_response_code(500);
         echo json_encode(['error' => 'Erro ao guardar', 'csrf_token' => generateCsrfToken()]);
-    }
-    exit;
-} elseif ($action === 'parse-line') {
-    $token = $_POST['csrf_token'] ?? '';
-    if (!validateCsrfToken($token)) {
-        http_response_code(400);
-        echo json_encode(['error' => 'Token CSRF inválido', 'csrf_token' => generateCsrfToken(true)]);
-        exit;
-    }
-    $text = $_POST['text'] ?? '';
-    try {
-        $fields = parseInvoiceLineText($text);
-        echo json_encode(['fields' => $fields, 'csrf_token' => generateCsrfToken()]);
-    } catch (Exception $e) {
-        http_response_code(400);
-        echo json_encode(['error' => 'Linha inválida', 'csrf_token' => generateCsrfToken()]);
     }
     exit;
 } elseif ($action === 'remove') {


### PR DESCRIPTION
## Summary
- Parse each OCR line with `parseInvoiceLineText` when exporting invoice lines
- Drop unused `parse-line` API action

## Testing
- `php -l contabilidade/save-analysis.php`
- `php -l contabilidade/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bebd9f9ee4832091ffcdf51a0b39b7