### PR TITLE
Tornar campo Centro de Custo editável

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -127,6 +127,11 @@ window.addEventListener('load', function() {
             };
         });
         costCenterInput = form.querySelector('.cost-center-field');
+        if (costCenterInput) {
+            costCenterInput.setAttribute('type', 'text');
+            costCenterInput.removeAttribute('readonly');
+            costCenterInput.disabled = false;
+        }
     }
     var currentBtn = null;
     var linesModal = new bootstrap.Modal(document.getElementById('linesModal'));

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -292,9 +292,12 @@ require_once __DIR__ . '/../header.php';
                                     <td><input type="text" class="form-control form-control-sm general-account-field" name="rates[<?= $rate; ?>][general_account]"></td>
                                     <?php if ($rate === '0'): ?>
                                     <td rowspan="<?= count($modalRates); ?>" class="align-middle">
-
-                                        <input type="text" class="form-control cost-center-field" name="cost_center">
-
+                                        <input
+                                            type="text"
+                                            class="form-control form-control-sm cost-center-field"
+                                            name="cost_center"
+                                            placeholder="Introduza o centro de custo"
+                                        >
                                     </td>
                                     <?php endif; ?>
                                 </tr>


### PR DESCRIPTION
## Summary
- ajusta o campo Centro de Custo no modal de classificação para usar um input de texto com placeholder e estilo compacto
- garante via JavaScript que o campo é tratado como texto e permanece editável ao abrir o modal

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c966a250148320822473710d68d4b7