### PR TITLE
Handle optional VAT accounts: enforce NOVAT requirement

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -20,21 +20,24 @@ window.addEventListener('load', function() {
         var amtIva6 = Math.abs(parseFloat(btn.getAttribute('data-amt-iva6'))) || 0;
         var amtIva13 = Math.abs(parseFloat(btn.getAttribute('data-amt-iva13'))) || 0;
         var amtIva23 = Math.abs(parseFloat(btn.getAttribute('data-amt-iva23'))) || 0;
+        var needNovat = btn.getAttribute('data-req-novat') === '1';
 
         var needIva6 = amtIva6 > 0;
         var needIva13 = amtIva13 > 0;
         var needIva23 = amtIva23 > 0;
 
-        var requires = needIva6 || needIva13 || needIva23;
-        var allFilled = true;
+        var hasIva6 = parseInt(iva6, 10) > 0;
+        var hasIva13 = parseInt(iva13, 10) > 0;
+        var hasIva23 = parseInt(iva23, 10) > 0;
+        var hasNovat = parseInt(novat, 10) > 0;
 
-        if (needIva6 && !iva6) { allFilled = false; }
-        if (needIva13 && !iva13) { allFilled = false; }
-        if (needIva23 && !iva23) { allFilled = false; }
+        var requires = needIva6 || needIva13 || needIva23 || needNovat;
+        var allFilled = true;
 
         if (needIva6 && !hasIva6) { allFilled = false; }
         if (needIva13 && !hasIva13) { allFilled = false; }
         if (needIva23 && !hasIva23) { allFilled = false; }
+        if (needNovat && !hasNovat) { allFilled = false; }
 
         var hasAnyAccount = hasIva6 || hasIva13 || hasIva23 || hasNovat;
         btn.classList.remove('btn-success', 'btn-warning', 'btn-secondary');

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -84,13 +84,16 @@ require_once __DIR__ . '/../header.php';
                         $hasIva6 = $amtIva6 > 0;
                         $hasIva13 = $amtIva13 > 0;
                         $hasIva23 = $amtIva23 > 0;
+                        $total = abs((float)($row['field_O'] ?? 0));
+                        $needsNovat = !$hasIva6 && !$hasIva13 && !$hasIva23 && $total > 0;
 
                         $allAccounts = (
                             ($amtIva6 == 0 || (int)($row['account_iva6'] ?? 0) > 0) &&
                             ($amtIva13 == 0 || (int)($row['account_iva13'] ?? 0) > 0) &&
-                            ($amtIva23 == 0 || (int)($row['account_iva23'] ?? 0) > 0)
+                            ($amtIva23 == 0 || (int)($row['account_iva23'] ?? 0) > 0) &&
+                            (!$needsNovat || (int)($row['account_novat'] ?? 0) > 0)
                         );
-                        $requires = $hasIva6 || $hasIva13 || $hasIva23;
+                        $requires = $hasIva6 || $hasIva13 || $hasIva23 || $needsNovat;
                         $hasAnyAccount = (
                             (int)($row['account_iva6'] ?? 0) > 0 ||
                             (int)($row['account_iva13'] ?? 0) > 0 ||
@@ -109,7 +112,7 @@ require_once __DIR__ . '/../header.php';
                     ?>
                     <td class="text-center">
 
-                        <button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-iva6="<?= htmlspecialchars($row['account_iva6'] ?? ''); ?>" data-iva13="<?= htmlspecialchars($row['account_iva13'] ?? ''); ?>" data-iva23="<?= htmlspecialchars($row['account_iva23'] ?? ''); ?>" data-novat="<?= htmlspecialchars($row['account_novat'] ?? ''); ?>" data-amt-iva6="<?= $amtIva6; ?>" data-amt-iva13="<?= $amtIva13; ?>" data-amt-iva23="<?= $amtIva23; ?>" data-emitter="<?= htmlspecialchars($row['field_A'] ?? ''); ?>" data-acquirer="<?= htmlspecialchars($row['field_B'] ?? ''); ?>" data-doctype="<?= htmlspecialchars($row['field_D'] ?? ''); ?>">Classificar</button>
+                        <button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-iva6="<?= htmlspecialchars($row['account_iva6'] ?? ''); ?>" data-iva13="<?= htmlspecialchars($row['account_iva13'] ?? ''); ?>" data-iva23="<?= htmlspecialchars($row['account_iva23'] ?? ''); ?>" data-novat="<?= htmlspecialchars($row['account_novat'] ?? ''); ?>" data-amt-iva6="<?= $amtIva6; ?>" data-amt-iva13="<?= $amtIva13; ?>" data-amt-iva23="<?= $amtIva23; ?>" data-req-novat="<?= $needsNovat ? 1 : 0; ?>" data-emitter="<?= htmlspecialchars($row['field_A'] ?? ''); ?>" data-acquirer="<?= htmlspecialchars($row['field_B'] ?? ''); ?>" data-doctype="<?= htmlspecialchars($row['field_D'] ?? ''); ?>">Classificar</button>
 
                         <a href="contabilidade/save-analysis.php?action=lines&id=<?= (int)$row['id']; ?>" class="btn btn-xs btn-info" target="_blank">Analisar</a>
                         <button type="button" class="btn btn-xs btn-danger remove-row" data-id="<?= (int)$row['id']; ?>"><i class="fa fa-trash"></i></button>


### PR DESCRIPTION
## Summary
- require NOVAT account when rows contain totals but no VAT amounts
- propagate NOVAT requirement to client classification script

## Testing
- `php -l contabilidade/classificacao-importacao.php`
- `node --check assets/js/classificacao_importacao.js && echo "Syntax OK"`
- `pre-commit run --files assets/js/classificacao_importacao.js contabilidade/classificacao-importacao.php` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68c298aeb9108320ab902f282e770729