### PR TITLE
Handle missing PNotify in classificacao_importacao.js

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -1,11 +1,15 @@
 window.addEventListener('load', function() {
     function showError(message) {
-        new PNotify({
-            title: 'Erro',
-            text: message,
-            type: 'error',
-            styling: 'bootstrap3'
-        });
+        if (window.PNotify) {
+            new PNotify({
+                title: 'Erro',
+                text: message,
+                type: 'error',
+                styling: 'bootstrap3'
+            });
+        } else {
+            alert(message);
+        }
     }
 
     function fetchJson(url, options) {


### PR DESCRIPTION
## Summary
- Avoid ReferenceError when PNotify library isn't loaded
- Fallback to simple alert for error notifications

## Testing
- `node --check assets/js/classificacao_importacao.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e62a5a3c8320b02db68242f5e6d9