### PR TITLE
Show ERP entity names in accounting imports

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -527,6 +527,26 @@ function deriveEntityNameFromField(string $rawFieldValue, string $nif): string {
 }
 
 /**
+ * Determine whether a stored entity name is just a placeholder derived from the VAT number.
+ *
+ * @param string|null $name Stored name.
+ * @param string      $nif  VAT number associated with the entity.
+ * @return bool Whether the name should be refreshed from the ERP webservice.
+ */
+function isPlaceholderAccountingEntityName(?string $name, string $nif): bool {
+    $normalized = trim((string) $name);
+    if ($normalized === '') {
+        return true;
+    }
+
+    $normalized = strtoupper(preg_replace('/\s+/', ' ', $normalized));
+    $compact = preg_replace('/[^A-Z0-9]/', '', $normalized);
+    $expectedCompact = 'CLIENTE' . $nif;
+
+    return $compact === $expectedCompact;
+}
+
+/**
  * Ensure that an accounting entity exists locally, fetching it from the ERP
  * when necessary.
  *
@@ -546,9 +566,10 @@ function ensureAccountingEntity(PDO $pdo, string $entityFieldValue): ?array {
         return $cache[$nif] ?: null;
     }
 
+    $existing = null;
     try {
         $existing = findAccountingEntity($pdo, $nif);
-        if ($existing !== null) {
+        if ($existing !== null && !isPlaceholderAccountingEntityName($existing['name'] ?? '', $nif)) {
             $cache[$nif] = $existing;
             return $existing;
         }
@@ -560,6 +581,11 @@ function ensureAccountingEntity(PDO $pdo, string $entityFieldValue): ?array {
 
     $remote = fetchAccountingEntityFromErp($nif);
     if ($remote === null) {
+        if ($existing !== null) {
+            $cache[$nif] = $existing;
+            return $existing;
+        }
+
         $cache[$nif] = null;
         return null;
     }


### PR DESCRIPTION
## Summary
- resolve emitter and acquirer names from the ERP-synchronised entities when preparing accounting import rows
- keep the classification listings showing the original emitter/acquirer strings while persisting the ERP-provided names for bookkeeping
- refresh stored accounting entity names when only placeholder labels exist so the ERP-provided strNome is persisted

## Testing
- php -l contabilidade/functions.php
- php -l contabilidade/classificacao-importacao.php

------
https://chatgpt.com/codex/tasks/task_e_68c9d292356083208a7fb3a2e19600c9