### PR TITLE
Improve Textract tax rate detection

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -198,6 +198,15 @@ function parseInvoiceLineTextract(string $filePath): array {
                                 case 'TAX_RATE':
                                     $line['imposto'] = $num;
                                     break;
+                                case 'TAX':
+                                    // Textract sometimes labels the tax rate simply as "TAX".
+                                    // When the value represents a percentage we treat it as the
+                                    // tax rate rather than the tax amount.
+                                    if (in_array('PERCENTAGE', $field['EntityTypes'] ?? [], true)
+                                        || strpos($value, '%') !== false) {
+                                        $line['imposto'] = $num;
+                                    }
+                                    break;
                                 case 'DISCOUNT':
                                     $line['desconto_valor'] = $num;
                                     break;


### PR DESCRIPTION
## Summary
- handle AWS Textract fields labeled as TAX when they represent a percentage to better detect tax rates

## Testing
- `php -l contabilidade/functions.php`
- `composer test` *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_68c3301b91a0832085b1bcec2e3e8624