### PR TITLE
Refine VAT classification button color

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -15,8 +15,13 @@ window.addEventListener('load', function() {
         var iva6 = parseInt(btn.getAttribute('data-iva6')) || 0;
         var iva13 = parseInt(btn.getAttribute('data-iva13')) || 0;
         var iva23 = parseInt(btn.getAttribute('data-iva23')) || 0;
-        var novat = parseInt(btn.getAttribute('data-novat')) || 0;
-        var allFilled = iva6 > 0 && iva13 > 0 && iva23 > 0 && novat > 0;
+        var needIva6 = btn.getAttribute('data-req-iva6') === '1';
+        var needIva13 = btn.getAttribute('data-req-iva13') === '1';
+        var needIva23 = btn.getAttribute('data-req-iva23') === '1';
+        var allFilled = true;
+        if (needIva6) { allFilled = allFilled && iva6 > 0; }
+        if (needIva13) { allFilled = allFilled && iva13 > 0; }
+        if (needIva23) { allFilled = allFilled && iva23 > 0; }
         btn.classList.toggle('btn-success', allFilled);
         btn.classList.toggle('btn-warning', !allFilled);
     }

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -66,16 +66,18 @@ require_once __DIR__ . '/../header.php';
                     <td><?= htmlspecialchars($row['field_R'] ?? ''); ?></td>
                     <td class="text-center"><a href="<?= htmlspecialchars($row['filename'] ?? ''); ?>" target="_blank" class="btn btn-xs btn-secondary"><i class="fa fa-file-pdf-o"></i></a></td>
                     <?php
+                        $hasIva6 = (float)($row['field_I1'] ?? 0) > 0 || (float)($row['field_I3'] ?? 0) > 0;
+                        $hasIva13 = (float)($row['field_I4'] ?? 0) > 0 || (float)($row['field_I5'] ?? 0) > 0;
+                        $hasIva23 = (float)($row['field_I6'] ?? 0) > 0 || (float)($row['field_I7'] ?? 0) > 0;
                         $allAccounts = (
-                            (int)($row['account_iva6'] ?? 0) > 0 &&
-                            (int)($row['account_iva13'] ?? 0) > 0 &&
-                            (int)($row['account_iva23'] ?? 0) > 0 &&
-                            (int)($row['account_novat'] ?? 0) > 0
+                            (!$hasIva6 || (int)($row['account_iva6'] ?? 0) > 0) &&
+                            (!$hasIva13 || (int)($row['account_iva13'] ?? 0) > 0) &&
+                            (!$hasIva23 || (int)($row['account_iva23'] ?? 0) > 0)
                         );
                         $btnClass = $allAccounts ? 'btn-success' : 'btn-warning';
                     ?>
                     <td class="text-center">
-                        <button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-iva6="<?= htmlspecialchars($row['account_iva6'] ?? ''); ?>" data-iva13="<?= htmlspecialchars($row['account_iva13'] ?? ''); ?>" data-iva23="<?= htmlspecialchars($row['account_iva23'] ?? ''); ?>" data-novat="<?= htmlspecialchars($row['account_novat'] ?? ''); ?>" data-emitter="<?= htmlspecialchars($row['field_A'] ?? ''); ?>" data-acquirer="<?= htmlspecialchars($row['field_B'] ?? ''); ?>" data-doctype="<?= htmlspecialchars($row['field_D'] ?? ''); ?>">Classificar</button>
+                        <button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-iva6="<?= htmlspecialchars($row['account_iva6'] ?? ''); ?>" data-iva13="<?= htmlspecialchars($row['account_iva13'] ?? ''); ?>" data-iva23="<?= htmlspecialchars($row['account_iva23'] ?? ''); ?>" data-novat="<?= htmlspecialchars($row['account_novat'] ?? ''); ?>" data-req-iva6="<?= $hasIva6 ? 1 : 0; ?>" data-req-iva13="<?= $hasIva13 ? 1 : 0; ?>" data-req-iva23="<?= $hasIva23 ? 1 : 0; ?>" data-emitter="<?= htmlspecialchars($row['field_A'] ?? ''); ?>" data-acquirer="<?= htmlspecialchars($row['field_B'] ?? ''); ?>" data-doctype="<?= htmlspecialchars($row['field_D'] ?? ''); ?>">Classificar</button>
                         <a href="contabilidade/save-analysis.php?action=lines&id=<?= (int)$row['id']; ?>" class="btn btn-xs btn-info" target="_blank">Analisar</a>
                         <button type="button" class="btn btn-xs btn-danger remove-row" data-id="<?= (int)$row['id']; ?>"><i class="fa fa-trash"></i></button>
                     </td>


### PR DESCRIPTION
## Summary
- Only require accounting fields for VAT rates present in each row when deciding button color
- Track required VAT rates on each row and update button styling accordingly on client

## Testing
- `php -l contabilidade/classificacao-importacao.php`
- `node --check assets/js/classificacao_importacao.js`


------
https://chatgpt.com/codex/tasks/task_e_68c07353afcc8320b0c1c1c3d1d6185e