### PR TITLE
Stop using NIF.pt fallback for accounting sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ O projeto disponibiliza um endpoint simples em [`api.php`](api.php) para aceder 
 O endpoint responde com informação da taxonomia e a lista de termos associados.
 
 ## Integração ERP
-O módulo de contabilidade pode consultar um webservice ERP para sincronizar dados de clientes. Caso o ERP devolva um código HTTP 404 (ou não forneça dados utilizáveis) e exista um **Token NIF.PT** configurado em **Definições > ERP**, o sistema tenta obter a informação através do serviço [NIF.pt](https://www.nif.pt/). Certifique-se de que o token está ativo para que a sincronização consiga recorrer a este fallback.
+O módulo de contabilidade consulta o webservice **ERP-SINC** para sincronizar dados de clientes. Certifique-se de que a URL e o token do serviço estão configurados em **Definições > ERP**. O sincronismo passa a depender exclusivamente do ERP-SINC, não recorrendo a dados alternativos do [NIF.pt](https://www.nif.pt/).
 
 ## Textract OCR
 O módulo de contabilidade pode utilizar o [AWS Textract](https://aws.amazon.com/textract/) para extrair dados de faturas. A integração é feita através do script Python `contabilidade/textract.py`, que requer a biblioteca `boto3`.

--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -112,7 +112,7 @@ function buildErpClientEndpoint(string $baseUrl, string $nif): string {
  * @param bool   $logEmpty    Whether to log when no usable data is found.
  * @return array|null Associative array with the extracted data or null if none was found.
  */
-function parseErpEntityPayload(array $payload, string $nif, string $sourceLabel = 'Webservice ERP', bool $logEmpty = true): ?array {
+function parseErpEntityPayload(array $payload, string $nif, string $sourceLabel = 'Webservice ERP-SINC', bool $logEmpty = true): ?array {
     if (isset($payload['success']) && $payload['success'] === false) {
         $message = isset($payload['message']) ? (string) $payload['message'] : (string) ($payload['error'] ?? 'Resposta sem sucesso');
         logErpMessage($sourceLabel . ' devolveu erro: ' . $message);
@@ -256,7 +256,10 @@ function parseErpEntityPayload(array $payload, string $nif, string $sourceLabel 
 }
 
 /**
- * Retrieve accounting entity information from the NIF.pt service as a fallback.
+ * Retrieve accounting entity information from the NIF.pt service.
+ *
+ * This legacy helper is kept for backwards compatibility and is not used by the
+ * current ERP-SINC synchronisation flow.
  *
  * @param string $nif    VAT number requested.
  * @param string $reason Contextual reason for logging when the fallback is used.
@@ -380,27 +383,27 @@ function fetchAccountingEntityFromNifPt(string $nif, string $reason = ''): ?arra
 }
 
 /**
- * Retrieve client information from the ERP webservice.
+ * Retrieve client information from the ERP-SINC webservice.
  *
  * @param string $nif VAT number to request.
  * @return array|null Entity data or null when the request fails.
  */
 function fetchAccountingEntityFromErp(string $nif): ?array {
     if (!function_exists('curl_init')) {
-        logErpMessage('Extensão cURL não disponível para sincronizar entidade ' . $nif);
+        logErpMessage('Extensão cURL não disponível para sincronizar entidade ' . $nif . ' via ERP-SINC.');
         return null;
     }
 
     $baseUrl = getSetting('erp_webservice_url', '');
     if ($baseUrl === null || trim($baseUrl) === '') {
-        logErpMessage('URL do ERP não configurada para sincronizar o NIF ' . $nif . '.');
-        return fetchAccountingEntityFromNifPt($nif, 'URL do ERP não configurada');
+        logErpMessage('URL do ERP-SINC não configurada para sincronizar o NIF ' . $nif . '.');
+        return null;
     }
 
     $endpoint = buildErpClientEndpoint($baseUrl, $nif);
     if ($endpoint === '') {
-        logErpMessage('URL do ERP inválida para o NIF ' . $nif . '.');
-        return fetchAccountingEntityFromNifPt($nif, 'URL do ERP inválida');
+        logErpMessage('URL do ERP-SINC inválida para o NIF ' . $nif . '.');
+        return null;
     }
 
     $token = getSetting('erp_token', '');
@@ -412,8 +415,8 @@ function fetchAccountingEntityFromErp(string $nif): ?array {
 
     $handle = curl_init($endpoint);
     if ($handle === false) {
-        logErpMessage('Falha ao inicializar pedido ao ERP para o NIF ' . $nif);
-        return fetchAccountingEntityFromNifPt($nif, 'falha ao inicializar pedido ao ERP');
+        logErpMessage('Falha ao inicializar pedido ao ERP-SINC para o NIF ' . $nif . '.');
+        return null;
     }
 
     curl_setopt_array($handle, [
@@ -425,42 +428,33 @@ function fetchAccountingEntityFromErp(string $nif): ?array {
 
     $response = curl_exec($handle);
     if ($response === false) {
-        logErpMessage('Erro cURL ao obter entidade ' . $nif . ': ' . curl_error($handle));
+        logErpMessage('Erro cURL ao obter entidade ' . $nif . ' do ERP-SINC: ' . curl_error($handle));
         curl_close($handle);
-        return fetchAccountingEntityFromNifPt($nif, 'erro cURL no ERP');
+        return null;
     }
 
     $status = curl_getinfo($handle, CURLINFO_HTTP_CODE);
     curl_close($handle);
 
     if ($status >= 400) {
-        logErpMessage('Webservice ERP devolveu HTTP ' . $status . ' para o NIF ' . $nif);
-        if (in_array($status, [404, 410], true)) {
-            $fallback = fetchAccountingEntityFromNifPt($nif, 'HTTP ' . $status . ' no ERP');
-            if ($fallback !== null) {
-                return $fallback;
-            }
-        }
+        logErpMessage('Webservice ERP-SINC devolveu HTTP ' . $status . ' para o NIF ' . $nif . '.');
         return null;
     }
 
     if ($status === 204 || trim((string) $response) === '') {
-        logErpMessage('Webservice ERP devolveu resposta vazia para o NIF ' . $nif);
-        return fetchAccountingEntityFromNifPt($nif, 'resposta vazia do ERP');
+        logErpMessage('Webservice ERP-SINC devolveu resposta vazia para o NIF ' . $nif . '.');
+        return null;
     }
 
     $data = json_decode($response, true);
     if (!is_array($data)) {
-        logErpMessage('Resposta ERP inválida para o NIF ' . $nif . ': ' . substr($response, 0, 200));
-        return fetchAccountingEntityFromNifPt($nif, 'resposta inválida do ERP');
+        logErpMessage('Resposta ERP-SINC inválida para o NIF ' . $nif . ': ' . substr($response, 0, 200));
+        return null;
     }
 
     $entity = parseErpEntityPayload($data, $nif);
     if ($entity === null) {
-        $fallback = fetchAccountingEntityFromNifPt($nif, 'dados indisponíveis no ERP');
-        if ($fallback !== null) {
-            return $fallback;
-        }
+        logErpMessage('Dados do NIF ' . $nif . ' indisponíveis no ERP-SINC.');
         return null;
     }
 

--- a/definicoes.php
+++ b/definicoes.php
@@ -78,12 +78,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['erp_webservice_url'])) {
         $erpWebserviceUrl = trim($_POST['erp_webservice_url'] ?? '');
         $erpToken = trim($_POST['erp_token'] ?? '');
-        $erpNifPt = isset($_POST['erp_nif_pt']) ? trim((string)$_POST['erp_nif_pt']) : '';
-
 
         setSetting('erp_webservice_url', $erpWebserviceUrl);
         setSetting('erp_token', $erpToken);
-        setSetting('erp_nif_pt', $erpNifPt);
 
         $erpSaved = true;
     }
@@ -113,7 +110,6 @@ $currentAwsRegion = getSetting('aws_region', '');
 $currentOcrProvider = getSetting('ocr_provider', 'tesseract');
 $currentErpWebserviceUrl = getSetting('erp_webservice_url', '');
 $currentErpToken = getSetting('erp_token', '');
-$currentErpNifPt = getSetting('erp_nif_pt', '');
 $currentModules = getActiveModules();
 
 require_once __DIR__ . '/header.php';
@@ -265,13 +261,6 @@ require_once __DIR__ . '/header.php';
                     <div class="mb-3 col-md-6 col-sm-12">
                         <label for="erp_token" class="form-label">Token</label>
                         <input type="text" class="form-control" id="erp_token" name="erp_token" value="<?= htmlspecialchars($currentErpToken); ?>">
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="mb-3 col-md-6 col-sm-12">
-                        <label for="erp_nif_pt" class="form-label">Token NIF.PT</label>
-                        <input type="text" class="form-control" id="erp_nif_pt" name="erp_nif_pt" value="<?= htmlspecialchars($currentErpNifPt); ?>" autocomplete="off" spellcheck="false">
-
                     </div>
                 </div>
                 <button type="submit" class="btn btn-md btn-primary"><i class="fa fa-save"></i> Guardar</button>


### PR DESCRIPTION
## Summary
- disable the NIF.pt fallback when synchronising accounting entities so data only comes from ERP-SINC
- update ERP integration messaging and logs to reference ERP-SINC exclusively
- remove the unused NIF.pt token configuration field from the settings page and refresh the README instructions

## Testing
- php -l contabilidade/functions.php
- php -l definicoes.php

------
https://chatgpt.com/codex/tasks/task_e_68c9cc17f5a88320976a0308569f7f32