### PR TITLE
Handle missing tables when dropping legacy account columns

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -746,14 +746,29 @@ function dropLegacyAccountColumns(PDO $pdo): void {
     $tables = ['accounting_imports', 'accounting_classifications'];
 
     foreach ($tables as $table) {
-        $stmt = $pdo->query("SHOW COLUMNS FROM {$table}");
+        if (! tableExists($pdo, $table)) {
+            continue;
+        }
+
+        $quotedTable = "`" . str_replace("`", "``", $table) . "`";
+        $stmt = $pdo->query("SHOW COLUMNS FROM {$quotedTable}");
         $existing = $stmt->fetchAll(PDO::FETCH_COLUMN);
         foreach ($legacyCols as $col) {
             if (in_array($col, $existing, true)) {
-                $pdo->exec("ALTER TABLE {$table} DROP COLUMN {$col}");
+                $quotedColumn = "`" . str_replace("`", "``", $col) . "`";
+                $pdo->exec("ALTER TABLE {$quotedTable} DROP COLUMN {$quotedColumn}");
             }
         }
     }
+}
+
+/**
+ * Check if a table exists in the current database schema.
+ */
+function tableExists(PDO $pdo, string $table): bool {
+    $stmt = $pdo->prepare('SHOW TABLES LIKE :table');
+    $stmt->execute([':table' => $table]);
+    return $stmt->fetchColumn() !== false;
 }
 
 /**


### PR DESCRIPTION
## Summary
- guard the legacy account cleanup against missing tables in test environments
- escape table and column names before executing the drop statements
- add a helper to detect table existence before running column queries

## Testing
- php -l contabilidade/functions.php

------
https://chatgpt.com/codex/tasks/task_e_68d132375fe48320bfc6698d56f5d5a1