### PR TITLE
Cache OCR line items and display in modal

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -98,6 +98,8 @@ window.addEventListener('load', function() {
     var classifyModal = new bootstrap.Modal(document.getElementById('classifyModal'));
     var form = document.getElementById('classify-form');
     var currentBtn = null;
+    var linesModal = new bootstrap.Modal(document.getElementById('linesModal'));
+    var linesContainer = document.getElementById('linesContainer');
 
     $('#classify-table').on('click', '.classify-row', function() {
         var btn = this;
@@ -201,5 +203,56 @@ window.addEventListener('load', function() {
             showError(err.message || 'Erro ao remover');
         });
     });
+
+    // Handle line analysis (import type 2)
+    $('#classify-table').on('click', '.analyze-lines', function() {
+        var btn = this;
+        var id = btn.getAttribute('data-id');
+        var params = new URLSearchParams({
+            action: 'lines',
+            id: id,
+            csrf_token: csrfInput.value
+        });
+        fetchJson('contabilidade/save-analysis.php?' + params.toString())
+            .then(function(res) {
+                if (res.csrf_token) {
+                    csrfInput.value = res.csrf_token;
+                }
+                if (res.error) {
+                    showError(res.error);
+                    return;
+                }
+                renderLines(res);
+                linesModal.show();
+            })
+            .catch(function(err) {
+                showError(err.message || 'Erro na análise');
+            });
+    });
+
+    function renderLines(lines) {
+        if (!Array.isArray(lines) || lines.length === 0) {
+            linesContainer.innerHTML = '<p>Sem linhas detectadas</p>';
+            return;
+        }
+        var headers = [];
+        lines.forEach(function(line) {
+            Object.keys(line).forEach(function(key) {
+                if (headers.indexOf(key) === -1) {
+                    headers.push(key);
+                }
+            });
+        });
+        var html = '<table class="table table-striped"><thead><tr>';
+        headers.forEach(function(h) { html += '<th>' + h + '</th>'; });
+        html += '</tr></thead><tbody>';
+        lines.forEach(function(line) {
+            html += '<tr>';
+            headers.forEach(function(h) { html += '<td>' + (line[h] || '') + '</td>'; });
+            html += '</tr>';
+        });
+        html += '</tbody></table>';
+        linesContainer.innerHTML = html;
+    }
 });
 

--- a/contabilidade/classificacao-importacao-data.php
+++ b/contabilidade/classificacao-importacao-data.php
@@ -111,9 +111,7 @@ foreach ($rows as $row) {
             . 'data-doctype="' . htmlspecialchars($row['field_D'] ?? '') . '">Classificar</button>';
     }
     if ($importType === 2) {
-        $actionsParts[] = '<a href="contabilidade/save-analysis.php?action=lines&id=' . (int)$row['id']
-            . '&csrf_token=' . urlencode($csrfToken) . '" '
-            . 'class="btn btn-xs btn-info" target="_blank">Analisar</a>';
+        $actionsParts[] = '<button type="button" class="btn btn-xs btn-info analyze-lines" data-id="' . (int)$row['id'] . '">Analisar</button>';
     }
     $actionsParts[] = '<button type="button" class="btn btn-xs btn-danger remove-row" data-id="' . (int)$row['id'] . '"><i class="fa fa-trash"></i></button>';
     $actions = implode(' ', $actionsParts);

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -124,7 +124,7 @@ require_once __DIR__ . '/../header.php';
                         <?php endif; ?>
 
                         <?php if ($importType === 2): ?>
-                        <a href="contabilidade/save-analysis.php?action=lines&id=<?= (int)$row['id']; ?>&csrf_token=<?= urlencode($csrfToken); ?>" class="btn btn-xs btn-info" target="_blank">Analisar</a>
+                        <button type="button" class="btn btn-xs btn-info analyze-lines" data-id="<?= (int)$row['id']; ?>">Analisar</button>
                         <?php endif; ?>
                         <button type="button" class="btn btn-xs btn-danger remove-row" data-id="<?= (int)$row['id']; ?>"><i class="fa fa-trash"></i></button>
                     </td>
@@ -134,7 +134,7 @@ require_once __DIR__ . '/../header.php';
             </tbody>
         </table>
         <input type="hidden" id="csrf_token" value="<?= htmlspecialchars($csrfToken); ?>">
-    </div>
+</div>
 </div>
 <div class="modal fade" id="classifyModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">
@@ -167,6 +167,22 @@ require_once __DIR__ . '/../header.php';
                     <button type="submit" class="btn btn-primary">Guardar</button>
                 </div>
             </form>
+</div>
+</div>
+</div>
+<div class="modal fade" id="linesModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Linhas do Documento</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+            </div>
+            <div class="modal-body">
+                <div id="linesContainer"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Confirmar</button>
+            </div>
         </div>
     </div>
 </div>

--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -34,13 +34,24 @@ if ($action === 'lines') {
         echo json_encode(['error' => 'Empresa não selecionada']);
         exit;
     }
-    $stmt = $pdo->prepare('SELECT id, filename FROM accounting_imports WHERE id = ?');
+    $stmt = $pdo->prepare('SELECT id, filename, line_items FROM accounting_imports WHERE id = ?');
     $stmt->execute([$id]);
     $row = $stmt->fetch(PDO::FETCH_ASSOC);
     if (! $row) {
         http_response_code(404);
         exit;
     }
+    // If line items already stored, return them without invoking OCR again.
+    if (!empty($row['line_items'])) {
+        $items = json_decode($row['line_items'], true);
+        if (!is_array($items)) {
+            $items = [];
+        }
+        header('Content-Type: application/json');
+        echo json_encode($items, JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+
     $path = dirname(__DIR__) . '/' . $row['filename'];
     $ocrProvider = getSetting('ocr_provider', 'tesseract');
 
@@ -53,6 +64,9 @@ if ($action === 'lines') {
 
     try {
         $items = parseInvoiceLineTextract($path);
+        // Store OCR result so subsequent requests can reuse it.
+        $stmt = $pdo->prepare('UPDATE accounting_imports SET line_items = ? WHERE id = ?');
+        $stmt->execute([json_encode($items, JSON_UNESCAPED_UNICODE), $id]);
         header('Content-Type: application/json');
         echo json_encode($items, JSON_UNESCAPED_UNICODE);
         exit;

--- a/migrations/add_accounting_imports_line_items_column.sql
+++ b/migrations/add_accounting_imports_line_items_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE accounting_imports ADD COLUMN line_items LONGTEXT DEFAULT NULL;

--- a/schema.sql
+++ b/schema.sql
@@ -153,6 +153,7 @@ CREATE TABLE IF NOT EXISTS accounting_imports (
     field_Q VARCHAR(255) DEFAULT '',
     field_R VARCHAR(255) DEFAULT '',
     account VARCHAR(255) DEFAULT '',
+    line_items LONGTEXT DEFAULT NULL,
     filename VARCHAR(255) DEFAULT '',
     import_type TINYINT DEFAULT 1,
     dte_add TIMESTAMP DEFAULT CURRENT_TIMESTAMP


### PR DESCRIPTION
## Summary
- cache extracted invoice lines in new `line_items` column
- show stored lines in modal instead of new tab and reuse cached data
- migration to add `line_items` column to `accounting_imports`

## Testing
- `php -l contabilidade/save-analysis.php`
- `php -l contabilidade/classificacao-importacao.php`
- `php -l contabilidade/classificacao-importacao-data.php`


------
https://chatgpt.com/codex/tasks/task_e_68c5ebcc99f08320ad0bf7b1226bd955