### PR TITLE
feat: add paginated import classification

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -1,6 +1,9 @@
 window.addEventListener('load', function() {
     var csrfInput = document.getElementById('csrf_token');
     var table = $('#classify-table').DataTable({
+        serverSide: true,
+        processing: true,
+        ajax: 'contabilidade/classificacao-importacao-data.php',
         orderCellsTop: true,
         language: { url: 'vendors/datatables.net/i18n/pt-PT.json' },
         columnDefs: [
@@ -158,7 +161,7 @@ window.addEventListener('load', function() {
                 csrfInput.value = res.csrf_token;
             }
             if (res.success) {
-                table.row($(btn).closest('tr')).remove().draw();
+                table.ajax.reload(null, false);
             } else {
                 alert(res.error || 'Erro ao remover');
             }

--- a/contabilidade/classificacao-importacao-data.php
+++ b/contabilidade/classificacao-importacao-data.php
@@ -1,0 +1,139 @@
+<?php
+require_once __DIR__ . '/../functions.php';
+require_once __DIR__ . '/functions.php';
+
+startSession();
+requireLogin();
+
+$pdo = getPDO();
+dropLegacyAccountColumns($pdo);
+
+$columns = [
+    'id',
+    'account',
+    'field_A',
+    'field_B',
+    'field_C',
+    'field_D',
+    'field_E',
+    'field_F',
+    'field_G',
+    'field_H',
+    'field_I1',
+    'field_I3',
+    'field_I4',
+    'field_I5',
+    'field_I6',
+    'field_I7',
+    'field_I8',
+    'field_N',
+    'field_O',
+    'field_Q',
+    'field_R',
+    'filename'
+];
+
+$draw = (int)($_GET['draw'] ?? 0);
+$start = (int)($_GET['start'] ?? 0);
+$length = (int)($_GET['length'] ?? 10);
+if ($length <= 0) {
+    $length = 10;
+}
+
+$total = (int)$pdo->query('SELECT COUNT(*) FROM accounting_imports')->fetchColumn();
+
+$colList = implode(', ', array_map(fn($c) => "`$c`", $columns));
+$sql = "SELECT $colList FROM accounting_imports ORDER BY id LIMIT :start, :length";
+$stmt = $pdo->prepare($sql);
+$stmt->bindValue(':start', $start, PDO::PARAM_INT);
+$stmt->bindValue(':length', $length, PDO::PARAM_INT);
+$stmt->execute();
+$rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+foreach ($rows as &$row) {
+    $accounts = json_decode($row['account'] ?? '', true) ?: [];
+    $row['account_iva6'] = $accounts['iva6'] ?? '';
+    $row['account_iva13'] = $accounts['iva13'] ?? '';
+    $row['account_iva23'] = $accounts['iva23'] ?? '';
+    $row['account_novat'] = $accounts['novat'] ?? '';
+    $amtIva6 = abs((float) str_replace(',', '.', $row['field_I3'] ?? 0));
+    $amtIva13 = abs((float) str_replace(',', '.', $row['field_I5'] ?? 0));
+    $amtIva23 = abs((float) str_replace(',', '.', $row['field_I7'] ?? 0));
+    $needsNovat = !$amtIva6 && !$amtIva13 && !$amtIva23 && abs((float)($row['field_O'] ?? 0)) > 0;
+    $row['btn_class'] = 'btn-secondary';
+    $hasAnyAccount = (
+        (int)($row['account_iva6'] ?? 0) > 0 ||
+        (int)($row['account_iva13'] ?? 0) > 0 ||
+        (int)($row['account_iva23'] ?? 0) > 0 ||
+        (int)($row['account_novat'] ?? 0) > 0
+    );
+    $allAccounts = (
+        ($amtIva6 == 0 || (int)($row['account_iva6'] ?? 0) > 0) &&
+        ($amtIva13 == 0 || (int)($row['account_iva13'] ?? 0) > 0) &&
+        ($amtIva23 == 0 || (int)($row['account_iva23'] ?? 0) > 0) &&
+        (!$needsNovat || (int)($row['account_novat'] ?? 0) > 0)
+    );
+    $requires = $amtIva6 > 0 || $amtIva13 > 0 || $amtIva23 > 0 || $needsNovat;
+    if (!$requires || $allAccounts) {
+        $row['btn_class'] = 'btn-success';
+    } elseif ($hasAnyAccount) {
+        $row['btn_class'] = 'btn-warning';
+    }
+    $row['needs_novat'] = $needsNovat ? 1 : 0;
+    $row['amt_iva6'] = $amtIva6;
+    $row['amt_iva13'] = $amtIva13;
+    $row['amt_iva23'] = $amtIva23;
+}
+unset($row);
+
+$data = [];
+foreach ($rows as $row) {
+    $actions = '<button type="button" class="btn btn-xs ' . $row['btn_class'] . ' classify-row" '
+        . 'data-id="' . (int)$row['id'] . '" '
+        . 'data-iva6="' . htmlspecialchars($row['account_iva6']) . '" '
+        . 'data-iva13="' . htmlspecialchars($row['account_iva13']) . '" '
+        . 'data-iva23="' . htmlspecialchars($row['account_iva23']) . '" '
+        . 'data-novat="' . htmlspecialchars($row['account_novat']) . '" '
+        . 'data-amt-iva6="' . $row['amt_iva6'] . '" '
+        . 'data-amt-iva13="' . $row['amt_iva13'] . '" '
+        . 'data-amt-iva23="' . $row['amt_iva23'] . '" '
+        . 'data-req-novat="' . $row['needs_novat'] . '" '
+        . 'data-emitter="' . htmlspecialchars($row['field_A'] ?? '') . '" '
+        . 'data-acquirer="' . htmlspecialchars($row['field_B'] ?? '') . '" '
+        . 'data-doctype="' . htmlspecialchars($row['field_D'] ?? '') . '">Classificar</button> '
+        . '<a href="contabilidade/save-analysis.php?action=lines&id=' . (int)$row['id'] . '" '
+        . 'class="btn btn-xs btn-info" target="_blank">Analisar</a> '
+        . '<button type="button" class="btn btn-xs btn-danger remove-row" data-id="' . (int)$row['id'] . '"><i class="fa fa-trash"></i></button>';
+    $pdfLink = '<a href="' . htmlspecialchars($row['filename'] ?? '') . '" target="_blank" class="btn btn-xs btn-secondary"><i class="fa fa-file-pdf-o"></i></a>';
+    $data[] = [
+        htmlspecialchars($row['field_A'] ?? ''),
+        htmlspecialchars($row['field_B'] ?? ''),
+        htmlspecialchars($row['field_C'] ?? ''),
+        htmlspecialchars($row['field_D'] ?? ''),
+        htmlspecialchars($row['field_E'] ?? ''),
+        htmlspecialchars($row['field_F'] ?? ''),
+        htmlspecialchars($row['field_G'] ?? ''),
+        htmlspecialchars($row['field_H'] ?? ''),
+        htmlspecialchars($row['field_I1'] ?? ''),
+        htmlspecialchars($row['field_I3'] ?? ''),
+        htmlspecialchars($row['field_I4'] ?? ''),
+        htmlspecialchars($row['field_I5'] ?? ''),
+        htmlspecialchars($row['field_I6'] ?? ''),
+        htmlspecialchars($row['field_I7'] ?? ''),
+        htmlspecialchars($row['field_I8'] ?? ''),
+        htmlspecialchars($row['field_N'] ?? ''),
+        htmlspecialchars($row['field_O'] ?? ''),
+        htmlspecialchars($row['field_Q'] ?? ''),
+        htmlspecialchars($row['field_R'] ?? ''),
+        $pdfLink,
+        $actions
+    ];
+}
+
+header('Content-Type: application/json; charset=utf-8');
+echo json_encode([
+    'draw' => $draw,
+    'recordsTotal' => $total,
+    'recordsFiltered' => $total,
+    'data' => $data,
+], JSON_UNESCAPED_UNICODE);

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -10,16 +10,6 @@ $useDropzone = false;
 
 $pdo = getPDO();
 dropLegacyAccountColumns($pdo);
-$stmt = $pdo->query('SELECT * FROM accounting_imports');
-$rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
-foreach ($rows as &$row) {
-    $accounts = json_decode($row['account'] ?? '', true) ?: [];
-    $row['account_iva6'] = $accounts['iva6'] ?? '';
-    $row['account_iva13'] = $accounts['iva13'] ?? '';
-    $row['account_iva23'] = $accounts['iva23'] ?? '';
-    $row['account_novat'] = $accounts['novat'] ?? '';
-}
-unset($row);
 $csrfToken = generateCsrfToken();
 
 require_once __DIR__ . '/../header.php';
@@ -53,73 +43,6 @@ require_once __DIR__ . '/../header.php';
                 </tr>
             </thead>
             <tbody>
-            <?php foreach ($rows as $row): ?>
-                <tr>
-                    <td class="text-start"><?= htmlspecialchars($row['field_A'] ?? ''); ?></td>
-                    <td class="text-start"><?= htmlspecialchars($row['field_B'] ?? ''); ?></td>
-                    <td><?= htmlspecialchars($row['field_C'] ?? ''); ?></td>
-                    <td class="text-middle"><?= htmlspecialchars($row['field_D'] ?? ''); ?></td>
-                    <td><?= htmlspecialchars($row['field_E'] ?? ''); ?></td>
-                    <td class="text-middle"><?= htmlspecialchars($row['field_F'] ?? ''); ?></td>
-                    <td><?= htmlspecialchars($row['field_G'] ?? ''); ?></td>
-                    <td><?= htmlspecialchars($row['field_H'] ?? ''); ?></td>
-                    <td><?= htmlspecialchars($row['field_I1'] ?? ''); ?></td>
-                    <td><?= htmlspecialchars($row['field_I3'] ?? ''); ?></td>
-                    <td><?= htmlspecialchars($row['field_I4'] ?? ''); ?></td>
-                    <td><?= htmlspecialchars($row['field_I5'] ?? ''); ?></td>
-                    <td><?= htmlspecialchars($row['field_I6'] ?? ''); ?></td>
-                    <td><?= htmlspecialchars($row['field_I7'] ?? ''); ?></td>
-                    <td><?= htmlspecialchars($row['field_I8'] ?? ''); ?></td>
-                    <td><?= htmlspecialchars($row['field_N'] ?? ''); ?></td>
-                    <td><?= htmlspecialchars($row['field_O'] ?? ''); ?></td>
-                    <td><?= htmlspecialchars($row['field_Q'] ?? ''); ?></td>
-                    <td><?= htmlspecialchars($row['field_R'] ?? ''); ?></td>
-                    <td class="text-center"><a href="<?= htmlspecialchars($row['filename'] ?? ''); ?>" target="_blank" class="btn btn-xs btn-secondary"><i class="fa fa-file-pdf-o"></i></a></td>
-                    <?php
-
-                        // Only consider VAT columns to determine whether accounts are required.
-                        $amtIva6 = abs((float) str_replace(',', '.', $row['field_I3'] ?? 0));
-                        $amtIva13 = abs((float) str_replace(',', '.', $row['field_I5'] ?? 0));
-                        $amtIva23 = abs((float) str_replace(',', '.', $row['field_I7'] ?? 0));
-                        $hasIva6 = $amtIva6 > 0;
-                        $hasIva13 = $amtIva13 > 0;
-                        $hasIva23 = $amtIva23 > 0;
-
-                        $total = abs((float)($row['field_O'] ?? 0));
-                        $needsNovat = !$hasIva6 && !$hasIva13 && !$hasIva23 && $total > 0;
-
-                        $allAccounts = (
-                            ($amtIva6 == 0 || (int)($row['account_iva6'] ?? 0) > 0) &&
-                            ($amtIva13 == 0 || (int)($row['account_iva13'] ?? 0) > 0) &&
-                            ($amtIva23 == 0 || (int)($row['account_iva23'] ?? 0) > 0) &&
-                            (!$needsNovat || (int)($row['account_novat'] ?? 0) > 0)
-                        );
-                        $requires = $hasIva6 || $hasIva13 || $hasIva23 || $needsNovat;
-                        $hasAnyAccount = (
-                            (int)($row['account_iva6'] ?? 0) > 0 ||
-                            (int)($row['account_iva13'] ?? 0) > 0 ||
-                            (int)($row['account_iva23'] ?? 0) > 0 ||
-                            (int)($row['account_novat'] ?? 0) > 0
-                        );
-                        if (!$requires) {
-                            $btnClass = 'btn-success';
-                        } elseif ($allAccounts) {
-                            $btnClass = 'btn-success';
-                        } elseif ($hasAnyAccount) {
-                            $btnClass = 'btn-warning';
-                        } else {
-                            $btnClass = 'btn-secondary';
-                        }
-                    ?>
-                    <td class="text-center">
-
-                        <button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-iva6="<?= htmlspecialchars($row['account_iva6'] ?? ''); ?>" data-iva13="<?= htmlspecialchars($row['account_iva13'] ?? ''); ?>" data-iva23="<?= htmlspecialchars($row['account_iva23'] ?? ''); ?>" data-novat="<?= htmlspecialchars($row['account_novat'] ?? ''); ?>" data-amt-iva6="<?= $amtIva6; ?>" data-amt-iva13="<?= $amtIva13; ?>" data-amt-iva23="<?= $amtIva23; ?>" data-req-novat="<?= $needsNovat ? 1 : 0; ?>" data-emitter="<?= htmlspecialchars($row['field_A'] ?? ''); ?>" data-acquirer="<?= htmlspecialchars($row['field_B'] ?? ''); ?>" data-doctype="<?= htmlspecialchars($row['field_D'] ?? ''); ?>">Classificar</button>
-
-                        <a href="contabilidade/save-analysis.php?action=lines&id=<?= (int)$row['id']; ?>" class="btn btn-xs btn-info" target="_blank">Analisar</a>
-                        <button type="button" class="btn btn-xs btn-danger remove-row" data-id="<?= (int)$row['id']; ?>"><i class="fa fa-trash"></i></button>
-                    </td>
-                </tr>
-            <?php endforeach; ?>
             </tbody>
         </table>
         <input type="hidden" id="csrf_token" value="<?= htmlspecialchars($csrfToken); ?>">


### PR DESCRIPTION
## Summary
- load import classification data through new paginated endpoint
- query explicit columns instead of `SELECT *`
- update frontend to use server-side DataTables and reload after deletions

## Testing
- `php -l contabilidade/classificacao-importacao.php`
- `php -l contabilidade/classificacao-importacao-data.php`
- `node --check assets/js/classificacao_importacao.js`


------
https://chatgpt.com/codex/tasks/task_e_68c57336d76c8320b9983cc172db2541