### PR TITLE
Update classification modal and add cost center

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -43,42 +43,53 @@ window.addEventListener('load', function() {
         ]
     });
 
+    function parseJsonAttribute(el, attr) {
+        var value = el.getAttribute(attr);
+        if (!value) {
+            return null;
+        }
+        try {
+            return JSON.parse(value);
+        } catch (e) {
+            return null;
+        }
+    }
+
     function updateButtonClass(btn) {
-        var iva6 = btn.getAttribute('data-iva6') || '';
-        var iva13 = btn.getAttribute('data-iva13') || '';
-        var iva23 = btn.getAttribute('data-iva23') || '';
-        var novat = btn.getAttribute('data-novat') || '';
+        var rateData = parseJsonAttribute(btn, 'data-rates') || {};
+        var requirements = parseJsonAttribute(btn, 'data-requirements') || {};
 
-
-        var amtIva6 = Math.abs(parseFloat(btn.getAttribute('data-amt-iva6'))) || 0;
-        var amtIva13 = Math.abs(parseFloat(btn.getAttribute('data-amt-iva13'))) || 0;
-        var amtIva23 = Math.abs(parseFloat(btn.getAttribute('data-amt-iva23'))) || 0;
-        var needNovat = btn.getAttribute('data-req-novat') === '1';
-
-        var needIva6 = amtIva6 > 0;
-        var needIva13 = amtIva13 > 0;
-        var needIva23 = amtIva23 > 0;
-
-        var hasIva6 = parseInt(iva6, 10) > 0;
-        var hasIva13 = parseInt(iva13, 10) > 0;
-        var hasIva23 = parseInt(iva23, 10) > 0;
-        var hasNovat = parseInt(novat, 10) > 0;
-
-        var requires = needIva6 || needIva13 || needIva23 || needNovat;
+        var requires = false;
         var allFilled = true;
+        var hasAny = false;
 
-        if (needIva6 && !hasIva6) { allFilled = false; }
-        if (needIva13 && !hasIva13) { allFilled = false; }
-        if (needIva23 && !hasIva23) { allFilled = false; }
-        if (needNovat && !hasNovat) { allFilled = false; }
+        Object.keys(requirements).forEach(function(rate) {
+            var req = requirements[rate] || {};
+            var data = rateData[rate] || {};
+            if (req.general) {
+                requires = true;
+                var general = (data.general_account || '').trim();
+                if (!general) {
+                    allFilled = false;
+                } else {
+                    hasAny = true;
+                }
+            }
+            if (req.iva) {
+                requires = true;
+                var iva = (data.iva_account || '').trim();
+                if (!iva) {
+                    allFilled = false;
+                } else {
+                    hasAny = true;
+                }
+            }
+        });
 
-        var hasAnyAccount = hasIva6 || hasIva13 || hasIva23 || hasNovat;
         btn.classList.remove('btn-success', 'btn-warning', 'btn-secondary');
-        if (!requires) {
+        if (!requires || allFilled) {
             btn.classList.add('btn-success');
-        } else if (allFilled) {
-            btn.classList.add('btn-success');
-        } else if (hasAnyAccount) {
+        } else if (hasAny) {
             btn.classList.add('btn-warning');
         } else {
             btn.classList.add('btn-secondary');
@@ -97,6 +108,23 @@ window.addEventListener('load', function() {
 
     var classifyModal = new bootstrap.Modal(document.getElementById('classifyModal'));
     var form = document.getElementById('classify-form');
+    var rateInputs = {};
+    var costCenterInput = null;
+    var currentRateData = {};
+    var currentCostCenter = '';
+    if (form) {
+        var rateRows = Array.prototype.slice.call(form.querySelectorAll('tbody tr[data-rate]'));
+        rateRows.forEach(function(row) {
+            var rate = row.getAttribute('data-rate');
+            rateInputs[rate] = {
+                base: row.querySelector('.base-field'),
+                iva: row.querySelector('.iva-field'),
+                ivaAccount: row.querySelector('.iva-account-field'),
+                generalAccount: row.querySelector('.general-account-field')
+            };
+        });
+        costCenterInput = form.querySelector('.cost-center-field');
+    }
     var currentBtn = null;
     var linesModal = new bootstrap.Modal(document.getElementById('linesModal'));
     var linesContainer = document.getElementById('linesContainer');
@@ -106,11 +134,28 @@ window.addEventListener('load', function() {
     $('#classify-table').on('click', '.classify-row', function() {
         var btn = this;
         currentBtn = btn;
-        var emitter = btn.getAttribute('data-emitter');
-        var acquirer = btn.getAttribute('data-acquirer');
-        var docType = btn.getAttribute('data-doctype');
+        var emitter = btn.getAttribute('data-emitter') || '';
+        var acquirer = btn.getAttribute('data-acquirer') || '';
+        var docType = btn.getAttribute('data-doctype') || '';
+        currentRateData = parseJsonAttribute(btn, 'data-rates') || {};
+
+        Object.keys(rateInputs).forEach(function(rate) {
+            var info = rateInputs[rate];
+            var data = currentRateData[rate] || {};
+            if (info.base) { info.base.value = data.base || ''; }
+            if (info.iva) { info.iva.value = data.iva || ''; }
+            if (info.ivaAccount) { info.ivaAccount.value = data.iva_account || ''; }
+            if (info.generalAccount) { info.generalAccount.value = data.general_account || ''; }
+        });
+
+        currentCostCenter = btn.getAttribute('data-cost-center') || '';
+        if (costCenterInput) {
+            costCenterInput.value = currentCostCenter;
+        }
+
         var params = new URLSearchParams({
             action: 'get',
+            id: btn.getAttribute('data-id') || '',
             A: emitter,
             B: acquirer,
             D: docType,
@@ -121,10 +166,49 @@ window.addEventListener('load', function() {
                 if (res.csrf_token) {
                     csrfInput.value = res.csrf_token;
                 }
-                form.iva6.value = btn.getAttribute('data-iva6') || res.iva6 || '';
-                form.iva13.value = btn.getAttribute('data-iva13') || res.iva13 || '';
-                form.iva23.value = btn.getAttribute('data-iva23') || res.iva23 || '';
-                form.novat.value = btn.getAttribute('data-novat') || res.novat || '';
+
+                var rowRates = res.row_rates || {};
+                Object.keys(rateInputs).forEach(function(rate) {
+                    var info = rateInputs[rate];
+                    var rowData = rowRates[rate] || {};
+                    if (info.ivaAccount && Object.prototype.hasOwnProperty.call(rowData, 'iva_account')) {
+                        info.ivaAccount.value = rowData.iva_account || '';
+                    }
+                    if (info.generalAccount && Object.prototype.hasOwnProperty.call(rowData, 'general_account')) {
+                        info.generalAccount.value = rowData.general_account || '';
+                    }
+                });
+
+                var defaults = res.rates || {};
+                Object.keys(rateInputs).forEach(function(rate) {
+                    var info = rateInputs[rate];
+                    var defaultData = defaults[rate] || {};
+                    if (info.ivaAccount && !info.ivaAccount.value) {
+                        info.ivaAccount.value = defaultData.iva_account || '';
+                    }
+                    if (info.generalAccount && !info.generalAccount.value) {
+                        info.generalAccount.value = defaultData.general_account || '';
+                    }
+                });
+
+                if (costCenterInput && res.cost_center !== undefined && res.cost_center !== null) {
+                    if (!costCenterInput.value) {
+                        costCenterInput.value = res.cost_center || '';
+                    }
+                }
+
+                currentCostCenter = costCenterInput ? costCenterInput.value : currentCostCenter;
+                Object.keys(rateInputs).forEach(function(rate) {
+                    var info = rateInputs[rate];
+                    if (!currentRateData[rate]) {
+                        currentRateData[rate] = {};
+                    }
+                    currentRateData[rate].base = info.base ? info.base.value : '';
+                    currentRateData[rate].iva = info.iva ? info.iva.value : '';
+                    currentRateData[rate].iva_account = info.ivaAccount ? info.ivaAccount.value : '';
+                    currentRateData[rate].general_account = info.generalAccount ? info.generalAccount.value : '';
+                });
+
                 classifyModal.show();
             })
             .catch(function(err) {
@@ -137,19 +221,24 @@ window.addEventListener('load', function() {
         if (!currentBtn) {
             return;
         }
-        var iva6 = form.iva6.value.trim();
-        var iva13 = form.iva13.value.trim();
-        var iva23 = form.iva23.value.trim();
-        var novat = form.novat.value.trim();
+
+        var ratesPayload = {};
+        Object.keys(rateInputs).forEach(function(rate) {
+            var info = rateInputs[rate];
+            ratesPayload[rate] = {
+                iva_account: info.ivaAccount ? info.ivaAccount.value.trim() : '',
+                general_account: info.generalAccount ? info.generalAccount.value.trim() : ''
+            };
+        });
+
+        var costCenterValue = costCenterInput ? costCenterInput.value.trim() : '';
         var body = new URLSearchParams({
-            id: currentBtn.getAttribute('data-id'),
-            A: currentBtn.getAttribute('data-emitter'),
-            B: currentBtn.getAttribute('data-acquirer'),
-            D: currentBtn.getAttribute('data-doctype'),
-            iva6: iva6,
-            iva13: iva13,
-            iva23: iva23,
-            novat: novat,
+            id: currentBtn.getAttribute('data-id') || '',
+            A: currentBtn.getAttribute('data-emitter') || '',
+            B: currentBtn.getAttribute('data-acquirer') || '',
+            D: currentBtn.getAttribute('data-doctype') || '',
+            rates: JSON.stringify(ratesPayload),
+            cost_center: costCenterValue,
             csrf_token: csrfInput.value
         });
         fetchJson('contabilidade/save-analysis.php?action=save', {
@@ -162,10 +251,47 @@ window.addEventListener('load', function() {
                 csrfInput.value = res.csrf_token;
             }
             if (res.success) {
-                currentBtn.setAttribute('data-iva6', iva6);
-                currentBtn.setAttribute('data-iva13', iva13);
-                currentBtn.setAttribute('data-iva23', iva23);
-                currentBtn.setAttribute('data-novat', novat);
+                if (res.cost_center !== undefined && res.cost_center !== null) {
+                    currentCostCenter = res.cost_center;
+                    if (costCenterInput) {
+                        costCenterInput.value = res.cost_center;
+                    }
+                } else {
+                    currentCostCenter = costCenterValue;
+                }
+
+                if (res.row_rates && typeof res.row_rates === 'object') {
+                    Object.keys(res.row_rates).forEach(function(rate) {
+                        var info = rateInputs[rate];
+                        if (!currentRateData[rate]) {
+                            currentRateData[rate] = {};
+                        }
+                        currentRateData[rate].base = info && info.base ? info.base.value : '';
+                        currentRateData[rate].iva = info && info.iva ? info.iva.value : '';
+                        currentRateData[rate].iva_account = (res.row_rates[rate] && res.row_rates[rate].iva_account) || '';
+                        currentRateData[rate].general_account = (res.row_rates[rate] && res.row_rates[rate].general_account) || '';
+                        if (info && info.ivaAccount) {
+                            info.ivaAccount.value = currentRateData[rate].iva_account;
+                        }
+                        if (info && info.generalAccount) {
+                            info.generalAccount.value = currentRateData[rate].general_account;
+                        }
+                    });
+                } else {
+                    Object.keys(rateInputs).forEach(function(rate) {
+                        var info = rateInputs[rate];
+                        if (!currentRateData[rate]) {
+                            currentRateData[rate] = {};
+                        }
+                        currentRateData[rate].base = info.base ? info.base.value : '';
+                        currentRateData[rate].iva = info.iva ? info.iva.value : '';
+                        currentRateData[rate].iva_account = ratesPayload[rate].iva_account;
+                        currentRateData[rate].general_account = ratesPayload[rate].general_account;
+                    });
+                }
+
+                currentBtn.setAttribute('data-rates', JSON.stringify(currentRateData));
+                currentBtn.setAttribute('data-cost-center', currentCostCenter);
                 updateButtonClass(currentBtn);
                 classifyModal.hide();
             } else {

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -12,6 +12,31 @@ $pdo = getPDO();
 $action = $_GET['action'] ?? '';
 $importType = (int)($_GET['import_type'] ?? 1);
 
+function prepareImportRow(array $row): array {
+    $accounts = normalizeAccountingAccounts($row['account'] ?? '');
+    $summaries = computeImportRateSummaries($row);
+    [$payload, $requirements] = buildRatePayload($summaries, $accounts);
+    $row['rate_payload'] = $payload;
+    $row['rate_requirements'] = $requirements;
+    $row['btn_class'] = determineClassificationButtonClass($requirements, $payload);
+    $row['line_btn_class'] = 'btn-info';
+    $lines = json_decode($row['line_items'] ?? '', true);
+    if (is_array($lines) && count($lines) > 0) {
+        $allFilled = true;
+        foreach ($lines as $line) {
+            if (trim((string) ($line['ERP'] ?? '')) === '') {
+                $allFilled = false;
+                break;
+            }
+        }
+        if ($allFilled) {
+            $row['line_btn_class'] = 'btn-success';
+        }
+    }
+
+    return $row;
+}
+
 if ($action === 'data') {
     $csrfToken = generateCsrfToken();
     dropLegacyAccountColumns($pdo);
@@ -19,6 +44,7 @@ if ($action === 'data') {
     $columns = [
         'id',
         'account',
+        'cost_center',
         'field_A',
         'field_B',
         'field_C',
@@ -63,69 +89,22 @@ if ($action === 'data') {
     $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
     foreach ($rows as &$row) {
-        $accounts = json_decode($row['account'] ?? '', true) ?: [];
-        $row['account_iva6'] = $accounts['iva6'] ?? '';
-        $row['account_iva13'] = $accounts['iva13'] ?? '';
-        $row['account_iva23'] = $accounts['iva23'] ?? '';
-        $row['account_novat'] = $accounts['novat'] ?? '';
-        $amtIva6 = abs((float) str_replace(',', '.', $row['field_I3'] ?? 0));
-        $amtIva13 = abs((float) str_replace(',', '.', $row['field_I5'] ?? 0));
-        $amtIva23 = abs((float) str_replace(',', '.', $row['field_I7'] ?? 0));
-        $needsNovat = !$amtIva6 && !$amtIva13 && !$amtIva23 && abs((float)($row['field_O'] ?? 0)) > 0;
-        $row['btn_class'] = 'btn-secondary';
-        $hasAnyAccount = (
-            (int)($row['account_iva6'] ?? 0) > 0 ||
-            (int)($row['account_iva13'] ?? 0) > 0 ||
-            (int)($row['account_iva23'] ?? 0) > 0 ||
-            (int)($row['account_novat'] ?? 0) > 0
-        );
-        $allAccounts = (
-            ($amtIva6 == 0 || (int)($row['account_iva6'] ?? 0) > 0) &&
-            ($amtIva13 == 0 || (int)($row['account_iva13'] ?? 0) > 0) &&
-            ($amtIva23 == 0 || (int)($row['account_iva23'] ?? 0) > 0) &&
-            (!$needsNovat || (int)($row['account_novat'] ?? 0) > 0)
-        );
-        $requires = $amtIva6 > 0 || $amtIva13 > 0 || $amtIva23 > 0 || $needsNovat;
-        if (!$requires || $allAccounts) {
-            $row['btn_class'] = 'btn-success';
-        } elseif ($hasAnyAccount) {
-            $row['btn_class'] = 'btn-warning';
-        }
-        $row['needs_novat'] = $needsNovat ? 1 : 0;
-        $row['amt_iva6'] = $amtIva6;
-        $row['amt_iva13'] = $amtIva13;
-        $row['amt_iva23'] = $amtIva23;
-        $row['line_btn_class'] = 'btn-info';
-        $lines = json_decode($row['line_items'] ?? '', true);
-        if (is_array($lines) && count($lines) > 0) {
-            $allFilled = true;
-            foreach ($lines as $line) {
-                if (trim($line['ERP'] ?? '') === '') {
-                    $allFilled = false;
-                    break;
-                }
-            }
-            if ($allFilled) {
-                $row['line_btn_class'] = 'btn-success';
-            }
-        }
+        $row = prepareImportRow($row);
     }
     unset($row);
 
     $data = [];
     foreach ($rows as $row) {
         $actionsParts = [];
+        $ratesAttr = htmlspecialchars(json_encode($row['rate_payload'], JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8');
+        $requirementsAttr = htmlspecialchars(json_encode($row['rate_requirements'], JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8');
+        $costCenterAttr = htmlspecialchars($row['cost_center'] ?? '', ENT_QUOTES, 'UTF-8');
         if ($importType === 1) {
             $actionsParts[] = '<button type="button" class="btn btn-xs ' . $row['btn_class'] . ' classify-row" '
                 . 'data-id="' . (int)$row['id'] . '" '
-                . 'data-iva6="' . htmlspecialchars($row['account_iva6']) . '" '
-                . 'data-iva13="' . htmlspecialchars($row['account_iva13']) . '" '
-                . 'data-iva23="' . htmlspecialchars($row['account_iva23']) . '" '
-                . 'data-novat="' . htmlspecialchars($row['account_novat']) . '" '
-                . 'data-amt-iva6="' . $row['amt_iva6'] . '" '
-                . 'data-amt-iva13="' . $row['amt_iva13'] . '" '
-                . 'data-amt-iva23="' . $row['amt_iva23'] . '" '
-                . 'data-req-novat="' . $row['needs_novat'] . '" '
+                . 'data-rates="' . $ratesAttr . '" '
+                . 'data-requirements="' . $requirementsAttr . '" '
+                . 'data-cost-center="' . $costCenterAttr . '" '
                 . 'data-emitter="' . htmlspecialchars($row['field_A'] ?? '') . '" '
                 . 'data-acquirer="' . htmlspecialchars($row['field_B'] ?? '') . '" '
                 . 'data-doctype="' . htmlspecialchars($row['field_D'] ?? '') . '">Classificar</button>';
@@ -176,11 +155,7 @@ $stmt->execute([':type' => $importType]);
 
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 foreach ($rows as &$row) {
-    $accounts = json_decode($row['account'] ?? '', true) ?: [];
-    $row['account_iva6'] = $accounts['iva6'] ?? '';
-    $row['account_iva13'] = $accounts['iva13'] ?? '';
-    $row['account_iva23'] = $accounts['iva23'] ?? '';
-    $row['account_novat'] = $accounts['novat'] ?? '';
+    $row = prepareImportRow($row);
 }
 unset($row);
 
@@ -242,49 +217,28 @@ require_once __DIR__ . '/../header.php';
                     <td><?= htmlspecialchars($row['field_R'] ?? ''); ?></td>
                     <td class="text-center"><a href="<?= htmlspecialchars($row['filename'] ?? ''); ?>" target="_blank" class="btn btn-xs btn-secondary"><i class="fa fa-file-pdf-o"></i></a></td>
                     <?php
-
-                        // Only consider VAT columns to determine whether accounts are required.
-                        $amtIva6 = abs((float) str_replace(',', '.', $row['field_I3'] ?? 0));
-                        $amtIva13 = abs((float) str_replace(',', '.', $row['field_I5'] ?? 0));
-                        $amtIva23 = abs((float) str_replace(',', '.', $row['field_I7'] ?? 0));
-                        $hasIva6 = $amtIva6 > 0;
-                        $hasIva13 = $amtIva13 > 0;
-                        $hasIva23 = $amtIva23 > 0;
-
-                        $total = abs((float)($row['field_O'] ?? 0));
-                        $needsNovat = !$hasIva6 && !$hasIva13 && !$hasIva23 && $total > 0;
-
-                        $allAccounts = (
-                            ($amtIva6 == 0 || (int)($row['account_iva6'] ?? 0) > 0) &&
-                            ($amtIva13 == 0 || (int)($row['account_iva13'] ?? 0) > 0) &&
-                            ($amtIva23 == 0 || (int)($row['account_iva23'] ?? 0) > 0) &&
-                            (!$needsNovat || (int)($row['account_novat'] ?? 0) > 0)
-                        );
-                        $requires = $hasIva6 || $hasIva13 || $hasIva23 || $needsNovat;
-                        $hasAnyAccount = (
-                            (int)($row['account_iva6'] ?? 0) > 0 ||
-                            (int)($row['account_iva13'] ?? 0) > 0 ||
-                            (int)($row['account_iva23'] ?? 0) > 0 ||
-                            (int)($row['account_novat'] ?? 0) > 0
-                        );
-                        if (!$requires) {
-                            $btnClass = 'btn-success';
-                        } elseif ($allAccounts) {
-                            $btnClass = 'btn-success';
-                        } elseif ($hasAnyAccount) {
-                            $btnClass = 'btn-warning';
-                        } else {
-                            $btnClass = 'btn-secondary';
-                        }
+                        $ratesAttr = htmlspecialchars(json_encode($row['rate_payload'], JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8');
+                        $requirementsAttr = htmlspecialchars(json_encode($row['rate_requirements'], JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8');
+                        $costCenterAttr = htmlspecialchars($row['cost_center'] ?? '', ENT_QUOTES, 'UTF-8');
+                        $btnClass = htmlspecialchars($row['btn_class'] ?? 'btn-secondary');
                     ?>
                     <td class="text-center">
 
                         <?php if ($importType === 1): ?>
-                        <button type="button" class="btn btn-xs <?= $btnClass; ?> classify-row" data-id="<?= (int)$row['id']; ?>" data-iva6="<?= htmlspecialchars($row['account_iva6'] ?? ''); ?>" data-iva13="<?= htmlspecialchars($row['account_iva13'] ?? ''); ?>" data-iva23="<?= htmlspecialchars($row['account_iva23'] ?? ''); ?>" data-novat="<?= htmlspecialchars($row['account_novat'] ?? ''); ?>" data-amt-iva6="<?= $amtIva6; ?>" data-amt-iva13="<?= $amtIva13; ?>" data-amt-iva23="<?= $amtIva23; ?>" data-req-novat="<?= $needsNovat ? 1 : 0; ?>" data-emitter="<?= htmlspecialchars($row['field_A'] ?? ''); ?>" data-acquirer="<?= htmlspecialchars($row['field_B'] ?? ''); ?>" data-doctype="<?= htmlspecialchars($row['field_D'] ?? ''); ?>">Classificar</button>
+                        <button
+                            type="button"
+                            class="btn btn-xs <?= $btnClass; ?> classify-row"
+                            data-id="<?= (int)$row['id']; ?>"
+                            data-rates="<?= $ratesAttr; ?>"
+                            data-requirements="<?= $requirementsAttr; ?>"
+                            data-cost-center="<?= $costCenterAttr; ?>"
+                            data-emitter="<?= htmlspecialchars($row['field_A'] ?? ''); ?>"
+                            data-acquirer="<?= htmlspecialchars($row['field_B'] ?? ''); ?>"
+                            data-doctype="<?= htmlspecialchars($row['field_D'] ?? ''); ?>">Classificar</button>
                         <?php endif; ?>
 
                         <?php if ($importType === 2): ?>
-                        <button type="button" class="btn btn-xs btn-info analyze-lines" data-id="<?= (int)$row['id']; ?>">Analisar</button>
+                        <button type="button" class="btn btn-xs <?= htmlspecialchars($row['line_btn_class'] ?? 'btn-info'); ?> analyze-lines" data-id="<?= (int)$row['id']; ?>">Analisar</button>
                         <?php endif; ?>
                         <button type="button" class="btn btn-xs btn-danger remove-row" data-id="<?= (int)$row['id']; ?>"><i class="fa fa-trash"></i></button>
                     </td>
@@ -305,21 +259,43 @@ require_once __DIR__ . '/../header.php';
             </div>
             <form id="classify-form">
                 <div class="modal-body">
-                    <div class="mb-3">
-                        <label class="form-label">IVA 6%</label>
-                        <input type="number" class="form-control" name="iva6">
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">IVA 13%</label>
-                        <input type="number" class="form-control" name="iva13">
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">IVA 23%</label>
-                        <input type="number" class="form-control" name="iva23">
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Valor S IVA</label>
-                        <input type="number" class="form-control" name="novat">
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Taxa</th>
+                                    <th>Base</th>
+                                    <th>IVA</th>
+                                    <th>Conta IVA</th>
+                                    <th>Conta Geral</th>
+                                    <th>Centro de Custo</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php
+                                $modalRates = [
+                                    '0' => '0%',
+                                    '6' => '6%',
+                                    '13' => '13%',
+                                    '23' => '23%',
+                                ];
+                                foreach ($modalRates as $rate => $label):
+                                ?>
+                                <tr data-rate="<?= $rate; ?>">
+                                    <td class="align-middle"><?= $label; ?></td>
+                                    <td><input type="text" class="form-control form-control-sm base-field" readonly></td>
+                                    <td><input type="text" class="form-control form-control-sm iva-field" readonly></td>
+                                    <td><input type="text" class="form-control form-control-sm iva-account-field" name="rates[<?= $rate; ?>][iva_account]"></td>
+                                    <td><input type="text" class="form-control form-control-sm general-account-field" name="rates[<?= $rate; ?>][general_account]"></td>
+                                    <?php if ($rate === '0'): ?>
+                                    <td rowspan="<?= count($modalRates); ?>" class="align-middle">
+                                        <input type="text" class="form-control cost-center-field" name="cost_center">
+                                    </td>
+                                    <?php endif; ?>
+                                </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -166,4 +166,298 @@ function dropLegacyAccountColumns(PDO $pdo): void {
     }
 }
 
+/**
+ * Normalize stored account information into a structure keyed by VAT rate.
+ *
+ * @param string|null $json JSON-encoded account data.
+ * @return array<string,array<string,string>>
+ */
+function normalizeAccountingAccounts(?string $json): array {
+    $rates = ['0', '6', '13', '23'];
+    $result = [];
+    foreach ($rates as $rate) {
+        $result[$rate] = [
+            'iva_account' => '',
+            'general_account' => '',
+        ];
+    }
+
+    if ($json === null || $json === '') {
+        return $result;
+    }
+
+    $data = json_decode($json, true);
+    if (!is_array($data)) {
+        return $result;
+    }
+
+    $sources = [];
+    if (isset($data['rates']) && is_array($data['rates'])) {
+        $sources[] = $data['rates'];
+    } else {
+        $sources[] = $data;
+    }
+
+    foreach ($sources as $source) {
+        foreach ($source as $key => $value) {
+            $keyString = (string) $key;
+            if (in_array($keyString, $rates, true)) {
+                if (is_array($value)) {
+                    if (array_key_exists('iva_account', $value)) {
+                        $result[$keyString]['iva_account'] = (string) $value['iva_account'];
+                    } elseif (array_key_exists('iva', $value)) {
+                        $result[$keyString]['iva_account'] = (string) $value['iva'];
+                    }
+                    if (array_key_exists('general_account', $value)) {
+                        $result[$keyString]['general_account'] = (string) $value['general_account'];
+                    } elseif (array_key_exists('general', $value)) {
+                        $result[$keyString]['general_account'] = (string) $value['general'];
+                    }
+                } elseif (is_string($value) || is_numeric($value)) {
+                    $result[$keyString]['general_account'] = (string) $value;
+                }
+                continue;
+            }
+
+            switch ($keyString) {
+                case 'iva6':
+                    $result['6']['iva_account'] = (string) $value;
+                    break;
+                case 'iva13':
+                    $result['13']['iva_account'] = (string) $value;
+                    break;
+                case 'iva23':
+                    $result['23']['iva_account'] = (string) $value;
+                    break;
+                case 'novat':
+                    $result['0']['general_account'] = (string) $value;
+                    break;
+            }
+        }
+    }
+
+    return $result;
+}
+
+/**
+ * Sanitize raw account input ensuring expected VAT rates are present.
+ *
+ * @param array<string,mixed> $input
+ * @return array<string,array<string,string>>
+ */
+function sanitizeAccountInput(array $input): array {
+    $rates = ['0', '6', '13', '23'];
+    $result = [];
+    foreach ($rates as $rate) {
+        $rateInput = $input[$rate] ?? [];
+        if (!is_array($rateInput)) {
+            $rateInput = [];
+        }
+        $result[$rate] = [
+            'iva_account' => isset($rateInput['iva_account']) ? trim((string) $rateInput['iva_account']) : '',
+            'general_account' => isset($rateInput['general_account']) ? trim((string) $rateInput['general_account']) : '',
+        ];
+    }
+
+    return $result;
+}
+
+/**
+ * Merge two account configurations, giving precedence to override values.
+ *
+ * @param array<string,mixed> $base
+ * @param array<string,mixed> $override
+ * @return array<string,array<string,string>>
+ */
+function mergeAccountingAccounts(array $base, array $override): array {
+    $baseSanitized = sanitizeAccountInput($base);
+    $overrideSanitized = sanitizeAccountInput($override);
+
+    foreach (['0', '6', '13', '23'] as $rate) {
+        foreach (['iva_account', 'general_account'] as $field) {
+            if (array_key_exists($field, $overrideSanitized[$rate])) {
+                $baseSanitized[$rate][$field] = $overrideSanitized[$rate][$field];
+            }
+        }
+    }
+
+    return $baseSanitized;
+}
+
+/**
+ * Serialize normalized account information as JSON.
+ *
+ * @param array<string,mixed> $rates
+ * @return string
+ */
+function serializeAccountingAccounts(array $rates): string {
+    $sanitized = sanitizeAccountInput($rates);
+    return json_encode([
+        'version' => 2,
+        'rates' => $sanitized,
+    ], JSON_UNESCAPED_UNICODE);
+}
+
+/**
+ * Calculate VAT rate amounts and requirements for an imported document row.
+ *
+ * @param array<string,mixed> $row
+ * @return array<string,array<string,mixed>>
+ */
+function computeImportRateSummaries(array $row): array {
+    $parseAmount = static function ($value): float {
+        if ($value === null) {
+            return 0.0;
+        }
+        if (is_numeric($value)) {
+            return (float) $value;
+        }
+        $stringValue = trim((string) $value);
+        if ($stringValue === '') {
+            return 0.0;
+        }
+        return (float) str_replace(',', '.', $stringValue);
+    };
+
+    $formatAmount = static function (?float $value, $original = null): string {
+        $originalStr = is_string($original) ? trim($original) : '';
+        if ($originalStr !== '') {
+            return $originalStr;
+        }
+        if ($value === null) {
+            return '';
+        }
+        return number_format($value, 2, '.', '');
+    };
+
+    $base6 = $parseAmount($row['field_I3'] ?? null);
+    $iva6 = $parseAmount($row['field_I4'] ?? null);
+    $base13 = $parseAmount($row['field_I5'] ?? null);
+    $iva13 = $parseAmount($row['field_I6'] ?? null);
+    $base23 = $parseAmount($row['field_I7'] ?? null);
+    $iva23 = $parseAmount($row['field_I8'] ?? null);
+    $totalIva = $parseAmount($row['field_N'] ?? null);
+    $total = $parseAmount($row['field_O'] ?? null);
+
+    $totalBase = $total - $totalIva;
+    if (!is_finite($totalBase)) {
+        $totalBase = 0.0;
+    }
+
+    $base0 = $totalBase - $base6 - $base13 - $base23;
+    if (!is_finite($base0)) {
+        $base0 = 0.0;
+    }
+    if (abs($base0) < 0.005) {
+        $base0 = 0.0;
+    }
+
+    return [
+        '0' => [
+            'base_value' => $base0,
+            'iva_value' => 0.0,
+            'base_display' => $formatAmount($base0),
+            'iva_display' => $formatAmount(0.0),
+            'require_general' => abs($base0) > 0.0001,
+            'require_iva' => false,
+        ],
+        '6' => [
+            'base_value' => $base6,
+            'iva_value' => $iva6,
+            'base_display' => $formatAmount($base6, $row['field_I3'] ?? null),
+            'iva_display' => $formatAmount($iva6, $row['field_I4'] ?? null),
+            'require_general' => abs($base6) > 0.0001,
+            'require_iva' => abs($iva6) > 0.0001,
+        ],
+        '13' => [
+            'base_value' => $base13,
+            'iva_value' => $iva13,
+            'base_display' => $formatAmount($base13, $row['field_I5'] ?? null),
+            'iva_display' => $formatAmount($iva13, $row['field_I6'] ?? null),
+            'require_general' => abs($base13) > 0.0001,
+            'require_iva' => abs($iva13) > 0.0001,
+        ],
+        '23' => [
+            'base_value' => $base23,
+            'iva_value' => $iva23,
+            'base_display' => $formatAmount($base23, $row['field_I7'] ?? null),
+            'iva_display' => $formatAmount($iva23, $row['field_I8'] ?? null),
+            'require_general' => abs($base23) > 0.0001,
+            'require_iva' => abs($iva23) > 0.0001,
+        ],
+    ];
+}
+
+/**
+ * Build payload and requirement metadata for modal rendering.
+ *
+ * @param array<string,array<string,mixed>> $summaries
+ * @param array<string,array<string,string>> $accounts
+ * @return array{0: array<string,array<string,string>>, 1: array<string,array<string,bool>>}
+ */
+function buildRatePayload(array $summaries, array $accounts): array {
+    $payload = [];
+    $requirements = [];
+
+    foreach ($summaries as $rate => $info) {
+        $payload[$rate] = [
+            'base' => $info['base_display'] ?? '',
+            'iva' => $info['iva_display'] ?? '',
+            'iva_account' => $accounts[$rate]['iva_account'] ?? '',
+            'general_account' => $accounts[$rate]['general_account'] ?? '',
+        ];
+        $requirements[$rate] = [
+            'general' => !empty($info['require_general']),
+            'iva' => !empty($info['require_iva']),
+        ];
+    }
+
+    return [$payload, $requirements];
+}
+
+/**
+ * Determine the button class for a classification row based on requirements.
+ *
+ * @param array<string,array<string,bool>> $requirements
+ * @param array<string,array<string,string>> $payload
+ * @return string
+ */
+function determineClassificationButtonClass(array $requirements, array $payload): string {
+    $requires = false;
+    $allFilled = true;
+    $hasAny = false;
+
+    foreach ($requirements as $rate => $req) {
+        $data = $payload[$rate] ?? [];
+        if (!empty($req['general'])) {
+            $requires = true;
+            $general = trim((string) ($data['general_account'] ?? ''));
+            if ($general === '') {
+                $allFilled = false;
+            } else {
+                $hasAny = true;
+            }
+        }
+        if (!empty($req['iva'])) {
+            $requires = true;
+            $iva = trim((string) ($data['iva_account'] ?? ''));
+            if ($iva === '') {
+                $allFilled = false;
+            } else {
+                $hasAny = true;
+            }
+        }
+    }
+
+    if (!$requires || $allFilled) {
+        return 'btn-success';
+    }
+
+    if ($hasAny) {
+        return 'btn-warning';
+    }
+
+    return 'btn-secondary';
+}
+
 ?>

--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -19,6 +19,11 @@ if ($action === 'lines') {
         exit;
     }
     $id = $_GET['id'] ?? '';
+    if ($id === '') {
+        http_response_code(400);
+        echo json_encode(['error' => 'ID inválido', 'csrf_token' => generateCsrfToken(true)]);
+        exit;
+    }
     try {
         $pdo = getPDO();
     } catch (RuntimeException $e) {
@@ -90,6 +95,7 @@ if ($action === 'get') {
     $a = $_GET['A'] ?? '';
     $b = $_GET['B'] ?? '';
     $d = $_GET['D'] ?? '';
+    $id = $_GET['id'] ?? '';
     try {
         $pdo = getPDO();
     } catch (RuntimeException $e) {
@@ -102,12 +108,22 @@ if ($action === 'get') {
     );
     $stmt->execute([$a, $b, $d]);
     $row = $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
-    $accounts = json_decode($row['account'] ?? '', true) ?: [];
+    $classificationAccounts = normalizeAccountingAccounts($row['account'] ?? '');
+
+    $rowAccounts = normalizeAccountingAccounts(null);
+    $costCenter = '';
+    if ($id !== '') {
+        $stmtRow = $pdo->prepare('SELECT account, cost_center FROM accounting_imports WHERE id = ? LIMIT 1');
+        $stmtRow->execute([$id]);
+        $importRow = $stmtRow->fetch(PDO::FETCH_ASSOC) ?: [];
+        $rowAccounts = normalizeAccountingAccounts($importRow['account'] ?? '');
+        $costCenter = (string)($importRow['cost_center'] ?? '');
+    }
+
     echo json_encode([
-        'iva6' => $accounts['iva6'] ?? '',
-        'iva13' => $accounts['iva13'] ?? '',
-        'iva23' => $accounts['iva23'] ?? '',
-        'novat' => $accounts['novat'] ?? '',
+        'rates' => $classificationAccounts,
+        'row_rates' => $rowAccounts,
+        'cost_center' => $costCenter,
         'csrf_token' => generateCsrfToken()
     ]);
     exit;
@@ -132,46 +148,46 @@ if ($action === 'get') {
     try {
         $pdo->beginTransaction();
 
-        // Load existing classifications so new entries do not wipe out
-        // previously stored tax accounts for the same emitter/acquirer/doc type.
+        $ratesJson = $_POST['rates'] ?? '[]';
+        $ratesData = json_decode($ratesJson, true);
+        if (!is_array($ratesData)) {
+            $ratesData = [];
+        }
+        $submittedRates = sanitizeAccountInput($ratesData);
+        $costCenter = isset($_POST['cost_center']) ? trim((string) $_POST['cost_center']) : '';
+
         $stmtExisting = $pdo->prepare(
             'SELECT account FROM accounting_classifications WHERE emitter = ? AND acquirer = ? AND doc_type = ? LIMIT 1'
         );
         $stmtExisting->execute([$a, $b, $d]);
-        $existingClass = json_decode($stmtExisting->fetchColumn() ?: '[]', true);
-        if (!is_array($existingClass)) {
-            $existingClass = [];
-        }
+        $existingClass = normalizeAccountingAccounts($stmtExisting->fetchColumn() ?: '');
 
         $stmtRow = $pdo->prepare('SELECT account FROM accounting_imports WHERE id = ?');
         $stmtRow->execute([$id]);
-        $existingRow = json_decode($stmtRow->fetchColumn() ?: '[]', true);
-        if (!is_array($existingRow)) {
-            $existingRow = [];
-        }
+        $existingRow = normalizeAccountingAccounts($stmtRow->fetchColumn() ?: '');
 
-        // Merge existing accounts, giving priority to row-specific values and
-        // any values explicitly submitted in this request (even empty ones).
-        $accounts = array_merge($existingClass, $existingRow);
-        foreach (['iva6', 'iva13', 'iva23', 'novat'] as $key) {
-            if (array_key_exists($key, $_POST)) {
-                $accounts[$key] = $_POST[$key];
-            }
-        }
+        $rowAccounts = mergeAccountingAccounts($existingRow, $submittedRates);
+        $classAccounts = mergeAccountingAccounts($existingClass, $submittedRates);
 
-        $serialized = json_encode($accounts);
+        $serializedRow = serializeAccountingAccounts($rowAccounts);
+        $serializedClass = serializeAccountingAccounts($classAccounts);
 
-        $stmt = $pdo->prepare('UPDATE accounting_imports SET account = ? WHERE id = ?');
-        $stmt->execute([$serialized, $id]);
+        $stmt = $pdo->prepare('UPDATE accounting_imports SET account = ?, cost_center = ? WHERE id = ?');
+        $stmt->execute([$serializedRow, $costCenter, $id]);
 
         $stmt2 = $pdo->prepare(
             'INSERT INTO accounting_classifications (emitter, acquirer, doc_type, account) '
             . 'VALUES (?, ?, ?, ?) '
             . 'ON DUPLICATE KEY UPDATE account = VALUES(account)'
         );
-        $stmt2->execute([$a, $b, $d, $serialized]);
+        $stmt2->execute([$a, $b, $d, $serializedClass]);
         $pdo->commit();
-        echo json_encode(['success' => true, 'csrf_token' => generateCsrfToken()]);
+        echo json_encode([
+            'success' => true,
+            'csrf_token' => generateCsrfToken(),
+            'row_rates' => $rowAccounts,
+            'cost_center' => $costCenter
+        ]);
     } catch (Exception $e) {
         if ($pdo->inTransaction()) {
             $pdo->rollBack();

--- a/migrations/add_accounting_imports_cost_center_column.sql
+++ b/migrations/add_accounting_imports_cost_center_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE accounting_imports ADD COLUMN cost_center VARCHAR(255) DEFAULT '' AFTER account;

--- a/schema.sql
+++ b/schema.sql
@@ -153,6 +153,7 @@ CREATE TABLE IF NOT EXISTS accounting_imports (
     field_Q VARCHAR(255) DEFAULT '',
     field_R VARCHAR(255) DEFAULT '',
     account VARCHAR(255) DEFAULT '',
+    cost_center VARCHAR(255) DEFAULT '',
     line_items LONGTEXT DEFAULT NULL,
     filename VARCHAR(255) DEFAULT '',
     import_type TINYINT DEFAULT 1,


### PR DESCRIPTION
## Summary
- add helper utilities to normalize VAT accounts, compute rate requirements, and serialize the new structure
- update the classification page/modal and backend API to show per-rate base/IVA values, capture VAT/general accounts, and store a cost center
- introduce a migration and schema update that adds the cost_center column to accounting_imports

## Testing
- php -l contabilidade/functions.php
- php -l contabilidade/classificacao-importacao.php
- php -l contabilidade/save-analysis.php

------
https://chatgpt.com/codex/tasks/task_e_68c941cf1af08320bc854555fb4acdba