### PR TITLE
Add ERP-SINC API key header when fetching clients

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -520,7 +520,7 @@ function fetchAccountingEntityFromErp(string $nif): ?array {
     $headers = ['Accept: application/json'];
     if ($token !== null && $token !== '') {
         $headers[] = 'Authorization: Bearer ' . $token;
-        $headers[] = 'X-Auth-Token: ' . $token;
+        $headers[] = 'X-API-KEY: ' . $token;
     }
 
     $handle = curl_init($endpoint);


### PR DESCRIPTION
## Summary
- include the ERP-SINC X-API-KEY header when requesting client data by NIF

## Testing
- php -l contabilidade/functions.php

------
https://chatgpt.com/codex/tasks/task_e_68c9f20de55c8320a84c5719b84d48fd