### PR TITLE
Allow NIF.PT token field to accept plain text

### DIFF
--- a/definicoes.php
+++ b/definicoes.php
@@ -78,9 +78,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['erp_webservice_url'])) {
         $erpWebserviceUrl = trim($_POST['erp_webservice_url'] ?? '');
         $erpToken = trim($_POST['erp_token'] ?? '');
+        $erpNifPt = isset($_POST['erp_nif_pt']) ? trim((string)$_POST['erp_nif_pt']) : '';
 
         setSetting('erp_webservice_url', $erpWebserviceUrl);
         setSetting('erp_token', $erpToken);
+        setSetting('erp_nif_pt', $erpNifPt);
 
         $erpSaved = true;
     }
@@ -110,6 +112,7 @@ $currentAwsRegion = getSetting('aws_region', '');
 $currentOcrProvider = getSetting('ocr_provider', 'tesseract');
 $currentErpWebserviceUrl = getSetting('erp_webservice_url', '');
 $currentErpToken = getSetting('erp_token', '');
+$currentErpNifPt = getSetting('erp_nif_pt', '');
 $currentModules = getActiveModules();
 
 require_once __DIR__ . '/header.php';
@@ -261,6 +264,12 @@ require_once __DIR__ . '/header.php';
                     <div class="mb-3 col-md-6 col-sm-12">
                         <label for="erp_token" class="form-label">Token</label>
                         <input type="text" class="form-control" id="erp_token" name="erp_token" value="<?= htmlspecialchars($currentErpToken); ?>">
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="mb-3 col-md-6 col-sm-12">
+                        <label for="erp_nif_pt" class="form-label">Token NIF.PT</label>
+                        <input type="text" class="form-control" id="erp_nif_pt" name="erp_nif_pt" value="<?= htmlspecialchars($currentErpNifPt); ?>" autocomplete="off" spellcheck="false">
                     </div>
                 </div>
                 <button type="submit" class="btn btn-md btn-primary"><i class="fa fa-save"></i> Guardar</button>


### PR DESCRIPTION
## Summary
- store the submitted NIF.PT value as a trimmed string without assuming the POST key is always present
- treat the ERP NIF.PT form control as a plain token field by disabling autocomplete and spellcheck so browsers do not enforce URL formatting

## Testing
- php -l definicoes.php

------
https://chatgpt.com/codex/tasks/task_e_68c96d6084948320bf14eb1990d13a25