### PR TITLE
Fix headers already sent warning by removing closing PHP tag

### DIFF
--- a/data/db.php
+++ b/data/db.php
@@ -29,5 +29,3 @@ function getPDO() {
     }
     return $pdo;
 }
-?>
-


### PR DESCRIPTION
## Summary
- remove closing PHP tag from database helper to avoid stray output

## Testing
- `php -l data/db.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c32833f3848320aa66e2d1413abe22