### PR TITLE
Remove CSRF requirement from line analysis and hide EXPENSE_ROW column

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -210,14 +210,10 @@ window.addEventListener('load', function() {
         var id = btn.getAttribute('data-id');
         var params = new URLSearchParams({
             action: 'lines',
-            id: id,
-            csrf_token: csrfInput.value
+            id: id
         });
         fetchJson('contabilidade/save-analysis.php?' + params.toString())
             .then(function(res) {
-                if (res.csrf_token) {
-                    csrfInput.value = res.csrf_token;
-                }
                 if (res.error) {
                     showError(res.error);
                     return;
@@ -238,7 +234,7 @@ window.addEventListener('load', function() {
         var headers = [];
         lines.forEach(function(line) {
             Object.keys(line).forEach(function(key) {
-                if (headers.indexOf(key) === -1) {
+                if (key !== 'EXPENSE_ROW' && headers.indexOf(key) === -1) {
                     headers.push(key);
                 }
             });

--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -18,13 +18,6 @@ if ($action === 'lines') {
         http_response_code(403);
         exit;
     }
-    $token = $_GET['csrf_token'] ?? $_POST['csrf_token'] ?? '';
-    if (!validateCsrfToken($token)) {
-        http_response_code(400);
-        header('Content-Type: application/json');
-        echo json_encode(['error' => 'Token CSRF inválido', 'csrf_token' => generateCsrfToken(true)]);
-        exit;
-    }
     $id = $_GET['id'] ?? '';
     try {
         $pdo = getPDO();


### PR DESCRIPTION
## Summary
- Allow line analysis endpoint to run without CSRF tokens
- Hide EXPENSE_ROW column in line analysis modal

## Testing
- `php -l contabilidade/save-analysis.php`
- `node --check assets/js/classificacao_importacao.js && echo "JS syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68c5f11251cc8320a2ce4d5bb719aaa9