### PR TITLE
Avoid duplicate article entries for multi-page PDFs

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -49,8 +49,14 @@ window.addEventListener('load', function() {
         }
         if (data.qr_texts && data.qr_texts.length) {
             var keys = ['A','B','C','D','E','F','G','H','I1','I3','I4','I5','I6','I7','I8','N','O','Q','R'];
+            var seen = new Set();
             data.qr_texts.forEach(function(qrText) {
                 var qrData = extractQR(qrText);
+                var identifier = qrData['H'] || qrText;
+                if (seen.has(identifier)) {
+                    return;
+                }
+                seen.add(identifier);
                 var row = keys.map(function(key) {
                     var value = qrData[key] || '';
                     if (key === 'F') {


### PR DESCRIPTION
## Summary
- Prevent duplicate QR-derived entries by tracking processed invoice codes, ensuring only one article record per multi-page PDF.

## Testing
- `node --check assets/js/accounting_upload.js`
- `npm test` *(fails: Could not read package.json)*
- `composer validate` *(warnings: description and license missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c342e71c508320aa1b5851d0c207fb