### PR TITLE
feat: add purchases import option

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -4,6 +4,7 @@ window.addEventListener('load', function() {
     var form = document.getElementById('multi-upload');
     var csrfInput = form.querySelector('input[name="csrf_token"]');
     var importBtn = document.getElementById('import-btn');
+    var importComprasBtn = document.getElementById('import-compras-btn');
 
     var table;
     if ($.fn.dataTable.isDataTable('#qr-table')) {
@@ -124,8 +125,13 @@ window.addEventListener('load', function() {
     });
 
     dz.on('queuecomplete', function() {
-        if (importBtn && table.rows().data().length) {
-            importBtn.style.display = 'inline-block';
+        if (table.rows().data().length) {
+            if (importBtn) {
+                importBtn.style.display = 'inline-block';
+            }
+            if (importComprasBtn) {
+                importComprasBtn.style.display = 'inline-block';
+            }
         }
     });
 
@@ -166,48 +172,58 @@ window.addEventListener('load', function() {
         });
     });
 
-    if (importBtn) {
-        importBtn.addEventListener('click', function() {
-            var nodes = table.rows().nodes().toArray();
-            if (!nodes.length) {
-                alert('Não há dados para importar');
-                return;
+    function handleImport(type) {
+        var nodes = table.rows().nodes().toArray();
+        if (!nodes.length) {
+            alert('Não há dados para importar');
+            return;
+        }
+        var keys = ['A','B','C','D','E','F','G','H','I1','I3','I4','I5','I6','I7','I8','N','O','Q','R'];
+        var payload = nodes.map(function(node) {
+            var data = table.row(node).data() || [];
+            var obj = {};
+            for (var i = 0; i < keys.length; i++) {
+                obj[keys[i]] = data[i] || '';
             }
-            var keys = ['A','B','C','D','E','F','G','H','I1','I3','I4','I5','I6','I7','I8','N','O','Q','R'];
-            var payload = nodes.map(function(node) {
-                var data = table.row(node).data() || [];
-                var obj = {};
-                for (var i = 0; i < keys.length; i++) {
-                    obj[keys[i]] = data[i] || '';
-                }
-                obj['filename'] = $(node).find('.delete-row').data('file') || '';
-                return obj;
-            });
-            fetch('contabilidade/upload.php?action=import', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({ rows: payload, csrf_token: csrfInput.value })
-            })
-            .then(function(res) { return res.json(); })
-            .then(function(res) {
-                if (res.csrf_token) {
-                    csrfInput.value = res.csrf_token;
-                }
-                if (res.success) {
-                    alert('Importação concluída');
-                    importBtn.style.display = 'none';
-                    table.clear().draw();
-                    dz.removeAllFiles(true);
-                } else {
-                    alert(res.error || 'Falha na importação');
-                }
-            })
-            .catch(function() {
-                alert('Falha na importação');
-            });
+            obj['filename'] = $(node).find('.delete-row').data('file') || '';
+            return obj;
         });
+        fetch('contabilidade/upload.php?action=import', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ rows: payload, import_type: type, csrf_token: csrfInput.value })
+        })
+        .then(function(res) { return res.json(); })
+        .then(function(res) {
+            if (res.csrf_token) {
+                csrfInput.value = res.csrf_token;
+            }
+            if (res.success) {
+                alert('Importação concluída');
+                if (importBtn) {
+                    importBtn.style.display = 'none';
+                }
+                if (importComprasBtn) {
+                    importComprasBtn.style.display = 'none';
+                }
+                table.clear().draw();
+                dz.removeAllFiles(true);
+            } else {
+                alert(res.error || 'Falha na importação');
+            }
+        })
+        .catch(function() {
+            alert('Falha na importação');
+        });
+    }
+
+    if (importBtn) {
+        importBtn.addEventListener('click', function() { handleImport(1); });
+    }
+    if (importComprasBtn) {
+        importComprasBtn.addEventListener('click', function() { handleImport(2); });
     }
 
 });

--- a/assets/js/mobile_capture.js
+++ b/assets/js/mobile_capture.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', function () {
     var fileBtn = document.getElementById('mobile-file-btn');
     var csrfInput = document.querySelector('#multi-upload input[name="csrf_token"]');
     var importBtn = document.getElementById('import-btn');
+    var importComprasBtn = document.getElementById('import-compras-btn');
     var table = window.accountingTable;
 
     if (!cameraBtn || !fileBtn) {
@@ -90,8 +91,13 @@ document.addEventListener('DOMContentLoaded', function () {
                         table.row.add(row).draw(); 
                     }
                 });
-                if (importBtn && table && table.rows().data().length) {
-                    importBtn.style.display = 'inline-block';
+                if (table && table.rows().data().length) {
+                    if (importBtn) {
+                        importBtn.style.display = 'inline-block';
+                    }
+                    if (importComprasBtn) {
+                        importComprasBtn.style.display = 'inline-block';
+                    }
                 }
             } else {
                 alert('QR code não encontrado');

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -10,7 +10,7 @@ $useDropzone = false;
 
 $pdo = getPDO();
 dropLegacyAccountColumns($pdo);
-$stmt = $pdo->query('SELECT * FROM accounting_imports');
+$stmt = $pdo->query('SELECT * FROM accounting_imports WHERE import_type = 1');
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 foreach ($rows as &$row) {
     $accounts = json_decode($row['account'] ?? '', true) ?: [];

--- a/contabilidade/upload.php
+++ b/contabilidade/upload.php
@@ -39,6 +39,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             exit;
         }
 
+        $importType = isset($data['import_type']) ? (int)$data['import_type'] : 1;
+
         $pdo = getPDO();
 
         // Preencher conta associada, se existir classificação
@@ -53,7 +55,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         unset($row);
 
         // Inserir linhas na tabela accounting_imports, evitando duplicados pelo field_H
-        $insert = $pdo->prepare('INSERT INTO accounting_imports (field_A, field_B, field_C, field_D, field_E, field_F, field_G, field_H, field_I1, field_I3, field_I4, field_I5, field_I6, field_I7, field_I8, field_N, field_O, field_Q, field_R, account, filename) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)');
+        $insert = $pdo->prepare('INSERT INTO accounting_imports (field_A, field_B, field_C, field_D, field_E, field_F, field_G, field_H, field_I1, field_I3, field_I4, field_I5, field_I6, field_I7, field_I8, field_N, field_O, field_Q, field_R, account, filename, import_type) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)');
         $exists = $pdo->prepare('SELECT 1 FROM accounting_imports WHERE field_H = ? LIMIT 1');
         foreach ($rows as $row) {
             $fieldH = $row['H'] ?? '';
@@ -85,7 +87,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $row['Q'] ?? '',
                 $row['R'] ?? '',
                 $row['account'] ?? '',
-                $row['filename'] ?? ''
+                $row['filename'] ?? '',
+                $importType
             ]);
         }
 
@@ -175,6 +178,7 @@ $csrfToken = generateCsrfToken();
         <tbody></tbody>
         </table>
         <button id="import-btn" class="btn btn-success mt-3" style="display: none;">Importar</button>
+        <button id="import-compras-btn" class="btn btn-primary mt-3" style="display: none;">Importar Compras</button>
     </div>
 
 </div>

--- a/schema.sql
+++ b/schema.sql
@@ -154,6 +154,7 @@ CREATE TABLE IF NOT EXISTS accounting_imports (
     field_R VARCHAR(255) DEFAULT '',
     account VARCHAR(255) DEFAULT '',
     filename VARCHAR(255) DEFAULT '',
+    import_type TINYINT DEFAULT 1,
     dte_add TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 


### PR DESCRIPTION
## Summary
- add optional purchases import button
- track import type for accounting vs purchases

## Testing
- `php -l contabilidade/upload.php`
- `php -l contabilidade/classificacao-importacao.php`


------
https://chatgpt.com/codex/tasks/task_e_68c5750216c4832090c43aae1b12ee09