### PR TITLE
Ensure multi-VAT rows require matching accounts

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -17,9 +17,9 @@ window.addEventListener('load', function() {
         var iva23 = btn.getAttribute('data-iva23') || '';
         var novat = btn.getAttribute('data-novat') || '';
 
-        var amtIva6 = parseFloat(btn.getAttribute('data-amt-iva6')) || 0;
-        var amtIva13 = parseFloat(btn.getAttribute('data-amt-iva13')) || 0;
-        var amtIva23 = parseFloat(btn.getAttribute('data-amt-iva23')) || 0;
+        var amtIva6 = Math.abs(parseFloat(btn.getAttribute('data-amt-iva6'))) || 0;
+        var amtIva13 = Math.abs(parseFloat(btn.getAttribute('data-amt-iva13'))) || 0;
+        var amtIva23 = Math.abs(parseFloat(btn.getAttribute('data-amt-iva23'))) || 0;
 
         var needIva6 = amtIva6 > 0;
         var needIva13 = amtIva13 > 0;

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -78,18 +78,18 @@ require_once __DIR__ . '/../header.php';
                     <?php
 
 
-                        $amtIva6 = (float)($row['field_I1'] ?? 0) + (float)($row['field_I3'] ?? 0);
-                        $amtIva13 = (float)($row['field_I4'] ?? 0) + (float)($row['field_I5'] ?? 0);
-                        $amtIva23 = (float)($row['field_I6'] ?? 0) + (float)($row['field_I7'] ?? 0);
+                        $amtIva6 = abs((float)($row['field_I1'] ?? 0)) + abs((float)($row['field_I3'] ?? 0));
+                        $amtIva13 = abs((float)($row['field_I4'] ?? 0)) + abs((float)($row['field_I5'] ?? 0));
+                        $amtIva23 = abs((float)($row['field_I6'] ?? 0)) + abs((float)($row['field_I7'] ?? 0));
                         $hasIva6 = $amtIva6 > 0;
                         $hasIva13 = $amtIva13 > 0;
                         $hasIva23 = $amtIva23 > 0;
                         $needsNovat = !$hasIva6 && !$hasIva13 && !$hasIva23;
 
                         $allAccounts = (
-                            ($amtIva6 <= 0 || (int)($row['account_iva6'] ?? 0) > 0) &&
-                            ($amtIva13 <= 0 || (int)($row['account_iva13'] ?? 0) > 0) &&
-                            ($amtIva23 <= 0 || (int)($row['account_iva23'] ?? 0) > 0) &&
+                            ($amtIva6 == 0 || (int)($row['account_iva6'] ?? 0) > 0) &&
+                            ($amtIva13 == 0 || (int)($row['account_iva13'] ?? 0) > 0) &&
+                            ($amtIva23 == 0 || (int)($row['account_iva23'] ?? 0) > 0) &&
                             (!$needsNovat || (int)($row['account_novat'] ?? 0) > 0)
                         );
                         $requires = $hasIva6 || $hasIva13 || $hasIva23 || $needsNovat;


### PR DESCRIPTION
## Summary
- handle negative VAT totals when determining if account numbers are required
- update frontend check to use absolute VAT amounts

## Testing
- `php -l contabilidade/classificacao-importacao.php`
- `node --check assets/js/classificacao_importacao.js`


------
https://chatgpt.com/codex/tasks/task_e_68c09c76e41c832097b71dcb80b0d25b