### PR TITLE
Handle missing transaction rollback in save-analysis

### DIFF
--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -204,7 +204,9 @@ if ($action === 'get') {
         $pdo->commit();
         echo json_encode(['success' => true, 'csrf_token' => generateCsrfToken()]);
     } catch (Exception $e) {
-        $pdo->rollBack();
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
         http_response_code(500);
         echo json_encode(['error' => 'Erro ao guardar', 'csrf_token' => generateCsrfToken()]);
     }


### PR DESCRIPTION
## Summary
- prevent unhandled PDO exceptions when saving analysis fails by verifying transaction before rollback

## Testing
- `php -l contabilidade/save-analysis.php`


------
https://chatgpt.com/codex/tasks/task_e_68c057f7ddfc83208973cca1f2ba9321