### PR TITLE
Add import type submenu for classification and filter records

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -8,10 +8,15 @@ window.addEventListener('load', function() {
         });
     }
     var csrfInput = document.getElementById('csrf_token');
+    var importTypeInput = document.getElementById('import_type');
+    var importType = importTypeInput ? importTypeInput.value : 1;
     var table = $('#classify-table').DataTable({
         serverSide: true,
         processing: true,
-        ajax: 'contabilidade/classificacao-importacao-data.php',
+        ajax: {
+            url: 'contabilidade/classificacao-importacao-data.php',
+            data: function(d) { d.import_type = importType; }
+        },
         orderCellsTop: true,
         language: { url: 'vendors/datatables.net/i18n/pt-PT.json' },
         columnDefs: [

--- a/contabilidade/classificacao-importacao-data.php
+++ b/contabilidade/classificacao-importacao-data.php
@@ -6,6 +6,7 @@ startSession();
 requireLogin();
 
 $pdo = getPDO();
+$importType = (int)($_GET['import_type'] ?? 1);
 dropLegacyAccountColumns($pdo);
 
 $columns = [
@@ -40,13 +41,16 @@ if ($length <= 0) {
     $length = 10;
 }
 
-$total = (int)$pdo->query('SELECT COUNT(*) FROM accounting_imports')->fetchColumn();
+$totalStmt = $pdo->prepare('SELECT COUNT(*) FROM accounting_imports WHERE import_type = :importType');
+$totalStmt->execute([':importType' => $importType]);
+$total = (int)$totalStmt->fetchColumn();
 
 $colList = implode(', ', array_map(fn($c) => "`$c`", $columns));
-$sql = "SELECT $colList FROM accounting_imports ORDER BY id LIMIT :start, :length";
+$sql = "SELECT $colList FROM accounting_imports WHERE import_type = :importType ORDER BY id LIMIT :start, :length";
 $stmt = $pdo->prepare($sql);
 $stmt->bindValue(':start', $start, PDO::PARAM_INT);
 $stmt->bindValue(':length', $length, PDO::PARAM_INT);
+$stmt->bindValue(':importType', $importType, PDO::PARAM_INT);
 $stmt->execute();
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -9,8 +9,10 @@ $useDataTables = true;
 $useDropzone = false;
 
 $pdo = getPDO();
+$importType = (int)($_GET['import_type'] ?? 1);
 
-$stmt = $pdo->query('SELECT * FROM accounting_imports');
+$stmt = $pdo->prepare('SELECT * FROM accounting_imports WHERE import_type = :type');
+$stmt->execute([':type' => $importType]);
 
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 foreach ($rows as &$row) {
@@ -26,6 +28,7 @@ $csrfToken = generateCsrfToken();
 
 require_once __DIR__ . '/../header.php';
 ?>
+<input type="hidden" id="import_type" value="<?= htmlspecialchars($importType); ?>">
 <div class="row mb-3">
     <div class="col-12">
         <table id="classify-table" class="table table-striped">

--- a/header.php
+++ b/header.php
@@ -100,7 +100,13 @@ foreach ($sidebarTypes as $sidebarType):
                                     <li><a href="<?= BASE_URL ?>contabilidade/saft">SAF-T</a></li>
                                 </ul>
                             </li>
-                            <li><a href="<?= BASE_URL ?>contabilidade/classificacao-importacao"><i class="fa fa-tasks"></i> Classificação e Importação</a></li>
+                            <li>
+                                <a><i class="fa fa-tasks"></i> Classificação e Importação <span class="fa fa-chevron-down"></span></a>
+                                <ul class="nav child_menu">
+                                    <li><a href="<?= BASE_URL ?>contabilidade/classificacao-importacao?import_type=1">Contabilidade -> Compras</a></li>
+                                    <li><a href="<?= BASE_URL ?>contabilidade/classificacao-importacao?import_type=2">Importação de Compras</a></li>
+                                </ul>
+                            </li>
 <?php endif; ?>
                         </ul>
                     </div>


### PR DESCRIPTION
## Summary
- Add submenu links under "Classificação e Importação" for Contabilidade -> Compras and Importação de Compras
- Filter classification listings by import_type and pass selection to DataTables
- Send import type in AJAX requests for dynamic tables

## Testing
- `php -l contabilidade/classificacao-importacao.php`
- `php -l contabilidade/classificacao-importacao-data.php`
- `php -l header.php`
- `node --check assets/js/classificacao_importacao.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5de6e454c83208802127670e7043c