### PR TITLE
Only mark VAT buttons green when required accounts filled

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -12,19 +12,24 @@ window.addEventListener('load', function() {
     });
 
     function updateButtonClass(btn) {
-        var iva6 = parseInt(btn.getAttribute('data-iva6')) || 0;
-        var iva13 = parseInt(btn.getAttribute('data-iva13')) || 0;
-        var iva23 = parseInt(btn.getAttribute('data-iva23')) || 0;
-        var novat = parseInt(btn.getAttribute('data-novat')) || 0;
-        var needIva6 = btn.getAttribute('data-req-iva6') === '1';
-        var needIva13 = btn.getAttribute('data-req-iva13') === '1';
-        var needIva23 = btn.getAttribute('data-req-iva23') === '1';
+        var iva6 = (btn.getAttribute('data-iva6') || '').trim();
+        var iva13 = (btn.getAttribute('data-iva13') || '').trim();
+        var iva23 = (btn.getAttribute('data-iva23') || '').trim();
+        var novat = (btn.getAttribute('data-novat') || '').trim();
+        var amtIva6 = parseFloat(btn.getAttribute('data-amt-iva6') || '0');
+        var amtIva13 = parseFloat(btn.getAttribute('data-amt-iva13') || '0');
+        var amtIva23 = parseFloat(btn.getAttribute('data-amt-iva23') || '0');
+        var needIva6 = amtIva6 > 0;
+        var needIva13 = amtIva13 > 0;
+        var needIva23 = amtIva23 > 0;
         var needNovat = btn.getAttribute('data-req-novat') === '1';
+        var requires = needIva6 || needIva13 || needIva23 || needNovat;
         var allFilled = true;
-        if (needIva6) { allFilled = allFilled && iva6 > 0; }
-        if (needIva13) { allFilled = allFilled && iva13 > 0; }
-        if (needIva23) { allFilled = allFilled && iva23 > 0; }
-        if (needNovat) { allFilled = allFilled && novat > 0; }
+        if (needIva6 && iva6 === '') { allFilled = false; }
+        if (needIva13 && iva13 === '') { allFilled = false; }
+        if (needIva23 && iva23 === '') { allFilled = false; }
+        if (needNovat && novat === '') { allFilled = false; }
+        if (!requires) { allFilled = false; }
         btn.classList.toggle('btn-success', allFilled);
         btn.classList.toggle('btn-warning', !allFilled);
     }

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -76,9 +76,12 @@ require_once __DIR__ . '/../header.php';
                     <td><?= htmlspecialchars($row['field_R'] ?? ''); ?></td>
                     <td class="text-center"><a href="<?= htmlspecialchars($row['filename'] ?? ''); ?>" target="_blank" class="btn btn-xs btn-secondary"><i class="fa fa-file-pdf-o"></i></a></td>
                     <?php
-                        $hasIva6 = (float)($row['field_I1'] ?? 0) > 0 || (float)($row['field_I3'] ?? 0) > 0;
-                        $hasIva13 = (float)($row['field_I4'] ?? 0) > 0 || (float)($row['field_I5'] ?? 0) > 0;
-                        $hasIva23 = (float)($row['field_I6'] ?? 0) > 0 || (float)($row['field_I7'] ?? 0) > 0;
+                        $amtIva6 = (float)($row['field_I1'] ?? 0) + (float)($row['field_I3'] ?? 0);
+                        $amtIva13 = (float)($row['field_I4'] ?? 0) + (float)($row['field_I5'] ?? 0);
+                        $amtIva23 = (float)($row['field_I6'] ?? 0) + (float)($row['field_I7'] ?? 0);
+                        $hasIva6 = $amtIva6 > 0;
+                        $hasIva13 = $amtIva13 > 0;
+                        $hasIva23 = $amtIva23 > 0;
                         $needsNovat = !$hasIva6 && !$hasIva13 && !$hasIva23;
 
                         $allAccounts = (
@@ -87,11 +90,11 @@ require_once __DIR__ . '/../header.php';
                             (!$hasIva23 || (int)($row['account_iva23'] ?? 0) > 0) &&
                             (!$needsNovat || (int)($row['account_novat'] ?? 0) > 0)
                         );
-                        $btnClass = $allAccounts ? 'btn-success' : 'btn-warning';
+                        $requires = $hasIva6 || $hasIva13 || $hasIva23 || $needsNovat;
+                        $btnClass = ($requires && $allAccounts) ? 'btn-success' : 'btn-warning';
                     ?>
                     <td class="text-center">
-
-                        <button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-iva6="<?= htmlspecialchars($row['account_iva6'] ?? ''); ?>" data-iva13="<?= htmlspecialchars($row['account_iva13'] ?? ''); ?>" data-iva23="<?= htmlspecialchars($row['account_iva23'] ?? ''); ?>" data-novat="<?= htmlspecialchars($row['account_novat'] ?? ''); ?>" data-req-iva6="<?= $hasIva6 ? 1 : 0; ?>" data-req-iva13="<?= $hasIva13 ? 1 : 0; ?>" data-req-iva23="<?= $hasIva23 ? 1 : 0; ?>" data-req-novat="<?= $needsNovat ? 1 : 0; ?>" data-emitter="<?= htmlspecialchars($row['field_A'] ?? ''); ?>" data-acquirer="<?= htmlspecialchars($row['field_B'] ?? ''); ?>" data-doctype="<?= htmlspecialchars($row['field_D'] ?? ''); ?>">Classificar</button>
+                        <button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-iva6="<?= htmlspecialchars($row['account_iva6'] ?? ''); ?>" data-iva13="<?= htmlspecialchars($row['account_iva13'] ?? ''); ?>" data-iva23="<?= htmlspecialchars($row['account_iva23'] ?? ''); ?>" data-novat="<?= htmlspecialchars($row['account_novat'] ?? ''); ?>" data-amt-iva6="<?= $amtIva6; ?>" data-amt-iva13="<?= $amtIva13; ?>" data-amt-iva23="<?= $amtIva23; ?>" data-req-novat="<?= $needsNovat ? 1 : 0; ?>" data-emitter="<?= htmlspecialchars($row['field_A'] ?? ''); ?>" data-acquirer="<?= htmlspecialchars($row['field_B'] ?? ''); ?>" data-doctype="<?= htmlspecialchars($row['field_D'] ?? ''); ?>">Classificar</button>
 
                         <a href="contabilidade/save-analysis.php?action=lines&id=<?= (int)$row['id']; ?>" class="btn btn-xs btn-info" target="_blank">Analisar</a>
                         <button type="button" class="btn btn-xs btn-danger remove-row" data-id="<?= (int)$row['id']; ?>"><i class="fa fa-trash"></i></button>


### PR DESCRIPTION
## Summary
- Avoid defaulting classification buttons to green by tracking whether any VAT or NOVAT accounts are required
- Require VAT button accounts only when corresponding amounts exist and attributes are non-empty

## Testing
- `php -l contabilidade/classificacao-importacao.php`
- `node --check assets/js/classificacao_importacao.js`


------
https://chatgpt.com/codex/tasks/task_e_68c084c1d5e08320b4af9d0060bb6c7b