### PR TITLE
Store IVA accounts in serialized column

### DIFF
--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -10,6 +10,14 @@ $useDropzone = false;
 $pdo = getPDO();
 $stmt = $pdo->query('SELECT * FROM accounting_imports');
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+foreach ($rows as &$row) {
+    $accounts = json_decode($row['account'] ?? '', true) ?: [];
+    $row['account_iva6'] = $accounts['iva6'] ?? '';
+    $row['account_iva13'] = $accounts['iva13'] ?? '';
+    $row['account_iva23'] = $accounts['iva23'] ?? '';
+    $row['account_novat'] = $accounts['novat'] ?? '';
+}
+unset($row);
 $csrfToken = generateCsrfToken();
 
 require_once __DIR__ . '/../header.php';

--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -168,16 +168,16 @@ if ($action === 'get') {
         exit;
     }
     $stmt = $pdo->prepare(
-        'SELECT account_iva6, account_iva13, account_iva23, account_novat '
-        . 'FROM accounting_classifications WHERE emitter = ? AND acquirer = ? AND doc_type = ? LIMIT 1'
+        'SELECT account FROM accounting_classifications WHERE emitter = ? AND acquirer = ? AND doc_type = ? LIMIT 1'
     );
     $stmt->execute([$a, $b, $d]);
     $row = $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
+    $accounts = json_decode($row['account'] ?? '', true) ?: [];
     echo json_encode([
-        'iva6' => $row['account_iva6'] ?? '',
-        'iva13' => $row['account_iva13'] ?? '',
-        'iva23' => $row['account_iva23'] ?? '',
-        'novat' => $row['account_novat'] ?? '',
+        'iva6' => $accounts['iva6'] ?? '',
+        'iva13' => $accounts['iva13'] ?? '',
+        'iva23' => $accounts['iva23'] ?? '',
+        'novat' => $accounts['novat'] ?? '',
         'csrf_token' => generateCsrfToken()
     ]);
     exit;
@@ -212,23 +212,15 @@ if ($action === 'get') {
             'novat' => $novat,
         ]);
         $stmt = $pdo->prepare(
-            'UPDATE accounting_imports '
-            . 'SET account = ?, account_iva6 = ?, account_iva13 = ?, account_iva23 = ?, account_novat = ? '
-            . 'WHERE id = ?'
+            'UPDATE accounting_imports SET account = ? WHERE id = ?'
         );
-        $stmt->execute([$serialized, $iva6, $iva13, $iva23, $novat, $id]);
+        $stmt->execute([$serialized, $id]);
         $stmt2 = $pdo->prepare(
-            'INSERT INTO accounting_classifications '
-            . '(emitter, acquirer, doc_type, account, account_iva6, account_iva13, account_iva23, account_novat) '
-            . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?) '
-            . 'ON DUPLICATE KEY UPDATE '
-            . 'account = VALUES(account), '
-            . 'account_iva6 = VALUES(account_iva6), '
-            . 'account_iva13 = VALUES(account_iva13), '
-            . 'account_iva23 = VALUES(account_iva23), '
-            . 'account_novat = VALUES(account_novat)'
+            'INSERT INTO accounting_classifications (emitter, acquirer, doc_type, account) '
+            . 'VALUES (?, ?, ?, ?) '
+            . 'ON DUPLICATE KEY UPDATE account = VALUES(account)'
         );
-        $stmt2->execute([$a, $b, $d, $novat, $iva6, $iva13, $iva23, $novat]);
+        $stmt2->execute([$a, $b, $d, $serialized]);
         $pdo->commit();
         echo json_encode(['success' => true, 'csrf_token' => generateCsrfToken()]);
     } catch (Exception $e) {

--- a/schema.sql
+++ b/schema.sql
@@ -128,10 +128,6 @@ CREATE TABLE IF NOT EXISTS accounting_classifications (
     acquirer VARCHAR(255) NOT NULL,
     doc_type VARCHAR(50) NOT NULL,
     account VARCHAR(255) NOT NULL,
-    account_iva6 VARCHAR(255) DEFAULT '',
-    account_iva13 VARCHAR(255) DEFAULT '',
-    account_iva23 VARCHAR(255) DEFAULT '',
-    account_novat VARCHAR(255) DEFAULT '',
     UNIQUE KEY unique_classification (emitter, acquirer, doc_type)
 );
 
@@ -157,10 +153,6 @@ CREATE TABLE IF NOT EXISTS accounting_imports (
     field_Q VARCHAR(255) DEFAULT '',
     field_R VARCHAR(255) DEFAULT '',
     account VARCHAR(255) DEFAULT '',
-    account_iva6 VARCHAR(255) DEFAULT '',
-    account_iva13 VARCHAR(255) DEFAULT '',
-    account_iva23 VARCHAR(255) DEFAULT '',
-    account_novat VARCHAR(255) DEFAULT '',
     filename VARCHAR(255) DEFAULT '',
     dte_add TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
- drop per-IVA columns and helper
- serialize IVA classification data in `account` field
- adjust schema and UI to read/write JSON

## Testing
- `php -l contabilidade/functions.php`
- `php -l contabilidade/classificacao-importacao.php`
- `php -l contabilidade/save-analysis.php`


------
https://chatgpt.com/codex/tasks/task_e_68c07d2866008320b69ad1d91b42c2d0