### PR TITLE
Handle missing AWS SDK in Textract parser

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -85,6 +85,9 @@ function parseInvoiceLineImage(string $imagePath): array {
  * @throws RuntimeException When Textract fails.
  */
 function parseInvoiceLineTextract(string $filePath): array {
+    if (!class_exists(TextractClient::class) || !class_exists(S3Client::class)) {
+        throw new RuntimeException('AWS SDK para PHP não instalado');
+    }
     $extension = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
     $allowedExtensions = ['pdf', 'png', 'jpg', 'jpeg', 'tiff', 'tif'];
     if (! in_array($extension, $allowedExtensions, true)) {


### PR DESCRIPTION
## Summary
- Avoid fatal errors when AWS SDK is missing by checking for required classes before using Textract OCR.

## Testing
- `php -l contabilidade/functions.php`
- `php -l contabilidade/save-analysis.php`


------
https://chatgpt.com/codex/tasks/task_e_68c3261ab64083208a74bf87f2874000