### PR TITLE
Fix default accounting entity type

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -715,7 +715,7 @@ function ensureAccountingEntity(PDO $pdo, string $entityFieldValue): ?array {
 
     $entityType = trim((string) ($remote['entity_type'] ?? ''));
     if ($entityType === '') {
-        $entityType = 'emitente';
+        $entityType = 'emitter';
     }
 
     $data = [


### PR DESCRIPTION
## Summary
- set the default entity type to `emitter` when creating accounting entities to match existing naming conventions

## Testing
- php -l contabilidade/functions.php

------
https://chatgpt.com/codex/tasks/task_e_68c9fa0db2308320b3286677f98e5329