### PR TITLE
Adjust import actions and module menus

### DIFF
--- a/contabilidade/classificacao-importacao-data.php
+++ b/contabilidade/classificacao-importacao-data.php
@@ -92,22 +92,28 @@ unset($row);
 
 $data = [];
 foreach ($rows as $row) {
-    $actions = '<button type="button" class="btn btn-xs ' . $row['btn_class'] . ' classify-row" '
-        . 'data-id="' . (int)$row['id'] . '" '
-        . 'data-iva6="' . htmlspecialchars($row['account_iva6']) . '" '
-        . 'data-iva13="' . htmlspecialchars($row['account_iva13']) . '" '
-        . 'data-iva23="' . htmlspecialchars($row['account_iva23']) . '" '
-        . 'data-novat="' . htmlspecialchars($row['account_novat']) . '" '
-        . 'data-amt-iva6="' . $row['amt_iva6'] . '" '
-        . 'data-amt-iva13="' . $row['amt_iva13'] . '" '
-        . 'data-amt-iva23="' . $row['amt_iva23'] . '" '
-        . 'data-req-novat="' . $row['needs_novat'] . '" '
-        . 'data-emitter="' . htmlspecialchars($row['field_A'] ?? '') . '" '
-        . 'data-acquirer="' . htmlspecialchars($row['field_B'] ?? '') . '" '
-        . 'data-doctype="' . htmlspecialchars($row['field_D'] ?? '') . '">Classificar</button> '
-        . '<a href="contabilidade/save-analysis.php?action=lines&id=' . (int)$row['id'] . '" '
-        . 'class="btn btn-xs btn-info" target="_blank">Analisar</a> '
-        . '<button type="button" class="btn btn-xs btn-danger remove-row" data-id="' . (int)$row['id'] . '"><i class="fa fa-trash"></i></button>';
+    $actionsParts = [];
+    if ($importType === 1) {
+        $actionsParts[] = '<button type="button" class="btn btn-xs ' . $row['btn_class'] . ' classify-row" '
+            . 'data-id="' . (int)$row['id'] . '" '
+            . 'data-iva6="' . htmlspecialchars($row['account_iva6']) . '" '
+            . 'data-iva13="' . htmlspecialchars($row['account_iva13']) . '" '
+            . 'data-iva23="' . htmlspecialchars($row['account_iva23']) . '" '
+            . 'data-novat="' . htmlspecialchars($row['account_novat']) . '" '
+            . 'data-amt-iva6="' . $row['amt_iva6'] . '" '
+            . 'data-amt-iva13="' . $row['amt_iva13'] . '" '
+            . 'data-amt-iva23="' . $row['amt_iva23'] . '" '
+            . 'data-req-novat="' . $row['needs_novat'] . '" '
+            . 'data-emitter="' . htmlspecialchars($row['field_A'] ?? '') . '" '
+            . 'data-acquirer="' . htmlspecialchars($row['field_B'] ?? '') . '" '
+            . 'data-doctype="' . htmlspecialchars($row['field_D'] ?? '') . '">Classificar</button>';
+    }
+    if ($importType === 2) {
+        $actionsParts[] = '<a href="contabilidade/save-analysis.php?action=lines&id=' . (int)$row['id'] . '" '
+            . 'class="btn btn-xs btn-info" target="_blank">Analisar</a>';
+    }
+    $actionsParts[] = '<button type="button" class="btn btn-xs btn-danger remove-row" data-id="' . (int)$row['id'] . '"><i class="fa fa-trash"></i></button>';
+    $actions = implode(' ', $actionsParts);
     $pdfLink = '<a href="' . htmlspecialchars($row['filename'] ?? '') . '" target="_blank" class="btn btn-xs btn-secondary"><i class="fa fa-file-pdf-o"></i></a>';
     $data[] = [
         htmlspecialchars($row['field_A'] ?? ''),

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -119,9 +119,13 @@ require_once __DIR__ . '/../header.php';
                     ?>
                     <td class="text-center">
 
+                        <?php if ($importType === 1): ?>
                         <button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-iva6="<?= htmlspecialchars($row['account_iva6'] ?? ''); ?>" data-iva13="<?= htmlspecialchars($row['account_iva13'] ?? ''); ?>" data-iva23="<?= htmlspecialchars($row['account_iva23'] ?? ''); ?>" data-novat="<?= htmlspecialchars($row['account_novat'] ?? ''); ?>" data-amt-iva6="<?= $amtIva6; ?>" data-amt-iva13="<?= $amtIva13; ?>" data-amt-iva23="<?= $amtIva23; ?>" data-req-novat="<?= $needsNovat ? 1 : 0; ?>" data-emitter="<?= htmlspecialchars($row['field_A'] ?? ''); ?>" data-acquirer="<?= htmlspecialchars($row['field_B'] ?? ''); ?>" data-doctype="<?= htmlspecialchars($row['field_D'] ?? ''); ?>">Classificar</button>
+                        <?php endif; ?>
 
+                        <?php if ($importType === 2): ?>
                         <a href="contabilidade/save-analysis.php?action=lines&id=<?= (int)$row['id']; ?>&csrf_token=<?= urlencode($csrfToken); ?>" class="btn btn-xs btn-info" target="_blank">Analisar</a>
+                        <?php endif; ?>
                         <button type="button" class="btn btn-xs btn-danger remove-row" data-id="<?= (int)$row['id']; ?>"><i class="fa fa-trash"></i></button>
                     </td>
                 </tr>

--- a/definicoes.php
+++ b/definicoes.php
@@ -12,7 +12,6 @@ $csrfToken = generateCsrfToken();
 $contentTypes = getContentTypes();
 $availableModules = [
     'contabilidade' => 'Contabilidade',
-    'faturacao' => 'Faturação',
     'compras' => 'Compras',
 ];
 

--- a/header.php
+++ b/header.php
@@ -100,11 +100,17 @@ foreach ($sidebarTypes as $sidebarType):
                                     <li><a href="<?= BASE_URL ?>contabilidade/saft">SAF-T</a></li>
                                 </ul>
                             </li>
+<?php endif; ?>
+<?php if (isModuleActive('contabilidade') || isModuleActive('compras')): ?>
                             <li>
                                 <a><i class="fa fa-tasks"></i> Classificação e Importação <span class="fa fa-chevron-down"></span></a>
                                 <ul class="nav child_menu">
+<?php if (isModuleActive('contabilidade')): ?>
                                     <li><a href="<?= BASE_URL ?>contabilidade/classificacao-importacao?import_type=1">Contabilidade -> Compras</a></li>
+<?php endif; ?>
+<?php if (isModuleActive('compras')): ?>
                                     <li><a href="<?= BASE_URL ?>contabilidade/classificacao-importacao?import_type=2">Importação de Compras</a></li>
+<?php endif; ?>
                                 </ul>
                             </li>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- Show classification or analysis buttons based on `import_type`
- Activate classification menu when either Contabilidade or Compras module is enabled and remove Faturação option

## Testing
- `php -l contabilidade/classificacao-importacao.php`
- `php -l contabilidade/classificacao-importacao-data.php`
- `php -l header.php`
- `php -l definicoes.php`


------
https://chatgpt.com/codex/tasks/task_e_68c5e26078748320a353dad04abf31bf