### PR TITLE
Mark analyze button green when ERP codes filled

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -282,6 +282,7 @@ window.addEventListener('load', function() {
         }
         var rows = linesContainer.querySelectorAll('tbody tr');
         var linesToSave = [];
+        var allErpFilled = true;
         rows.forEach(function(row) {
             var erp = row.querySelector('.erp-input').value.trim();
             var iva = row.querySelector('.iva-taxa').textContent.trim();
@@ -291,6 +292,9 @@ window.addEventListener('load', function() {
             var unitPrice = row.querySelector('.unit-price').textContent.trim();
             var price = row.querySelector('.price').textContent.trim();
             var priceVat = row.querySelector('.price-vat').value;
+            if (!erp) {
+                allErpFilled = false;
+            }
             linesToSave.push({
                 ERP: erp,
                 IVA_TAXA: iva,
@@ -319,6 +323,11 @@ window.addEventListener('load', function() {
             }
             if (res.success) {
                 linesModal.hide();
+                var analyzeBtn = document.querySelector('.analyze-lines[data-id="' + currentLinesId + '"]');
+                if (analyzeBtn) {
+                    analyzeBtn.classList.remove('btn-info', 'btn-success');
+                    analyzeBtn.classList.add(allErpFilled ? 'btn-success' : 'btn-info');
+                }
             } else {
                 showError(res.error || 'Erro ao guardar linhas');
             }

--- a/contabilidade/classificacao-importacao-data.php
+++ b/contabilidade/classificacao-importacao-data.php
@@ -33,7 +33,8 @@ $columns = [
     'field_O',
     'field_Q',
     'field_R',
-    'filename'
+    'filename',
+    'line_items'
 ];
 
 $draw = (int)($_GET['draw'] ?? 0);
@@ -89,6 +90,21 @@ foreach ($rows as &$row) {
     $row['amt_iva6'] = $amtIva6;
     $row['amt_iva13'] = $amtIva13;
     $row['amt_iva23'] = $amtIva23;
+    // Determine analyze button class based on line ERP codes
+    $row['line_btn_class'] = 'btn-info';
+    $lines = json_decode($row['line_items'] ?? '', true);
+    if (is_array($lines) && count($lines) > 0) {
+        $allFilled = true;
+        foreach ($lines as $line) {
+            if (trim($line['ERP'] ?? '') === '') {
+                $allFilled = false;
+                break;
+            }
+        }
+        if ($allFilled) {
+            $row['line_btn_class'] = 'btn-success';
+        }
+    }
 }
 unset($row);
 
@@ -111,7 +127,7 @@ foreach ($rows as $row) {
             . 'data-doctype="' . htmlspecialchars($row['field_D'] ?? '') . '">Classificar</button>';
     }
     if ($importType === 2) {
-        $actionsParts[] = '<button type="button" class="btn btn-xs btn-info analyze-lines" data-id="' . (int)$row['id'] . '">Analisar</button>';
+        $actionsParts[] = '<button type="button" class="btn btn-xs ' . $row['line_btn_class'] . ' analyze-lines" data-id="' . (int)$row['id'] . '">Analisar</button>';
     }
     $actionsParts[] = '<button type="button" class="btn btn-xs btn-danger remove-row" data-id="' . (int)$row['id'] . '"><i class="fa fa-trash"></i></button>';
     $actions = implode(' ', $actionsParts);


### PR DESCRIPTION
## Summary
- Include `line_items` in import query and inspect ERP codes to derive analyze button color
- Toggle analyze button to green when all ERP fields are filled on the client side

## Testing
- `php -l contabilidade/classificacao-importacao-data.php`
- `node --check assets/js/classificacao_importacao.js && echo "JS OK"`


------
https://chatgpt.com/codex/tasks/task_e_68c6a7f1dc8c8320aa3c9079c7140fc2