### PR TITLE
Add Compras module for conditional purchase import

### DIFF
--- a/contabilidade/upload.php
+++ b/contabilidade/upload.php
@@ -3,6 +3,8 @@ require_once __DIR__ . '/../functions.php';
 
 startSession();
 
+$comprasActive = isModuleActive('compras');
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     header('Content-Type: application/json');
 
@@ -178,7 +180,9 @@ $csrfToken = generateCsrfToken();
         <tbody></tbody>
         </table>
         <button id="import-btn" class="btn btn-success mt-3" style="display: none;">Importar</button>
+        <?php if ($comprasActive): ?>
         <button id="import-compras-btn" class="btn btn-primary mt-3" style="display: none;">Importar Compras</button>
+        <?php endif; ?>
     </div>
 
 </div>

--- a/definicoes.php
+++ b/definicoes.php
@@ -13,6 +13,7 @@ $contentTypes = getContentTypes();
 $availableModules = [
     'contabilidade' => 'Contabilidade',
     'faturacao' => 'Faturação',
+    'compras' => 'Compras',
 ];
 
 $generalSaved = false;


### PR DESCRIPTION
## Summary
- allow enabling a new **Compras** module in settings
- only display “Importar Compras” when the Compras module is active

## Testing
- `php -l definicoes.php contabilidade/upload.php`
- `composer validate --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68c59b47ff548320b5e4a3b14b94bd3e