### PR TITLE
Ensure Textract uses existing or newly created S3 bucket

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -9,6 +9,7 @@ use thiagoalessio\TesseractOCR\TesseractOCR;
 use Aws\Textract\TextractClient;
 use Aws\Textract\Exception\TextractException;
 use Aws\S3\S3Client;
+use Aws\Exception\AwsException;
 
 /**
  * Parse an invoice line from a text string produced by OCR.
@@ -101,6 +102,22 @@ function parseInvoiceLineTextract(string $filePath): array {
     }
 
     $s3 = new S3Client($config);
+
+    try {
+        $s3->headBucket(['Bucket' => $bucket]);
+    } catch (AwsException $e) {
+        if ($e->getStatusCode() === 404) {
+            $params = ['Bucket' => $bucket];
+            if ($region !== 'us-east-1') {
+                $params['CreateBucketConfiguration'] = ['LocationConstraint' => $region];
+            }
+            $s3->createBucket($params);
+            $s3->waitUntil('BucketExists', ['Bucket' => $bucket]);
+        } else {
+            throw $e;
+        }
+    }
+
     $textract = new TextractClient($config);
 
     $objectKey = 'textract/' . uniqid('', true) . '.' . $extension;


### PR DESCRIPTION
## Summary
- Create S3 bucket automatically when missing before uploading Textract documents

## Testing
- `php -l contabilidade/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2a6ecacbc8320ae914d7fe5abb308