### PR TITLE
Fix missing CSRF token for analysis links

### DIFF
--- a/contabilidade/classificacao-importacao-data.php
+++ b/contabilidade/classificacao-importacao-data.php
@@ -7,6 +7,8 @@ requireLogin();
 
 $pdo = getPDO();
 $importType = (int)($_GET['import_type'] ?? 1);
+// Reuse the existing session CSRF token so links can be authenticated
+$csrfToken = generateCsrfToken();
 dropLegacyAccountColumns($pdo);
 
 $columns = [
@@ -109,7 +111,8 @@ foreach ($rows as $row) {
             . 'data-doctype="' . htmlspecialchars($row['field_D'] ?? '') . '">Classificar</button>';
     }
     if ($importType === 2) {
-        $actionsParts[] = '<a href="contabilidade/save-analysis.php?action=lines&id=' . (int)$row['id'] . '" '
+        $actionsParts[] = '<a href="contabilidade/save-analysis.php?action=lines&id=' . (int)$row['id']
+            . '&csrf_token=' . urlencode($csrfToken) . '" '
             . 'class="btn btn-xs btn-info" target="_blank">Analisar</a>';
     }
     $actionsParts[] = '<button type="button" class="btn btn-xs btn-danger remove-row" data-id="' . (int)$row['id'] . '"><i class="fa fa-trash"></i></button>';


### PR DESCRIPTION
## Summary
- ensure DataTables analysis links include CSRF token

## Testing
- `php -l contabilidade/classificacao-importacao-data.php`


------
https://chatgpt.com/codex/tasks/task_e_68c5e89d16d0832086dfc17a62c8e15e