### PR TITLE
fix: harden login redirect handling

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -214,10 +214,72 @@ function isLoggedIn(): bool {
  * login the user is returned to the originally requested page via the
  * `redirect` query parameter.
  */
+/**
+ * Validate and normalize a redirect target ensuring it stays within the
+ * current application. Returns the normalized path (including optional query
+ * string and fragment) or null when the provided value is not a safe
+ * application-local redirect.
+ *
+ * @param string|null $redirect
+ * @return string|null
+ */
+function normalizeRedirectTarget(?string $redirect): ?string {
+    if ($redirect === null) {
+        return null;
+    }
+
+    $redirect = trim($redirect);
+    if ($redirect === '') {
+        return null;
+    }
+
+    $decoded = rawurldecode($redirect);
+    if ($decoded === '') {
+        return null;
+    }
+
+    if (preg_match("/[\r\n]/", $decoded)) {
+        return null;
+    }
+
+    if (strncmp($decoded, '//', 2) === 0) {
+        return null;
+    }
+
+    $parts = parse_url($decoded);
+    if ($parts === false) {
+        return null;
+    }
+
+    if (isset($parts['scheme']) || isset($parts['host']) || isset($parts['port'])
+        || isset($parts['user']) || isset($parts['pass'])) {
+        return null;
+    }
+
+    $path = $parts['path'] ?? '';
+    if ($path === '' || $path[0] !== '/') {
+        return null;
+    }
+
+    $normalized = $path;
+    if (isset($parts['query']) && $parts['query'] !== '') {
+        $normalized .= '?' . $parts['query'];
+    }
+    if (isset($parts['fragment']) && $parts['fragment'] !== '') {
+        $normalized .= '#' . $parts['fragment'];
+    }
+
+    return $normalized;
+}
+
 function requireLogin() {
     startSession();
     if (!isLoggedIn() || empty($_SESSION['company'])) {
-        $redirect = urlencode($_SERVER['REQUEST_URI'] ?? '/');
+        $requestedPath = normalizeRedirectTarget($_SERVER['REQUEST_URI'] ?? null);
+        if ($requestedPath === null) {
+            $requestedPath = BASE_URL . 'dashboard';
+        }
+        $redirect = urlencode($requestedPath);
         header('Location: ' . BASE_URL . 'login?redirect=' . $redirect);
         exit;
     }

--- a/login.php
+++ b/login.php
@@ -33,7 +33,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             setCompanyContext($company);
             if (loginUser($username, $password)) {
                 // Redirect to dashboard or to a previously requested page
-                $redirect = $_GET['redirect'] ?? (BASE_URL . 'dashboard');
+                $redirect = normalizeRedirectTarget($_GET['redirect'] ?? null);
+                if ($redirect === null) {
+                    $redirect = BASE_URL . 'dashboard';
+                }
                 header('Location: ' . $redirect);
                 exit;
             } else {

--- a/tests/redirect_test.php
+++ b/tests/redirect_test.php
@@ -1,0 +1,42 @@
+<?php
+// Basic assertions verifying that redirects are normalized to internal paths
+// and that potentially malicious values are rejected.
+
+declare(strict_types=1);
+
+$_SERVER['SCRIPT_NAME'] = '/index.php';
+
+require_once __DIR__ . '/../functions.php';
+
+$cases = [
+    'valid path' => ['%2Fdashboard', '/dashboard'],
+    'valid path with query' => ['/cms/content.php?tab=seo', '/cms/content.php?tab=seo'],
+    'valid path with fragment' => ['/cms/content.php#preview', '/cms/content.php#preview'],
+    'external https' => ['https://example.com/', null],
+    'protocol-relative' => ['//example.com/path', null],
+    'with newline' => ["/cms/foo\r\nLocation: https://evil.com", null],
+    'relative without leading slash' => ['dashboard', null],
+];
+
+$allPassed = true;
+foreach ($cases as $label => [$input, $expected]) {
+    $result = normalizeRedirectTarget($input);
+    if ($result !== $expected) {
+        $allPassed = false;
+        fwrite(
+            STDERR,
+            sprintf(
+                "Test '%s' failed: expected %s got %s\n",
+                $label,
+                var_export($expected, true),
+                var_export($result, true)
+            )
+        );
+    }
+}
+
+if (!$allPassed) {
+    exit(1);
+}
+
+echo "All redirect normalization tests passed\n";


### PR DESCRIPTION
## Summary
- validate redirect parameters to ensure login responses stay within the app
- reuse the normalization logic inside requireLogin() to keep generated redirects internal
- cover the redirect sanitizer with executable assertions blocking external URLs

## Testing
- php tests/redirect_test.php
- php -l functions.php
- php -l login.php

------
https://chatgpt.com/codex/tasks/task_e_68d10cb2bc6483208d00a51cb6d6d04b