### PR TITLE
Disable sorting for tax columns in accounting tables

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -15,6 +15,7 @@ window.addEventListener('load', function() {
             columnDefs: [
                 { targets: [ 2, 4, 7, 8, 17, 18], visible: false },
                 { targets: [0, 1], className: 'text-start' },
+                { targets: [9, 10, 11, 12, 13, 14, 15, 16], orderable: false },
                 { targets: [ -1 ], orderable: false, searchable: false }
             ]
         });

--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -6,6 +6,7 @@ window.addEventListener('load', function() {
         columnDefs: [
             { targets: [ 2, 4, 7, 8, 17, 18 ], visible: false },
             { targets: [0, 1], className: 'text-start' },
+            { targets: [9, 10, 11, 12, 13, 14, 15, 16], orderable: false },
             { targets: [ -1, -2 ], orderable: false, searchable: false }
         ]
     });


### PR DESCRIPTION
## Summary
- prevent ordering on tax-related columns in accounting upload table
- disable sorting for tax-related columns in classification table

## Testing
- `node --check assets/js/accounting_upload.js`
- `node --check assets/js/classificacao_importacao.js`
- `composer validate`

------
https://chatgpt.com/codex/tasks/task_e_68c0337424ac83209fc88854a5abb36c