### PR TITLE
Ensure classification buttons require account for VAT values

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -14,28 +14,32 @@ window.addEventListener('load', function() {
     function updateButtonClass(btn) {
 
 
-
-        var iva6 = parseInt(btn.getAttribute('data-iva6')) || 0;
-        var iva13 = parseInt(btn.getAttribute('data-iva13')) || 0;
-        var iva23 = parseInt(btn.getAttribute('data-iva23')) || 0;
-        var novat = parseInt(btn.getAttribute('data-novat')) || 0;
-        var amtIva6 = parseFloat(btn.getAttribute('data-amt-iva6')) || 0;
-        var amtIva13 = parseFloat(btn.getAttribute('data-amt-iva13')) || 0;
-        var amtIva23 = parseFloat(btn.getAttribute('data-amt-iva23')) || 0;
-
-        var needIva6 = amtIva6 > 0;
-        var needIva13 = amtIva13 > 0;
-        var needIva23 = amtIva23 > 0;
-        var needNovat = btn.getAttribute('data-req-novat') === '1';
-        var requires = needIva6 || needIva13 || needIva23 || needNovat;
+        var rates = [6, 13, 23];
+        var requires = false;
         var allFilled = true;
-        if (needIva6 && iva6 === '') { allFilled = false; }
-        if (needIva13 && iva13 === '') { allFilled = false; }
-        if (needIva23 && iva23 === '') { allFilled = false; }
-        if (needNovat && novat === '') { allFilled = false; }
 
-      
-        if (!requires) { allFilled = false; }
+        rates.forEach(function(rate) {
+            var amount = parseFloat(btn.getAttribute('data-amt-iva' + rate)) || 0;
+            if (amount > 0) {
+                requires = true;
+                var account = btn.getAttribute('data-iva' + rate) || '';
+                if (!account) {
+                    allFilled = false;
+                }
+            }
+        });
+
+        var needNovat = btn.getAttribute('data-req-novat') === '1';
+        if (needNovat) {
+            requires = true;
+            if (!(btn.getAttribute('data-novat') || '')) {
+                allFilled = false;
+            }
+        }
+
+        if (!requires) {
+            allFilled = false;
+        }
         btn.classList.toggle('btn-success', allFilled);
         btn.classList.toggle('btn-warning', !allFilled);
     }


### PR DESCRIPTION
## Summary
- validate classification buttons across 6%, 13%, and 23% VAT rates by iterating over all rates and requiring each corresponding account

## Testing
- `node --check assets/js/classificacao_importacao.js`


------
https://chatgpt.com/codex/tasks/task_e_68c090cd67f08320a6c491ba0020d845