### PR TITLE
Validate Textract file extensions

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -70,7 +70,11 @@ function parseInvoiceLineImage(string $imagePath): array {
  * @throws RuntimeException When Textract fails.
  */
 function parseInvoiceLineTextract(string $filePath): array {
-
+    $extension = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
+    $allowedExtensions = ['pdf', 'png', 'jpg', 'jpeg', 'tiff', 'tif'];
+    if (! in_array($extension, $allowedExtensions, true)) {
+        throw new RuntimeException('Formato de arquivo não suportado pelo Textract');
+    }
 
     $key = getSetting('aws_access_key_id', getenv('AWS_ACCESS_KEY_ID') ?: '');
     $secret = getSetting('aws_secret_access_key', getenv('AWS_SECRET_ACCESS_KEY') ?: '');


### PR DESCRIPTION
## Summary
- prevent Textract OCR from running on unsupported file formats

## Testing
- `php -l contabilidade/functions.php`
- `php -l contabilidade/save-analysis.php`


------
https://chatgpt.com/codex/tasks/task_e_68c29fce277c83208c9b228e6206f517