### PR TITLE
Ensure 'Importar Compras' button is visible

### DIFF
--- a/contabilidade/upload.php
+++ b/contabilidade/upload.php
@@ -178,7 +178,7 @@ $csrfToken = generateCsrfToken();
         <tbody></tbody>
         </table>
         <button id="import-btn" class="btn btn-success mt-3" style="display: none;">Importar</button>
-        <button id="import-compras-btn" class="btn btn-primary mt-3" style="display: none;">Importar Compras</button>
+        <button id="import-compras-btn" class="btn btn-primary mt-3">Importar Compras</button>
     </div>
 
 </div>


### PR DESCRIPTION
## Summary
- Show 'Importar Compras' button on accounting upload screen

## Testing
- `php -l contabilidade/upload.php`


------
https://chatgpt.com/codex/tasks/task_e_68c58bfaa0a08320a604b10a8fe54132