### PR TITLE
Ensure purchase import button toggles with main import action

### DIFF
--- a/assets/js/accounting_upload.js
+++ b/assets/js/accounting_upload.js
@@ -6,6 +6,15 @@ window.addEventListener('load', function() {
     var importBtn = document.getElementById('import-btn');
     var importComprasBtn = document.getElementById('import-compras-btn');
 
+    function showImportButtons() {
+        if (importBtn) {
+            importBtn.style.display = 'inline-block';
+        }
+        if (importComprasBtn) {
+            importComprasBtn.style.display = 'inline-block';
+        }
+    }
+
     var table;
     if ($.fn.dataTable.isDataTable('#qr-table')) {
         table = $('#qr-table').DataTable();
@@ -64,6 +73,9 @@ window.addEventListener('load', function() {
                 row.push(actions);
                 table.row.add(row).draw(false);
             });
+            if (table.rows().data().length) {
+                showImportButtons();
+            }
         } else {
             alert('QR code não encontrado');
             if (data.file) {
@@ -126,12 +138,7 @@ window.addEventListener('load', function() {
 
     dz.on('queuecomplete', function() {
         if (table.rows().data().length) {
-            if (importBtn) {
-                importBtn.style.display = 'inline-block';
-            }
-            if (importComprasBtn) {
-                importComprasBtn.style.display = 'inline-block';
-            }
+            showImportButtons();
         }
     });
 

--- a/assets/js/mobile_capture.js
+++ b/assets/js/mobile_capture.js
@@ -12,6 +12,14 @@ document.addEventListener('DOMContentLoaded', function () {
     var csrfInput = document.querySelector('#multi-upload input[name="csrf_token"]');
     var importBtn = document.getElementById('import-btn');
     var importComprasBtn = document.getElementById('import-compras-btn');
+    function showImportButtons() {
+        if (importBtn) {
+            importBtn.style.display = 'inline-block';
+        }
+        if (importComprasBtn) {
+            importComprasBtn.style.display = 'inline-block';
+        }
+    }
     var table = window.accountingTable;
 
     if (!cameraBtn || !fileBtn) {
@@ -92,12 +100,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     }
                 });
                 if (table && table.rows().data().length) {
-                    if (importBtn) {
-                        importBtn.style.display = 'inline-block';
-                    }
-                    if (importComprasBtn) {
-                        importComprasBtn.style.display = 'inline-block';
-                    }
+                    showImportButtons();
                 }
             } else {
                 alert('QR code não encontrado');


### PR DESCRIPTION
## Summary
- Show both import buttons with a shared helper
- Display purchases import button whenever the table has rows

## Testing
- `node --check assets/js/accounting_upload.js`
- `node --check assets/js/mobile_capture.js`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c594296cac8320a30a35842b3c215f