### PR TITLE
Fix CSRF token reset on classification data endpoint

### DIFF
--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -39,7 +39,6 @@ function prepareImportRow(array $row): array {
 }
 
 if ($action === 'data') {
-    $csrfToken = generateCsrfToken();
     dropLegacyAccountColumns($pdo);
 
     $columns = [


### PR DESCRIPTION
## Summary
- avoid regenerating the CSRF token when serving classification imports data so subsequent actions retain a valid token

## Testing
- php -l contabilidade/classificacao-importacao.php

------
https://chatgpt.com/codex/tasks/task_e_68c9cee701dc8320a982a573916f2462