### PR TITLE
Show ERP entity names in accounting imports

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -104,6 +104,44 @@ function buildErpClientEndpoint(string $baseUrl, string $nif): string {
 }
 
 /**
+ * Prepare an URL string for logging by masking sensitive query parameters.
+ *
+ * @param string $url Original URL.
+ * @return string URL safe to expose in logs.
+ */
+function sanitizeUrlForLog(string $url): string {
+    if ($url === '') {
+        return '';
+    }
+
+    $sanitized = preg_replace_callback(
+        '/([?&])([^=&#]+)=([^&#]*)/',
+        function (array $matches): string {
+            $param = strtolower($matches[2]);
+            foreach (['token', 'key', 'secret', 'password', 'auth'] as $keyword) {
+                if (strpos($param, $keyword) !== false) {
+                    return $matches[1] . $matches[2] . '=***';
+                }
+            }
+
+            return $matches[0];
+        },
+        $url
+    );
+
+    if ($sanitized === null) {
+        $sanitized = $url;
+    }
+
+    $sanitized = preg_replace('/^([a-z][a-z0-9+.-]*:\/\/[^:@\/]+):[^@\/]*@/i', '$1:***@', $sanitized);
+    if ($sanitized === null) {
+        return $url;
+    }
+
+    return $sanitized;
+}
+
+/**
  * Normalise the ERP response structure and extract relevant entity data.
  *
  * @param array  $payload     Raw payload returned by the ERP webservice.
@@ -406,6 +444,9 @@ function fetchAccountingEntityFromErp(string $nif): ?array {
         return null;
     }
 
+    $sanitizedEndpoint = sanitizeUrlForLog($endpoint);
+    $endpointInfo = $sanitizedEndpoint !== '' ? ' URL: ' . $sanitizedEndpoint : '';
+
     $token = getSetting('erp_token', '');
     $headers = ['Accept: application/json'];
     if ($token !== null && $token !== '') {
@@ -415,7 +456,7 @@ function fetchAccountingEntityFromErp(string $nif): ?array {
 
     $handle = curl_init($endpoint);
     if ($handle === false) {
-        logErpMessage('Falha ao inicializar pedido ao ERP-SINC para o NIF ' . $nif . '.');
+        logErpMessage('Falha ao inicializar pedido ao ERP-SINC para o NIF ' . $nif . '.' . $endpointInfo);
         return null;
     }
 
@@ -428,7 +469,7 @@ function fetchAccountingEntityFromErp(string $nif): ?array {
 
     $response = curl_exec($handle);
     if ($response === false) {
-        logErpMessage('Erro cURL ao obter entidade ' . $nif . ' do ERP-SINC: ' . curl_error($handle));
+        logErpMessage('Erro cURL ao obter entidade ' . $nif . ' do ERP-SINC: ' . curl_error($handle) . $endpointInfo);
         curl_close($handle);
         return null;
     }
@@ -437,24 +478,24 @@ function fetchAccountingEntityFromErp(string $nif): ?array {
     curl_close($handle);
 
     if ($status >= 400) {
-        logErpMessage('Webservice ERP-SINC devolveu HTTP ' . $status . ' para o NIF ' . $nif . '.');
+        logErpMessage('Webservice ERP-SINC devolveu HTTP ' . $status . ' para o NIF ' . $nif . '.' . $endpointInfo);
         return null;
     }
 
     if ($status === 204 || trim((string) $response) === '') {
-        logErpMessage('Webservice ERP-SINC devolveu resposta vazia para o NIF ' . $nif . '.');
+        logErpMessage('Webservice ERP-SINC devolveu resposta vazia para o NIF ' . $nif . '.' . $endpointInfo);
         return null;
     }
 
     $data = json_decode($response, true);
     if (!is_array($data)) {
-        logErpMessage('Resposta ERP-SINC inválida para o NIF ' . $nif . ': ' . substr($response, 0, 200));
+        logErpMessage('Resposta ERP-SINC inválida para o NIF ' . $nif . ': ' . substr($response, 0, 200) . $endpointInfo);
         return null;
     }
 
     $entity = parseErpEntityPayload($data, $nif);
     if ($entity === null) {
-        logErpMessage('Dados do NIF ' . $nif . ' indisponíveis no ERP-SINC.');
+        logErpMessage('Dados do NIF ' . $nif . ' indisponíveis no ERP-SINC.' . $endpointInfo);
         return null;
     }
 
@@ -527,6 +568,26 @@ function deriveEntityNameFromField(string $rawFieldValue, string $nif): string {
 }
 
 /**
+ * Determine whether a stored entity name is just a placeholder derived from the VAT number.
+ *
+ * @param string|null $name Stored name.
+ * @param string      $nif  VAT number associated with the entity.
+ * @return bool Whether the name should be refreshed from the ERP webservice.
+ */
+function isPlaceholderAccountingEntityName(?string $name, string $nif): bool {
+    $normalized = trim((string) $name);
+    if ($normalized === '') {
+        return true;
+    }
+
+    $normalized = strtoupper(preg_replace('/\s+/', ' ', $normalized));
+    $compact = preg_replace('/[^A-Z0-9]/', '', $normalized);
+    $expectedCompact = 'CLIENTE' . $nif;
+
+    return $compact === $expectedCompact;
+}
+
+/**
  * Ensure that an accounting entity exists locally, fetching it from the ERP
  * when necessary.
  *
@@ -546,9 +607,10 @@ function ensureAccountingEntity(PDO $pdo, string $entityFieldValue): ?array {
         return $cache[$nif] ?: null;
     }
 
+    $existing = null;
     try {
         $existing = findAccountingEntity($pdo, $nif);
-        if ($existing !== null) {
+        if ($existing !== null && !isPlaceholderAccountingEntityName($existing['name'] ?? '', $nif)) {
             $cache[$nif] = $existing;
             return $existing;
         }
@@ -560,6 +622,11 @@ function ensureAccountingEntity(PDO $pdo, string $entityFieldValue): ?array {
 
     $remote = fetchAccountingEntityFromErp($nif);
     if ($remote === null) {
+        if ($existing !== null) {
+            $cache[$nif] = $existing;
+            return $existing;
+        }
+
         $cache[$nif] = null;
         return null;
     }


### PR DESCRIPTION
## Summary
- resolve emitter and acquirer names from the ERP-synchronised entities when preparing accounting import rows
- keep the classification listings showing the original emitter/acquirer strings while persisting the ERP-provided names for bookkeeping
- refresh stored accounting entity names when only placeholder labels exist so the ERP-provided strNome is persisted
- log the ERP client endpoint (with sensitive tokens masked) whenever ERP-SINC requests fail so 404 responses include the URL

## Testing
- php -l contabilidade/functions.php

------
https://chatgpt.com/codex/tasks/task_e_68c9d292356083208a7fb3a2e19600c9