### PR TITLE
Ensure classification button reflects novat requirement

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -15,13 +15,16 @@ window.addEventListener('load', function() {
         var iva6 = parseInt(btn.getAttribute('data-iva6')) || 0;
         var iva13 = parseInt(btn.getAttribute('data-iva13')) || 0;
         var iva23 = parseInt(btn.getAttribute('data-iva23')) || 0;
+        var novat = parseInt(btn.getAttribute('data-novat')) || 0;
         var needIva6 = btn.getAttribute('data-req-iva6') === '1';
         var needIva13 = btn.getAttribute('data-req-iva13') === '1';
         var needIva23 = btn.getAttribute('data-req-iva23') === '1';
+        var needNovat = btn.getAttribute('data-req-novat') === '1';
         var allFilled = true;
         if (needIva6) { allFilled = allFilled && iva6 > 0; }
         if (needIva13) { allFilled = allFilled && iva13 > 0; }
         if (needIva23) { allFilled = allFilled && iva23 > 0; }
+        if (needNovat) { allFilled = allFilled && novat > 0; }
         btn.classList.toggle('btn-success', allFilled);
         btn.classList.toggle('btn-warning', !allFilled);
     }

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -69,15 +69,17 @@ require_once __DIR__ . '/../header.php';
                         $hasIva6 = (float)($row['field_I1'] ?? 0) > 0 || (float)($row['field_I3'] ?? 0) > 0;
                         $hasIva13 = (float)($row['field_I4'] ?? 0) > 0 || (float)($row['field_I5'] ?? 0) > 0;
                         $hasIva23 = (float)($row['field_I6'] ?? 0) > 0 || (float)($row['field_I7'] ?? 0) > 0;
+                        $needsNovat = !$hasIva6 && !$hasIva13 && !$hasIva23;
                         $allAccounts = (
                             (!$hasIva6 || (int)($row['account_iva6'] ?? 0) > 0) &&
                             (!$hasIva13 || (int)($row['account_iva13'] ?? 0) > 0) &&
-                            (!$hasIva23 || (int)($row['account_iva23'] ?? 0) > 0)
+                            (!$hasIva23 || (int)($row['account_iva23'] ?? 0) > 0) &&
+                            (!$needsNovat || (int)($row['account_novat'] ?? 0) > 0)
                         );
                         $btnClass = $allAccounts ? 'btn-success' : 'btn-warning';
                     ?>
                     <td class="text-center">
-                        <button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-iva6="<?= htmlspecialchars($row['account_iva6'] ?? ''); ?>" data-iva13="<?= htmlspecialchars($row['account_iva13'] ?? ''); ?>" data-iva23="<?= htmlspecialchars($row['account_iva23'] ?? ''); ?>" data-novat="<?= htmlspecialchars($row['account_novat'] ?? ''); ?>" data-req-iva6="<?= $hasIva6 ? 1 : 0; ?>" data-req-iva13="<?= $hasIva13 ? 1 : 0; ?>" data-req-iva23="<?= $hasIva23 ? 1 : 0; ?>" data-emitter="<?= htmlspecialchars($row['field_A'] ?? ''); ?>" data-acquirer="<?= htmlspecialchars($row['field_B'] ?? ''); ?>" data-doctype="<?= htmlspecialchars($row['field_D'] ?? ''); ?>">Classificar</button>
+                        <button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-iva6="<?= htmlspecialchars($row['account_iva6'] ?? ''); ?>" data-iva13="<?= htmlspecialchars($row['account_iva13'] ?? ''); ?>" data-iva23="<?= htmlspecialchars($row['account_iva23'] ?? ''); ?>" data-novat="<?= htmlspecialchars($row['account_novat'] ?? ''); ?>" data-req-iva6="<?= $hasIva6 ? 1 : 0; ?>" data-req-iva13="<?= $hasIva13 ? 1 : 0; ?>" data-req-iva23="<?= $hasIva23 ? 1 : 0; ?>" data-req-novat="<?= $needsNovat ? 1 : 0; ?>" data-emitter="<?= htmlspecialchars($row['field_A'] ?? ''); ?>" data-acquirer="<?= htmlspecialchars($row['field_B'] ?? ''); ?>" data-doctype="<?= htmlspecialchars($row['field_D'] ?? ''); ?>">Classificar</button>
                         <a href="contabilidade/save-analysis.php?action=lines&id=<?= (int)$row['id']; ?>" class="btn btn-xs btn-info" target="_blank">Analisar</a>
                         <button type="button" class="btn btn-xs btn-danger remove-row" data-id="<?= (int)$row['id']; ?>"><i class="fa fa-trash"></i></button>
                     </td>

--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -211,8 +211,12 @@ if ($action === 'get') {
             'iva23' => $iva23,
             'novat' => $novat,
         ]);
-        $stmt = $pdo->prepare('UPDATE accounting_imports SET account = ? WHERE id = ?');
-        $stmt->execute([$serialized, $id]);
+        $stmt = $pdo->prepare(
+            'UPDATE accounting_imports '
+            . 'SET account = ?, account_iva6 = ?, account_iva13 = ?, account_iva23 = ?, account_novat = ? '
+            . 'WHERE id = ?'
+        );
+        $stmt->execute([$serialized, $iva6, $iva13, $iva23, $novat, $id]);
         $stmt2 = $pdo->prepare(
             'INSERT INTO accounting_classifications '
             . '(emitter, acquirer, doc_type, account, account_iva6, account_iva13, account_iva23, account_novat) '


### PR DESCRIPTION
## Summary
- consider novat account when determining if a row is fully classified
- keep classification button yellow until required novat account is set
- persist novat account on save so button state remains accurate across reloads

## Testing
- `php -l contabilidade/save-analysis.php`
- `php -l contabilidade/classificacao-importacao.php`
- `node --check assets/js/classificacao_importacao.js`


------
https://chatgpt.com/codex/tasks/task_e_68c076345da48320bc2dfba44dba4373