### PR TITLE
feat: add PNotify error utility

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -1,4 +1,12 @@
 window.addEventListener('load', function() {
+    function showError(message) {
+        new PNotify({
+            title: 'Erro',
+            text: message,
+            type: 'error',
+            styling: 'bootstrap3'
+        });
+    }
     var csrfInput = document.getElementById('csrf_token');
     var table = $('#classify-table').DataTable({
         orderCellsTop: true,
@@ -132,8 +140,7 @@ window.addEventListener('load', function() {
                 updateButtonClass(currentBtn);
                 classifyModal.hide();
             } else {
-                console.log(res);
-                alert(res.error || 'Erro ao guardar');
+                showError(res.error || 'Erro ao guardar');
             }
         });
     });
@@ -160,7 +167,7 @@ window.addEventListener('load', function() {
             if (res.success) {
                 table.row($(btn).closest('tr')).remove().draw();
             } else {
-                alert(res.error || 'Erro ao remover');
+                showError(res.error || 'Erro ao remover');
             }
         });
     });


### PR DESCRIPTION
## Summary
- show errors with PNotify instead of browser alerts
- replace alert/console.log with reusable PNotify helper

## Testing
- `node --check assets/js/classificacao_importacao.js` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c572d178a883208ccca30f28ae83ef