### PR TITLE
fix: highlight classification by VAT coverage

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -35,8 +35,15 @@ window.addEventListener('load', function() {
 
         if (!requires) { allFilled = false; }
 
-        btn.classList.toggle('btn-success', allFilled);
-        btn.classList.toggle('btn-warning', !allFilled);
+        var hasAnyAccount = iva6 || iva13 || iva23 || novat;
+        btn.classList.remove('btn-success', 'btn-warning', 'btn-secondary');
+        if (requires && allFilled) {
+            btn.classList.add('btn-success');
+        } else if (hasAnyAccount) {
+            btn.classList.add('btn-warning');
+        } else {
+            btn.classList.add('btn-secondary');
+        }
 
     }
 

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -93,7 +93,19 @@ require_once __DIR__ . '/../header.php';
                             (!$needsNovat || (int)($row['account_novat'] ?? 0) > 0)
                         );
                         $requires = $hasIva6 || $hasIva13 || $hasIva23 || $needsNovat;
-                        $btnClass = ($requires && $allAccounts) ? 'btn-success' : 'btn-warning';
+                        $hasAnyAccount = (
+                            (int)($row['account_iva6'] ?? 0) > 0 ||
+                            (int)($row['account_iva13'] ?? 0) > 0 ||
+                            (int)($row['account_iva23'] ?? 0) > 0 ||
+                            (int)($row['account_novat'] ?? 0) > 0
+                        );
+                        if ($requires && $allAccounts) {
+                            $btnClass = 'btn-success';
+                        } elseif ($hasAnyAccount) {
+                            $btnClass = 'btn-warning';
+                        } else {
+                            $btnClass = 'btn-secondary';
+                        }
                     ?>
                     <td class="text-center">
                         <button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-iva6="<?= htmlspecialchars($row['account_iva6'] ?? ''); ?>" data-iva13="<?= htmlspecialchars($row['account_iva13'] ?? ''); ?>" data-iva23="<?= htmlspecialchars($row['account_iva23'] ?? ''); ?>" data-novat="<?= htmlspecialchars($row['account_novat'] ?? ''); ?>" data-amt-iva6="<?= $amtIva6; ?>" data-amt-iva13="<?= $amtIva13; ?>" data-amt-iva23="<?= $amtIva23; ?>" data-req-novat="<?= $needsNovat ? 1 : 0; ?>" data-emitter="<?= htmlspecialchars($row['field_A'] ?? ''); ?>" data-acquirer="<?= htmlspecialchars($row['field_B'] ?? ''); ?>" data-doctype="<?= htmlspecialchars($row['field_D'] ?? ''); ?>">Classificar</button>


### PR DESCRIPTION
## Summary
- refactor classification color to show unfilled VAT mapping as gray
- flag partial VAT account mapping in yellow for easier review

## Testing
- `php -l contabilidade/classificacao-importacao.php`
- `node --check assets/js/classificacao_importacao.js && echo "JS OK"`


------
https://chatgpt.com/codex/tasks/task_e_68c28edc24f08320b70cfb3c98a56c9c