### PR TITLE
Add base company field to accounting settings

### DIFF
--- a/definicoes.php
+++ b/definicoes.php
@@ -48,7 +48,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         }
 
-        setSetting('accounting_enabled', isset($_POST['accounting_enabled']) ? '1' : '0');
+        $accountingEnabled = isset($_POST['accounting_enabled']) ? '1' : '0';
+        setSetting('accounting_enabled', $accountingEnabled);
+
+        $accountingBaseCompany = trim($_POST['accounting_base_company'] ?? '');
+        if ($accountingEnabled) {
+            setSetting('accounting_base_company', $accountingBaseCompany);
+        } else {
+            setSetting('accounting_base_company', '');
+        }
 
         $generalSaved = true;
     }
@@ -105,6 +113,7 @@ $currentAppName = getSetting('app_name', '');
 $currentApiEnabled = (int)getSetting('api_enabled', '0');
 $currentApiToken = getSetting('api_token', '');
 $currentAccountingEnabled = (int)getSetting('accounting_enabled', '0');
+$currentAccountingBaseCompany = getSetting('accounting_base_company', '');
 $contentTypes = getContentTypes();
 $contentTypeApi = [];
 foreach ($contentTypes as $type) {
@@ -169,6 +178,22 @@ require_once __DIR__ . '/header.php';
                         </div>
                     </div>
                 </div>
+                <div class="row">
+                    <div class="mb-3 col-md-6 col-sm-12">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="accounting_enabled" name="accounting_enabled" value="1" <?= $currentAccountingEnabled ? 'checked' : ''; ?>>
+                            <label class="form-check-label" for="accounting_enabled">Ativar Contabilidade</label>
+                        </div>
+                    </div>
+                </div>
+                <div id="accounting-settings" style="<?= $currentAccountingEnabled ? '' : 'display:none;'; ?>">
+                    <div class="row">
+                        <div class="mb-3 col-md-6 col-sm-12">
+                            <label for="accounting_base_company" class="form-label">Empresa Base</label>
+                            <input type="text" class="form-control" id="accounting_base_company" name="accounting_base_company" value="<?= htmlspecialchars($currentAccountingBaseCompany); ?>" <?= $currentAccountingEnabled ? '' : 'disabled'; ?>>
+                        </div>
+                    </div>
+                </div>
                 <div id="api-settings" style="<?= $currentApiEnabled ? '' : 'display:none;'; ?>">
                     <div class="row">
                         <div class="mb-3 col-md-6 col-sm-12">
@@ -198,7 +223,37 @@ require_once __DIR__ . '/header.php';
                         <button type="submit" class="btn btn-md btn-primary"><i class="fa fa-save"></i> Guardar</button>
                     </div>
                 </div>
-                
+                <script>
+                    document.addEventListener('DOMContentLoaded', function () {
+                        var accountingCheckbox = document.getElementById('accounting_enabled');
+                        var accountingSettings = document.getElementById('accounting-settings');
+                        if (!accountingCheckbox || !accountingSettings) {
+                            return;
+                        }
+
+                        var accountingInputs = accountingSettings.querySelectorAll('input, select, textarea');
+
+                        function setInputsDisabled(disabled) {
+                            for (var i = 0; i < accountingInputs.length; i++) {
+                                accountingInputs[i].disabled = disabled;
+                            }
+                        }
+
+                        function toggleAccountingSettings() {
+                            if (accountingCheckbox.checked) {
+                                accountingSettings.style.display = '';
+                                setInputsDisabled(false);
+                            } else {
+                                accountingSettings.style.display = 'none';
+                                setInputsDisabled(true);
+                            }
+                        }
+
+                        toggleAccountingSettings();
+                        accountingCheckbox.addEventListener('change', toggleAccountingSettings);
+                    });
+                </script>
+
             </form>
         </div>
         <div class="tab-pane fade" id="email" role="tabpanel" aria-labelledby="email-tab">


### PR DESCRIPTION
## Summary
- add support for saving the accounting base company when the accounting module is enabled
- show and disable the Base Company input dynamically based on the accounting checkbox in settings

## Testing
- php -l definicoes.php

------
https://chatgpt.com/codex/tasks/task_e_68d113c29c3883209e0c54058866a711