### PR TITLE
feat: capture item code from Textract results

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -207,6 +207,11 @@ function parseInvoiceLineTextract(string $filePath): array {
                                         $line['imposto'] = $num;
                                     }
                                     break;
+                                case 'PRODUCT_CODE':
+                                case 'ITEM_CODE':
+                                case 'SKU':
+                                    $line['codigo_artigo'] = $value;
+                                    break;
                                 case 'DISCOUNT':
                                     $line['desconto_valor'] = $num;
                                     break;


### PR DESCRIPTION
## Summary
- capture `codigo_artigo` from Textract expense line items when available

## Testing
- `php -l contabilidade/functions.php`
- `composer validate --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68c3308216e8832093f3670ef7fe9a12