### PR TITLE
Relax OCR line detection

### DIFF
--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -68,8 +68,14 @@ if ($action === 'lines') {
                 || strpos($norm, 'unidade') !== false
                 || strpos($norm, 'taxa') !== false) {
                 $inTable = true;
+                continue;
             }
-            continue;
+            $tokens = preg_split('/\s+/', trim($line));
+            if (count($tokens) >= 3 && preg_match('/\d/', $line)) {
+                $inTable = true;
+            } else {
+                continue;
+            }
         }
         if (strpos($normalize($line), 'mercadoria') !== false) {
             $inTable = false;
@@ -80,7 +86,7 @@ if ($action === 'lines') {
             continue;
         }
         $tokens = preg_split('/\s+/', trim($line));
-        if (count($tokens) < 5) {
+        if (count($tokens) < 3) {
             continue;
         }
         try {


### PR DESCRIPTION
## Summary
- Make invoice OCR line detection less strict by starting table processing when a line has digits and at least three tokens.
- Reduce minimum token requirement from five to three when writing CSV lines.

## Testing
- `php -l contabilidade/save-analysis.php`


------
https://chatgpt.com/codex/tasks/task_e_68bec421260c8320a93ef357aaee5210