### PR TITLE
Deduplicate OCR invoice line extraction

### DIFF
--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -61,6 +61,7 @@ if ($action === 'lines') {
     $normalize = static function (string $str): string {
         return strtolower(iconv('UTF-8', 'ASCII//TRANSLIT', $str));
     };
+    $unique = [];
     foreach ($lines as $i => $line) {
         if (! $inTable) {
             $norm = $normalize($line);
@@ -105,6 +106,13 @@ if ($action === 'lines') {
                 'imposto' => '',
             ];
         }
+
+        $key = trim($normalize($line));
+        if (isset($unique[$key])) {
+            continue;
+        }
+        $unique[$key] = true;
+
         fputcsv(
             $output,
             array_merge(


### PR DESCRIPTION
## Summary
- avoid repeating invoice lines when exporting OCR results by tracking normalized line text

## Testing
- `php -l contabilidade/save-analysis.php`
- `php -l contabilidade/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bec53015ac8320a749b240fcbdcfa0