### PR TITLE
Improve document lines modal and analysis UX

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -5103,6 +5103,12 @@ ul.project_files li a i {
     margin: 0;
 }
 
+#linesContainer .price {
+    font-size: inherit;
+    font-weight: inherit;
+    color: inherit;
+}
+
 .prod_title {
     border-bottom: 1px solid #DFDFDF;
     padding-bottom: 5px;

--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -211,6 +211,8 @@ window.addEventListener('load', function() {
         var btn = this;
         var id = btn.getAttribute('data-id');
         currentLinesId = id;
+        linesContainer.innerHTML = '<div class="d-flex justify-content-center my-3"><div class="spinner-border" role="status"><span class="visually-hidden">A carregar...</span></div></div>';
+        linesModal.show();
         var params = new URLSearchParams({
             action: 'lines',
             id: id
@@ -218,13 +220,14 @@ window.addEventListener('load', function() {
         fetchJson('contabilidade/save-analysis.php?' + params.toString())
             .then(function(res) {
                 if (res.error) {
+                    linesModal.hide();
                     showError(res.error);
                     return;
                 }
                 renderLines(res);
-                linesModal.show();
             })
             .catch(function(err) {
+                linesModal.hide();
                 showError(err.message || 'Erro na análise');
             });
     });
@@ -236,12 +239,12 @@ window.addEventListener('load', function() {
         }
         var html = '<table class="table table-striped"><thead><tr>' +
             '<th>ERP</th>' +
-            '<th>IVA_TAXA</th>' +
-            '<th>PRODUCT_CODE</th>' +
-            '<th>ITEM</th>' +
-            '<th>QUANTITY</th>' +
-            '<th>UNIT_PRICE</th>' +
-            '<th>PRICE</th>' +
+            '<th>IVA</th>' +
+            '<th>Código</th>' +
+            '<th>Descrição</th>' +
+            '<th>Qtd.</th>' +
+            '<th>P. Un.</th>' +
+            '<th>Preço</th>' +
             '</tr></thead><tbody>';
         lines.forEach(function(line) {
             var erp = line.ERP || '';

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -171,7 +171,7 @@ require_once __DIR__ . '/../header.php';
 </div>
 </div>
 <div class="modal fade" id="linesModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog modal-lg">
+    <div class="modal-dialog modal-xl">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">Linhas do Documento</h5>


### PR DESCRIPTION
## Summary
- widen document lines modal
- add loading spinner when analysing lines
- translate document line column headers and normalize price font

## Testing
- `php -l contabilidade/classificacao-importacao.php`
- `node --check assets/js/classificacao_importacao.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6a3ae3fdc8320a0b3b38d5f20f3cf