### PR TITLE
refactor: drop legacy account columns via migration

### DIFF
--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -9,7 +9,6 @@ $useDataTables = true;
 $useDropzone = false;
 
 $pdo = getPDO();
-dropLegacyAccountColumns($pdo);
 $stmt = $pdo->query('SELECT * FROM accounting_imports');
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 foreach ($rows as &$row) {

--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -139,26 +139,4 @@ function parseInvoiceLineTextract(string $filePath): array {
     return $data;
 }
 
-/**
- * Remove legacy per-IVA columns so only the serialized `account` column remains.
- */
-function dropLegacyAccountColumns(PDO $pdo): void {
-    $tables = ['accounting_imports', 'accounting_classifications'];
-    $legacy = ['account_iva6', 'account_iva13', 'account_iva23', 'account_novat'];
-
-    foreach ($tables as $table) {
-        $stmt = $pdo->query("SHOW COLUMNS FROM {$table}");
-        $columns = $stmt->fetchAll(PDO::FETCH_COLUMN);
-        $drops = [];
-        foreach ($legacy as $col) {
-            if (in_array($col, $columns, true)) {
-                $drops[] = "DROP COLUMN `{$col}`";
-            }
-        }
-        if ($drops) {
-            $pdo->exec("ALTER TABLE {$table} " . implode(', ', $drops));
-        }
-    }
-}
-
 ?>

--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -21,7 +21,6 @@ if ($action === 'lines') {
     $id = $_GET['id'] ?? '';
     try {
         $pdo = getPDO();
-        dropLegacyAccountColumns($pdo);
     } catch (RuntimeException $e) {
         http_response_code(400);
         header('Content-Type: application/json');
@@ -79,7 +78,6 @@ if ($action === 'get') {
     $d = $_GET['D'] ?? '';
     try {
         $pdo = getPDO();
-        dropLegacyAccountColumns($pdo);
     } catch (RuntimeException $e) {
         http_response_code(400);
         echo json_encode(['error' => 'Empresa não selecionada']);
@@ -112,7 +110,6 @@ if ($action === 'get') {
     $d = $_POST['D'] ?? '';
     try {
         $pdo = getPDO();
-        dropLegacyAccountColumns($pdo);
     } catch (RuntimeException $e) {
         http_response_code(400);
         echo json_encode(['error' => 'Empresa não selecionada']);
@@ -179,7 +176,6 @@ if ($action === 'get') {
     $id = $_POST['id'] ?? '';
     try {
         $pdo = getPDO();
-        dropLegacyAccountColumns($pdo);
     } catch (RuntimeException $e) {
         http_response_code(400);
         echo json_encode(['error' => 'Empresa não selecionada']);

--- a/migrations/drop_legacy_account_columns.sql
+++ b/migrations/drop_legacy_account_columns.sql
@@ -1,0 +1,9 @@
+ALTER TABLE accounting_imports DROP COLUMN account_iva6;
+ALTER TABLE accounting_imports DROP COLUMN account_iva13;
+ALTER TABLE accounting_imports DROP COLUMN account_iva23;
+ALTER TABLE accounting_imports DROP COLUMN account_novat;
+
+ALTER TABLE accounting_classifications DROP COLUMN account_iva6;
+ALTER TABLE accounting_classifications DROP COLUMN account_iva13;
+ALTER TABLE accounting_classifications DROP COLUMN account_iva23;
+ALTER TABLE accounting_classifications DROP COLUMN account_novat;


### PR DESCRIPTION
## Summary
- add SQL migration to remove legacy per-IVA columns
- stop running dropLegacyAccountColumns at runtime and remove helper

## Testing
- `sqlite3 /tmp/test.db <<'EOF'
CREATE TABLE accounting_imports (
    id INTEGER PRIMARY KEY,
    account_iva6 TEXT,
    account_iva13 TEXT,
    account_iva23 TEXT,
    account_novat TEXT,
    account TEXT
);
CREATE TABLE accounting_classifications (
    id INTEGER PRIMARY KEY,
    account_iva6 TEXT,
    account_iva13 TEXT,
    account_iva23 TEXT,
    account_novat TEXT,
    account TEXT
);
.schema accounting_imports
.schema accounting_classifications
.read migrations/drop_legacy_account_columns.sql
.schema accounting_imports
.schema accounting_classifications
EOF`
- `php -l contabilidade/classificacao-importacao.php`
- `php -l contabilidade/save-analysis.php`
- `php -l contabilidade/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68c572f72ee88320b27b1af7df9b61dd