### PR TITLE
Log OCR errors and remove Tesseract fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ contabilidade/test.php
 contabilidade/magick-*
 .history/*
 contabilidade/debug_qr.txt
+data/*.log

--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -12,6 +12,18 @@ use Aws\S3\S3Client;
 use Aws\Exception\AwsException;
 
 /**
+ * Append an OCR-related message to a log file.
+ *
+ * @param string $message Message to append.
+ * @return void
+ */
+function logOcrMessage(string $message): void {
+    $logFile = __DIR__ . '/../data/ocr.log';
+    $timestamp = date('Y-m-d H:i:s');
+    error_log("[$timestamp] $message\n", 3, $logFile);
+}
+
+/**
  * Parse an invoice line from a text string produced by OCR.
  *
  * @param string $text OCR text for a single invoice line.
@@ -200,9 +212,9 @@ function parseInvoiceLineTextract(string $filePath): array {
             if ($e->getAwsErrorCode() === 'UnsupportedDocumentException') {
                 throw new RuntimeException('Formato de arquivo não suportado pelo Textract', 0, $e);
             }
-            error_log('Textract StartExpenseAnalysis error: ' . $e->getMessage());
+            logOcrMessage('Textract StartExpenseAnalysis error: ' . $e->getMessage());
         } catch (Throwable $e) {
-            error_log('Textract StartExpenseAnalysis error: ' . $e->getMessage());
+            logOcrMessage('Textract StartExpenseAnalysis error: ' . $e->getMessage());
         }
 
         $start = $textract->startDocumentTextDetection([
@@ -257,10 +269,10 @@ function parseInvoiceLineTextract(string $filePath): array {
         if ($e->getAwsErrorCode() === 'UnsupportedDocumentException') {
             throw new RuntimeException('Formato de arquivo não suportado pelo Textract', 0, $e);
         }
-        error_log('Textract DetectDocumentText error: ' . $e->getMessage());
+        logOcrMessage('Textract DetectDocumentText error: ' . $e->getMessage());
         throw new RuntimeException('Falha no OCR Textract', 0, $e);
     } catch (Throwable $e) {
-        error_log('Textract DetectDocumentText error: ' . $e->getMessage());
+        logOcrMessage('Textract DetectDocumentText error: ' . $e->getMessage());
         throw new RuntimeException('Falha no OCR Textract', 0, $e);
     } finally {
         try {

--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -39,8 +39,6 @@ if ($action === 'lines') {
     $ocrProvider = getSetting('ocr_provider', 'tesseract');
 
     if ($ocrProvider === 'textract') {
-
-
         try {
             $items = parseInvoiceLineTextract($path);
             header('Content-Type: text/csv');
@@ -65,47 +63,55 @@ if ($action === 'lines') {
             }
             exit;
         } catch (Throwable $e) {
-            error_log('Textract OCR error: ' . $e->getMessage());
-            // Fallback to Tesseract below
+            logOcrMessage('Textract OCR error: ' . $e->getMessage());
+            http_response_code(500);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => 'Erro no OCR: ' . $e->getMessage()]);
+            exit;
         }
-
-    }
-
-    $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
-    $text = '';
-    try {
-        if ($extension === 'pdf') {
-            if (!class_exists('Imagick')) {
-                throw new RuntimeException('Extensão Imagick não disponível');
+    } elseif ($ocrProvider === 'tesseract') {
+        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+        $text = '';
+        try {
+            if ($extension === 'pdf') {
+                if (!class_exists('Imagick')) {
+                    throw new RuntimeException('Extensão Imagick não disponível');
+                }
+                $imagick = new Imagick();
+                $imagick->setResolution(300, 300);
+                $imagick->readImage($path);
+                $imagick->setImageFormat('png');
+                $tmpBase = sys_get_temp_dir() . '/ocr_' . uniqid();
+                $imagick->writeImages($tmpBase . '.png', false);
+                $imagick->clear();
+                $imagick->destroy();
+                foreach (glob($tmpBase . '-*.png') as $imgFile) {
+                    $ocr = new thiagoalessio\TesseractOCR\TesseractOCR($imgFile);
+                    $text .= $ocr->run() . PHP_EOL;
+                    unlink($imgFile);
+                }
+            } else {
+                $ocr = new thiagoalessio\TesseractOCR\TesseractOCR($path);
+                $text = $ocr->run();
             }
-            $imagick = new Imagick();
-            $imagick->setResolution(300, 300);
-            $imagick->readImage($path);
-            $imagick->setImageFormat('png');
-            $tmpBase = sys_get_temp_dir() . '/ocr_' . uniqid();
-            $imagick->writeImages($tmpBase . '.png', false);
-            $imagick->clear();
-            $imagick->destroy();
-            foreach (glob($tmpBase . '-*.png') as $imgFile) {
-                $ocr = new thiagoalessio\TesseractOCR\TesseractOCR($imgFile);
-                $text .= $ocr->run() . PHP_EOL;
-                unlink($imgFile);
-            }
-        } else {
-            $ocr = new thiagoalessio\TesseractOCR\TesseractOCR($path);
-            $text = $ocr->run();
+        } catch (Throwable $e) {
+            logOcrMessage('Tesseract OCR error: ' . $e->getMessage());
+            http_response_code(500);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => 'Erro no OCR: ' . $e->getMessage()]);
+            exit;
         }
-    } catch (Throwable $e) {
-        http_response_code(500);
+        header('Content-Type: text/csv');
+        header('Content-Disposition: attachment; filename="ocr_lines_' . $row['id'] . '.csv"');
+        $output = fopen('php://output', 'w');
+        fputcsv($output, ['line_number', 'text', 'arm', 'codigo_artigo', 'descricao', 'quantidade', 'unidade', 'preco_unitario', 'percentagem_desconto', 'desconto_valor', 'valor_liquido', 'imposto']);
+        $lines = explode(PHP_EOL, $text);
+    } else {
+        http_response_code(400);
         header('Content-Type: application/json');
-        echo json_encode(['error' => 'Erro no OCR: ' . $e->getMessage()]);
+        echo json_encode(['error' => 'OCR provider inválido']);
         exit;
     }
-    header('Content-Type: text/csv');
-    header('Content-Disposition: attachment; filename="ocr_lines_' . $row['id'] . '.csv"');
-    $output = fopen('php://output', 'w');
-    fputcsv($output, ['line_number', 'text', 'arm', 'codigo_artigo', 'descricao', 'quantidade', 'unidade', 'preco_unitario', 'percentagem_desconto', 'desconto_valor', 'valor_liquido', 'imposto']);
-    $lines = explode(PHP_EOL, $text);
     $inTable = false;
     $normalize = static function (string $str): string {
         return strtolower(iconv('UTF-8', 'ASCII//TRANSLIT', $str));


### PR DESCRIPTION
## Summary
- log OCR events to `data/ocr.log`
- honour configured OCR provider without automatic Tesseract fallback
- ignore log files

## Testing
- `php -l contabilidade/functions.php`
- `php -l contabilidade/save-analysis.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2aaabeef08320a977557b12928cfe