### PR TITLE
Allow per-rate cost centers in classification modal

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -121,25 +121,109 @@ window.addEventListener('load', function() {
     var modalTitleEl = document.getElementById('classifyModalLabel');
     var form = document.getElementById('classify-form');
     var rateInputs = {};
-    var costCenterInputs = [];
+    var rateKeys = [];
     var currentRateData = {};
-    var currentCostCenter = '';
+    var currentCostCenters = {};
 
-    function setCostCenterInputs(value, skipInput) {
-        var normalized = value === undefined || value === null ? '' : String(value);
-        currentCostCenter = normalized;
-        costCenterInputs.forEach(function(input) {
-            if (input !== skipInput && input.value !== normalized) {
-                input.value = normalized;
+    function forEachRate(callback) {
+        var keys = rateKeys.length ? rateKeys : Object.keys(rateInputs);
+        keys.forEach(callback);
+    }
+
+    function createEmptyCostCenters() {
+        var result = {};
+        forEachRate(function(rate) {
+            result[rate] = '';
+        });
+        return result;
+    }
+
+    function normalizeCostCenterValues(value) {
+        var normalized = createEmptyCostCenters();
+        var keys = Object.keys(normalized);
+        if (keys.length === 0) {
+            return normalized;
+        }
+
+        if (value === null || value === undefined) {
+            return normalized;
+        }
+
+        if (typeof value === 'string' || typeof value === 'number') {
+            var stringValue = String(value).trim();
+            keys.forEach(function(rate) {
+                normalized[rate] = stringValue;
+            });
+            return normalized;
+        }
+
+        if (Array.isArray(value)) {
+            value.forEach(function(entry, index) {
+                var rate = keys[index];
+                if (rate !== undefined) {
+                    normalized[rate] = entry === null || entry === undefined ? '' : String(entry).trim();
+                }
+            });
+            return normalized;
+        }
+
+        if (typeof value === 'object') {
+            var source = value;
+            if (source && typeof source.rates === 'object') {
+                source = source.rates;
+            }
+            keys.forEach(function(rate) {
+                if (!Object.prototype.hasOwnProperty.call(source, rate)) {
+                    return;
+                }
+                var entry = source[rate];
+                if (entry !== null && typeof entry === 'object') {
+                    if (Object.prototype.hasOwnProperty.call(entry, 'cost_center')) {
+                        normalized[rate] = String(entry.cost_center || '').trim();
+                        return;
+                    }
+                    if (Object.prototype.hasOwnProperty.call(entry, 'value')) {
+                        normalized[rate] = String(entry.value || '').trim();
+                        return;
+                    }
+                }
+                normalized[rate] = entry === null || entry === undefined ? '' : String(entry).trim();
+            });
+            return normalized;
+        }
+
+        return normalized;
+    }
+
+    function applyCostCenterValues(value) {
+        var normalized = normalizeCostCenterValues(value);
+        forEachRate(function(rate) {
+            currentCostCenters[rate] = normalized[rate];
+            var info = rateInputs[rate];
+            if (info && info.costCenter && info.costCenter.value !== normalized[rate]) {
+                info.costCenter.value = normalized[rate];
             }
         });
     }
 
-    function getCostCenterValue() {
-        if (costCenterInputs.length === 0) {
-            return '';
-        }
-        return costCenterInputs[0].value.trim();
+    function getCostCenterValues() {
+        var values = createEmptyCostCenters();
+        forEachRate(function(rate) {
+            var info = rateInputs[rate];
+            if (info && info.costCenter) {
+                values[rate] = info.costCenter.value.trim();
+            } else if (Object.prototype.hasOwnProperty.call(currentCostCenters, rate)) {
+                values[rate] = (currentCostCenters[rate] || '').trim();
+            }
+        });
+        return values;
+    }
+
+    function hasAnyCostCenterValue() {
+        var values = getCostCenterValues();
+        return Object.keys(values).some(function(rate) {
+            return values[rate] !== '';
+        });
     }
 
     if (form) {
@@ -150,24 +234,38 @@ window.addEventListener('load', function() {
                 base: row.querySelector('.base-field'),
                 iva: row.querySelector('.iva-field'),
                 ivaAccount: row.querySelector('.iva-account-field'),
-                generalAccount: row.querySelector('.general-account-field')
+                generalAccount: row.querySelector('.general-account-field'),
+                costCenter: row.querySelector('.cost-center-field')
             };
         });
-        costCenterInputs = Array.prototype.slice.call(form.querySelectorAll('.cost-center-field'));
-        costCenterInputs.forEach(function(input) {
+        rateKeys = Object.keys(rateInputs);
+        currentCostCenters = createEmptyCostCenters();
+        rateKeys.forEach(function(rate) {
+            var info = rateInputs[rate];
+            if (!info || !info.costCenter) {
+                return;
+            }
+            var input = info.costCenter;
             input.setAttribute('type', 'text');
             input.removeAttribute('readonly');
             input.removeAttribute('disabled');
             input.readOnly = false;
             input.disabled = false;
             input.addEventListener('input', function() {
-                setCostCenterInputs(input.value, input);
+                currentCostCenters[rate] = input.value;
             });
         });
     }
-    if (classifyModalEl && costCenterInputs.length > 0) {
+    if (classifyModalEl) {
         classifyModalEl.addEventListener('shown.bs.modal', function() {
-            costCenterInputs[0].focus();
+            for (var i = 0; i < rateKeys.length; i += 1) {
+                var info = rateInputs[rateKeys[i]];
+                if (info && info.costCenter) {
+                    info.costCenter.focus();
+                    info.costCenter.select();
+                    break;
+                }
+            }
         });
     }
 
@@ -196,7 +294,11 @@ window.addEventListener('load', function() {
             if (info.generalAccount) { info.generalAccount.value = data.general_account || ''; }
         });
 
-        setCostCenterInputs(btn.getAttribute('data-cost-center') || '');
+        var btnCostCenters = parseJsonAttribute(btn, 'data-cost-centers');
+        if (!btnCostCenters && btn.hasAttribute('data-cost-center')) {
+            btnCostCenters = btn.getAttribute('data-cost-center') || '';
+        }
+        applyCostCenterValues(btnCostCenters);
 
         var params = new URLSearchParams({
             action: 'get',
@@ -236,11 +338,17 @@ window.addEventListener('load', function() {
                     }
                 });
 
-                if (res.cost_center !== undefined && res.cost_center !== null && !getCostCenterValue()) {
-                    setCostCenterInputs(res.cost_center || '');
+                var serverCostCenters = null;
+                if (Object.prototype.hasOwnProperty.call(res, 'cost_centers')) {
+                    serverCostCenters = res.cost_centers;
+                } else if (Object.prototype.hasOwnProperty.call(res, 'cost_center')) {
+                    serverCostCenters = res.cost_center;
+                }
+                if (serverCostCenters !== null && serverCostCenters !== undefined && !hasAnyCostCenterValue()) {
+                    applyCostCenterValues(serverCostCenters);
                 }
 
-                currentCostCenter = getCostCenterValue() || currentCostCenter;
+                currentCostCenters = getCostCenterValues();
                 Object.keys(rateInputs).forEach(function(rate) {
                     var info = rateInputs[rate];
                     if (!currentRateData[rate]) {
@@ -276,14 +384,14 @@ window.addEventListener('load', function() {
             };
         });
 
-        var costCenterValue = getCostCenterValue();
+        var costCentersPayload = getCostCenterValues();
         var body = new URLSearchParams({
             id: currentBtn.getAttribute('data-id') || '',
             A: currentBtn.getAttribute('data-emitter') || '',
             B: currentBtn.getAttribute('data-acquirer') || '',
             D: currentBtn.getAttribute('data-doctype') || '',
             rates: JSON.stringify(ratesPayload),
-            cost_center: costCenterValue,
+            cost_centers: JSON.stringify(costCentersPayload),
             csrf_token: csrfInput.value
         });
         fetchJson('contabilidade/save-analysis.php?action=save', {
@@ -296,12 +404,16 @@ window.addEventListener('load', function() {
                 csrfInput.value = res.csrf_token;
             }
             if (res.success) {
-                if (res.cost_center !== undefined && res.cost_center !== null) {
-                    setCostCenterInputs(res.cost_center || '');
+                var responseCostCenters = null;
+                if (Object.prototype.hasOwnProperty.call(res, 'cost_centers')) {
+                    responseCostCenters = res.cost_centers;
+                } else if (Object.prototype.hasOwnProperty.call(res, 'cost_center')) {
+                    responseCostCenters = res.cost_center;
                 } else {
-                    setCostCenterInputs(costCenterValue);
+                    responseCostCenters = costCentersPayload;
                 }
-                currentCostCenter = getCostCenterValue();
+                applyCostCenterValues(responseCostCenters);
+                currentCostCenters = getCostCenterValues();
 
                 if (res.row_rates && typeof res.row_rates === 'object') {
                     Object.keys(res.row_rates).forEach(function(rate) {
@@ -334,7 +446,7 @@ window.addEventListener('load', function() {
                 }
 
                 currentBtn.setAttribute('data-rates', JSON.stringify(currentRateData));
-                currentBtn.setAttribute('data-cost-center', currentCostCenter);
+                currentBtn.setAttribute('data-cost-centers', JSON.stringify(currentCostCenters));
                 updateButtonClass(currentBtn);
                 if (classifyModal) {
                     classifyModal.hide();

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -18,6 +18,7 @@ function prepareImportRow(array $row): array {
     [$payload, $requirements] = buildRatePayload($summaries, $accounts);
     $row['rate_payload'] = $payload;
     $row['rate_requirements'] = $requirements;
+    $row['cost_centers'] = normalizeCostCenters($row['cost_center'] ?? '');
     $row['btn_class'] = determineClassificationButtonClass($requirements, $payload);
     $row['line_btn_class'] = 'btn-info';
     $lines = json_decode($row['line_items'] ?? '', true);
@@ -98,14 +99,14 @@ if ($action === 'data') {
         $actionsParts = [];
         $ratesAttr = htmlspecialchars(json_encode($row['rate_payload'], JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8');
         $requirementsAttr = htmlspecialchars(json_encode($row['rate_requirements'], JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8');
-        $costCenterAttr = htmlspecialchars($row['cost_center'] ?? '', ENT_QUOTES, 'UTF-8');
+        $costCentersAttr = htmlspecialchars(json_encode($row['cost_centers'] ?? [], JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8');
 
         if ($importType === 1) {
             $actionsParts[] = '<button type="button" class="btn btn-xs ' . $row['btn_class'] . ' classify-row" '
                 . 'data-id="' . (int)$row['id'] . '" '
                 . 'data-rates="' . $ratesAttr . '" '
                 . 'data-requirements="' . $requirementsAttr . '" '
-                . 'data-cost-center="' . $costCenterAttr . '" '
+                . 'data-cost-centers="' . $costCentersAttr . '" '
                 . 'data-emitter="' . htmlspecialchars($row['field_A'] ?? '') . '" '
                 . 'data-acquirer="' . htmlspecialchars($row['field_B'] ?? '') . '" '
                 . 'data-doctype="' . htmlspecialchars($row['field_D'] ?? '') . '">Classificar</button>';
@@ -220,7 +221,7 @@ require_once __DIR__ . '/../header.php';
                     <?php
                         $ratesAttr = htmlspecialchars(json_encode($row['rate_payload'], JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8');
                         $requirementsAttr = htmlspecialchars(json_encode($row['rate_requirements'], JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8');
-                        $costCenterAttr = htmlspecialchars($row['cost_center'] ?? '', ENT_QUOTES, 'UTF-8');
+                        $costCentersAttr = htmlspecialchars(json_encode($row['cost_centers'] ?? [], JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8');
                         $btnClass = htmlspecialchars($row['btn_class'] ?? 'btn-secondary');
                     ?>
                     <td class="text-center">
@@ -232,7 +233,7 @@ require_once __DIR__ . '/../header.php';
                             data-id="<?= (int)$row['id']; ?>"
                             data-rates="<?= $ratesAttr; ?>"
                             data-requirements="<?= $requirementsAttr; ?>"
-                            data-cost-center="<?= $costCenterAttr; ?>"
+                            data-cost-centers="<?= $costCentersAttr; ?>"
 
 
                             data-emitter="<?= htmlspecialchars($row['field_A'] ?? ''); ?>"
@@ -293,8 +294,8 @@ require_once __DIR__ . '/../header.php';
                                     <td class="align-middle">
                                         <input
                                             type="text"
-                                            class="form-control form-control-sm cost-center-field cost-center"
-                                            name="cost_center"
+                                            class="form-control form-control-sm cost-center-field"
+                                            name="cost_centers[<?= $rate; ?>]"
                                             placeholder="Introduza o centro de custo"
                                         >
                                     </td>

--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -889,6 +889,117 @@ function serializeAccountingAccounts(array $rates): string {
 }
 
 /**
+ * Build an empty cost centre map keyed by VAT rate.
+ *
+ * @return array<string,string>
+ */
+function buildEmptyCostCenterMap(): array {
+    $result = [];
+    foreach (['0', '6', '13', '23'] as $rate) {
+        $result[$rate] = '';
+    }
+
+    return $result;
+}
+
+/**
+ * Sanitize arbitrary cost centre input ensuring expected VAT keys exist.
+ *
+ * The function accepts the different shapes that may appear either from
+ * previously stored JSON blobs or user-submitted payloads and always
+ * returns an array keyed by the supported VAT rates containing strings.
+ *
+ * @param mixed $input
+ * @return array<string,string>
+ */
+function sanitizeCostCenterValues($input): array {
+    $result = buildEmptyCostCenterMap();
+
+    if (is_string($input) || is_numeric($input)) {
+        $value = trim((string) $input);
+        if ($value === '') {
+            return $result;
+        }
+
+        foreach ($result as $rate => $_) {
+            $result[$rate] = $value;
+        }
+
+        return $result;
+    }
+
+    if (!is_array($input)) {
+        return $result;
+    }
+
+    if (isset($input['rates']) && is_array($input['rates'])) {
+        $input = $input['rates'];
+    }
+
+    foreach ($result as $rate => $_) {
+        if (!array_key_exists($rate, $input)) {
+            continue;
+        }
+
+        $value = $input[$rate];
+        if (is_array($value)) {
+            if (array_key_exists('cost_center', $value)) {
+                $value = $value['cost_center'];
+            } elseif (array_key_exists('value', $value)) {
+                $value = $value['value'];
+            }
+        }
+
+        if ($value === null) {
+            $result[$rate] = '';
+        } else {
+            $result[$rate] = trim((string) $value);
+        }
+    }
+
+    return $result;
+}
+
+/**
+ * Normalize stored cost centre information into a predictable structure.
+ *
+ * @param string|null $json JSON-encoded cost centre data or legacy value.
+ * @return array<string,string>
+ */
+function normalizeCostCenters(?string $json): array {
+    if ($json === null) {
+        return buildEmptyCostCenterMap();
+    }
+
+    $trimmed = trim($json);
+    if ($trimmed === '') {
+        return buildEmptyCostCenterMap();
+    }
+
+    $decoded = json_decode($trimmed, true);
+    if (json_last_error() === JSON_ERROR_NONE) {
+        return sanitizeCostCenterValues($decoded);
+    }
+
+    return sanitizeCostCenterValues($trimmed);
+}
+
+/**
+ * Serialize cost centre values to be stored in the database.
+ *
+ * @param array<string,mixed> $centers
+ * @return string
+ */
+function serializeCostCenters(array $centers): string {
+    $sanitized = sanitizeCostCenterValues($centers);
+
+    return json_encode([
+        'version' => 1,
+        'rates' => $sanitized,
+    ], JSON_UNESCAPED_UNICODE);
+}
+
+/**
  * Calculate VAT rate amounts and requirements for an imported document row.
  *
  * @param array<string,mixed> $row

--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -112,19 +112,20 @@ if ($action === 'get') {
     $classificationAccounts = normalizeAccountingAccounts($row['account'] ?? '');
 
     $rowAccounts = normalizeAccountingAccounts(null);
-    $costCenter = '';
+    $rowCostCenters = buildEmptyCostCenterMap();
     if ($id !== '') {
         $stmtRow = $pdo->prepare('SELECT account, cost_center FROM accounting_imports WHERE id = ? LIMIT 1');
         $stmtRow->execute([$id]);
         $importRow = $stmtRow->fetch(PDO::FETCH_ASSOC) ?: [];
         $rowAccounts = normalizeAccountingAccounts($importRow['account'] ?? '');
-        $costCenter = (string)($importRow['cost_center'] ?? '');
+        $rowCostCenters = normalizeCostCenters($importRow['cost_center'] ?? '');
     }
 
     echo json_encode([
         'rates' => $classificationAccounts,
         'row_rates' => $rowAccounts,
-        'cost_center' => $costCenter,
+        'cost_center' => serializeCostCenters($rowCostCenters),
+        'cost_centers' => $rowCostCenters,
         'csrf_token' => generateCsrfToken()
     ]);
     exit;
@@ -156,7 +157,23 @@ if ($action === 'get') {
             $ratesData = [];
         }
         $submittedRates = sanitizeAccountInput($ratesData);
-        $costCenter = isset($_POST['cost_center']) ? trim((string) $_POST['cost_center']) : '';
+
+        $costCentersJson = $_POST['cost_centers'] ?? '';
+        $costCentersData = [];
+        if ($costCentersJson !== '') {
+            $decodedCostCenters = json_decode($costCentersJson, true);
+            if (!is_array($decodedCostCenters)) {
+                $decodedCostCenters = [];
+            }
+            $costCentersData = sanitizeCostCenterValues($decodedCostCenters);
+        } else {
+            $legacyCostCenter = isset($_POST['cost_center']) ? trim((string) $_POST['cost_center']) : '';
+            if ($legacyCostCenter === '') {
+                $costCentersData = sanitizeCostCenterValues([]);
+            } else {
+                $costCentersData = sanitizeCostCenterValues($legacyCostCenter);
+            }
+        }
 
         $stmtExisting = $pdo->prepare(
             'SELECT account FROM accounting_classifications WHERE emitter = ? AND acquirer = ? AND doc_type = ? LIMIT 1'
@@ -173,9 +190,10 @@ if ($action === 'get') {
 
         $serializedRow = serializeAccountingAccounts($rowAccounts);
         $serializedClass = serializeAccountingAccounts($classAccounts);
+        $serializedCostCenters = serializeCostCenters($costCentersData);
 
         $stmt = $pdo->prepare('UPDATE accounting_imports SET account = ?, cost_center = ? WHERE id = ?');
-        $stmt->execute([$serializedRow, $costCenter, $id]);
+        $stmt->execute([$serializedRow, $serializedCostCenters, $id]);
 
         $stmt2 = $pdo->prepare(
             'INSERT INTO accounting_classifications (emitter, acquirer, doc_type, account) '
@@ -188,7 +206,8 @@ if ($action === 'get') {
             'success' => true,
             'csrf_token' => generateCsrfToken(),
             'row_rates' => $rowAccounts,
-            'cost_center' => $costCenter
+            'cost_center' => $serializedCostCenters,
+            'cost_centers' => $costCentersData
         ]);
     } catch (Exception $e) {
         if ($pdo->inTransaction()) {


### PR DESCRIPTION
## Summary
- normalise and serialise cost centre data per VAT rate
- surface per-rate cost centres in the classification modal and dataset attributes
- update save-analysis endpoints and client script to read/write individual cost centres

## Testing
- php -l contabilidade/functions.php
- php -l contabilidade/classificacao-importacao.php
- php -l contabilidade/save-analysis.php

------
https://chatgpt.com/codex/tasks/task_e_68c9fbc68d60832091c7ed7a40da4d12