### PR TITLE
Show purchase import button with import actions

### DIFF
--- a/contabilidade/upload.php
+++ b/contabilidade/upload.php
@@ -178,7 +178,7 @@ $csrfToken = generateCsrfToken();
         <tbody></tbody>
         </table>
         <button id="import-btn" class="btn btn-success mt-3" style="display: none;">Importar</button>
-        <button id="import-compras-btn" class="btn btn-primary mt-3">Importar Compras</button>
+        <button id="import-compras-btn" class="btn btn-primary mt-3" style="display: none;">Importar Compras</button>
     </div>
 
 </div>


### PR DESCRIPTION
## Summary
- Hide "Importar Compras" by default so it displays only when "Importar" is shown

## Testing
- `composer test` (fails: Command "test" is not defined.)
- `php -l contabilidade/upload.php`


------
https://chatgpt.com/codex/tasks/task_e_68c58d2040608320b6b901d9d3cf776f