### PR TITLE
fix: correct DataTables counts for accounting imports

### DIFF
--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -74,6 +74,13 @@ if ($action === 'data') {
         $length = 10;
     }
 
+    $countSql = 'SELECT COUNT(*) FROM accounting_imports WHERE import_type = :importType';
+    $countStmt = $pdo->prepare($countSql);
+    $countStmt->bindValue(':importType', $importType, PDO::PARAM_INT);
+    $countStmt->execute();
+    $totalCount = (int)$countStmt->fetchColumn();
+    $filteredCount = $totalCount;
+
     $colList = implode(', ', array_map(fn($c) => "`$c`", $columns));
     $sql = "SELECT $colList FROM accounting_imports WHERE import_type = :importType ORDER BY id LIMIT :start, :length";
     $stmt = $pdo->prepare($sql);
@@ -139,8 +146,8 @@ if ($action === 'data') {
     header('Content-Type: application/json; charset=utf-8');
     echo json_encode([
         'draw' => $draw,
-        'recordsTotal' => count($rows),
-        'recordsFiltered' => count($rows),
+        'recordsTotal' => $totalCount,
+        'recordsFiltered' => $filteredCount,
         'data' => $data,
     ], JSON_UNESCAPED_UNICODE);
     exit;


### PR DESCRIPTION
## Summary
- query the total number of accounting imports for the requested import type before fetching rows
- use the computed totals for the DataTables recordsTotal and recordsFiltered values so pagination reflects the full dataset

## Testing
- php -l contabilidade/classificacao-importacao.php

------
https://chatgpt.com/codex/tasks/task_e_68d268419f40832081969c337c5f6b6c