### PR TITLE
Add dynamic line editor to document lines modal

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -68,6 +68,178 @@ window.addEventListener('load', function() {
             .replace(/'/g, '&#39;');
     }
 
+    function trimmedString(value) {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value).trim();
+    }
+
+    function extractLineValue(line, keys) {
+        if (!line || typeof line !== 'object') {
+            return '';
+        }
+        for (var i = 0; i < keys.length; i += 1) {
+            var key = keys[i];
+            if (Object.prototype.hasOwnProperty.call(line, key)) {
+                var directValue = line[key];
+                if (directValue !== null && directValue !== undefined) {
+                    var directString = trimmedString(directValue);
+                    if (directString !== '') {
+                        return directString;
+                    }
+                }
+            }
+            var lowerKey = typeof key === 'string' ? key.toLowerCase() : key;
+            if (lowerKey !== key && Object.prototype.hasOwnProperty.call(line, lowerKey)) {
+                var lowerValue = line[lowerKey];
+                if (lowerValue !== null && lowerValue !== undefined) {
+                    var lowerString = trimmedString(lowerValue);
+                    if (lowerString !== '') {
+                        return lowerString;
+                    }
+                }
+            }
+            var upperKey = typeof key === 'string' ? key.toUpperCase() : key;
+            if (upperKey !== key && Object.prototype.hasOwnProperty.call(line, upperKey)) {
+                var upperValue = line[upperKey];
+                if (upperValue !== null && upperValue !== undefined) {
+                    var upperString = trimmedString(upperValue);
+                    if (upperString !== '') {
+                        return upperString;
+                    }
+                }
+            }
+        }
+        return '';
+    }
+
+    function normalizeRateDisplay(value) {
+        var rate = trimmedString(value);
+        if (rate.endsWith('%')) {
+            rate = rate.slice(0, -1).trim();
+        }
+        return rate;
+    }
+
+    function parseLocalizedNumber(value) {
+        if (value === null || value === undefined) {
+            return null;
+        }
+        var stringValue = String(value).trim();
+        if (!stringValue) {
+            return null;
+        }
+        stringValue = stringValue.replace(/%/g, '').replace(/\s+/g, '');
+        var commaIndex = stringValue.lastIndexOf(',');
+        var dotIndex = stringValue.lastIndexOf('.');
+        if (commaIndex > -1 && dotIndex > -1) {
+            if (commaIndex > dotIndex) {
+                stringValue = stringValue.replace(/\./g, '').replace(',', '.');
+            } else {
+                stringValue = stringValue.replace(/,/g, '');
+            }
+        } else if (commaIndex > -1) {
+            stringValue = stringValue.replace(/\./g, '').replace(',', '.');
+        }
+        var result = parseFloat(stringValue);
+        return Number.isNaN(result) ? null : result;
+    }
+
+    function formatLocalizedNumber(value) {
+        if (typeof value !== 'number' || !isFinite(value)) {
+            return '';
+        }
+        return value.toFixed(2);
+    }
+
+    function buildLineRow(line) {
+        var data = line && typeof line === 'object' ? line : {};
+        var erp = extractLineValue(data, ['ERP']);
+        var taxRate = normalizeRateDisplay(extractLineValue(data, ['TAXA', 'IVA_TAXA', 'IVA', 'TAX_RATE', 'IVA TAXA', 'OTHER']));
+        var baseValue = extractLineValue(data, ['BASE', 'BASE_IMPONIVEL', 'BASE IMPONIVEL', 'PRICE', 'PRECO', 'VALOR']);
+        var ivaValue = extractLineValue(data, ['IVA', 'IVA_TOTAL', 'IVA_VALOR', 'IVA VALOR', 'TAX_AMOUNT']);
+        var ivaAccount = extractLineValue(data, ['CONTA_IVA', 'CONTA IVA', 'IVA_ACCOUNT']);
+        var generalAccount = extractLineValue(data, ['CONTA_GERAL', 'CONTA GERAL', 'GENERAL_ACCOUNT']);
+        var costCenter = extractLineValue(data, ['CENTRO_CUSTO', 'CENTRO DE CUSTO', 'CENTRO_DE_CUSTO', 'COST_CENTER']);
+        var productCode = extractLineValue(data, ['PRODUCT_CODE', 'CODIGO', 'CÓDIGO', 'COD ARTIGO']);
+        var item = extractLineValue(data, ['ITEM', 'DESCRICAO', 'DESCRIÇÃO']);
+        var quantity = extractLineValue(data, ['QUANTITY', 'QTD', 'QUANTIDADE']);
+        var unitPrice = extractLineValue(data, ['UNIT_PRICE', 'PRECO_UNITARIO', 'PREÇO_UNITARIO', 'PREÇO UNITÁRIO']);
+        var price = extractLineValue(data, ['PRICE', 'PRECO', 'VALOR']);
+        if (data.ITEM_QUANTITY_UNIT_PRICE && typeof data.ITEM_QUANTITY_UNIT_PRICE === 'object') {
+            var nested = data.ITEM_QUANTITY_UNIT_PRICE;
+            if (!item) {
+                item = trimmedString(extractLineValue(nested, ['ITEM', 'DESCRICAO', 'DESCRIÇÃO']));
+            }
+            if (!quantity) {
+                quantity = trimmedString(extractLineValue(nested, ['QUANTITY', 'QTD', 'QUANTIDADE']));
+            }
+            if (!unitPrice) {
+                unitPrice = trimmedString(extractLineValue(nested, ['UNIT_PRICE', 'PRECO_UNITARIO', 'PREÇO_UNITARIO', 'PREÇO UNITÁRIO']));
+            }
+            if (!price) {
+                price = trimmedString(extractLineValue(nested, ['PRICE', 'PRECO', 'VALOR']));
+            }
+        }
+        if (!baseValue && price) {
+            baseValue = price;
+        }
+        var priceVat = extractLineValue(data, ['PRICE_VAT', 'TOTAL_COM_IVA', 'TOTAL IVA', 'TOTAL']);
+        var baseNumber = parseLocalizedNumber(baseValue);
+        var ivaNumber = parseLocalizedNumber(ivaValue);
+        var rateNumber = parseLocalizedNumber(taxRate);
+        if (!ivaValue && baseNumber !== null && rateNumber !== null) {
+            ivaValue = formatLocalizedNumber(baseNumber * (rateNumber / 100));
+            ivaNumber = parseLocalizedNumber(ivaValue);
+        }
+        if (!priceVat) {
+            if (baseNumber !== null && ivaNumber !== null) {
+                priceVat = formatLocalizedNumber(baseNumber + ivaNumber);
+            } else if (baseNumber !== null && rateNumber !== null) {
+                priceVat = formatLocalizedNumber(baseNumber * (1 + rateNumber / 100));
+            }
+        }
+
+        var row = document.createElement('tr');
+        row.dataset.productCode = productCode;
+        row.dataset.item = item;
+        row.dataset.quantity = quantity;
+        row.dataset.unitPrice = unitPrice;
+        row.dataset.price = price || baseValue;
+        row.dataset.priceVat = priceVat || '';
+
+        var cells = [
+            { className: 'erp-input', value: erp },
+            { className: 'tax-rate-input', value: taxRate },
+            { className: 'base-input', value: baseValue },
+            { className: 'iva-amount-input', value: ivaValue },
+            { className: 'iva-account-input', value: ivaAccount },
+            { className: 'general-account-input', value: generalAccount },
+            { className: 'cost-center-input', value: costCenter }
+        ];
+
+        cells.forEach(function(cell) {
+            var td = document.createElement('td');
+            var input = document.createElement('input');
+            input.type = 'text';
+            input.className = 'form-control form-control-sm ' + cell.className;
+            input.value = cell.value || '';
+            td.appendChild(input);
+            row.appendChild(td);
+        });
+
+        var actionsTd = document.createElement('td');
+        actionsTd.className = 'text-center';
+        var removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'btn btn-sm btn-outline-danger remove-line-btn';
+        removeBtn.innerHTML = '<i class="fa fa-trash"></i>';
+        actionsTd.appendChild(removeBtn);
+        row.appendChild(actionsTd);
+
+        return row;
+    }
 
     function updateButtonClass(btn) {
         var rateData = parseJsonAttribute(btn, 'data-rates') || {};
@@ -519,58 +691,87 @@ window.addEventListener('load', function() {
             });
     });
 
+    function normalizeLinesPayload(raw) {
+        if (Array.isArray(raw)) {
+            return raw;
+        }
+        if (raw && typeof raw === 'object') {
+            if (Array.isArray(raw.lines)) {
+                return raw.lines;
+            }
+            if (Array.isArray(raw.items)) {
+                return raw.items;
+            }
+        }
+        return [];
+    }
+
     function renderLines(lines) {
-        if (!Array.isArray(lines) || lines.length === 0) {
-            linesContainer.innerHTML = '<p>Sem linhas detectadas</p>';
-            return;
-        }
-        var html = '<table class="table table-striped"><thead><tr>' +
-            '<th>ERP</th>' +
-            '<th>IVA</th>' +
-            '<th>Código</th>' +
-            '<th>Descrição</th>' +
-            '<th>Qtd.</th>' +
-            '<th>P. Un.</th>' +
-            '<th>Preço</th>';
-        if (showLineCostCenter) {
-            html += '<th>Centro de Custo</th>';
-        }
-        html += '</tr></thead><tbody>';
-        lines.forEach(function(line) {
-            var erp = line.ERP || '';
-            var iva = line.IVA_TAXA || line.OTHER || '';
-            var productCode = line.PRODUCT_CODE || '';
-            var item = line.ITEM || (line.ITEM_QUANTITY_UNIT_PRICE && line.ITEM_QUANTITY_UNIT_PRICE.ITEM) || '';
-            var quantity = line.QUANTITY || (line.ITEM_QUANTITY_UNIT_PRICE && line.ITEM_QUANTITY_UNIT_PRICE.QUANTITY) || '';
-            var unitPrice = line.UNIT_PRICE || (line.ITEM_QUANTITY_UNIT_PRICE && line.ITEM_QUANTITY_UNIT_PRICE.UNIT_PRICE) || '';
-            var price = line.PRICE || '';
-            var priceVat = line.PRICE_VAT || '';
-            var costCenter = '';
-            if (showLineCostCenter) {
-                costCenter = line.COST_CENTER || line.cost_center || '';
+        var normalized = normalizeLinesPayload(lines);
+        linesContainer.innerHTML = '';
+
+        var wrapper = document.createElement('div');
+
+        var actionsRow = document.createElement('div');
+        actionsRow.className = 'd-flex justify-content-end mb-2';
+        var addButton = document.createElement('button');
+        addButton.type = 'button';
+        addButton.className = 'btn btn-sm btn-outline-primary add-line-btn';
+        addButton.textContent = 'Adicionar linha';
+        actionsRow.appendChild(addButton);
+        wrapper.appendChild(actionsRow);
+
+        var table = document.createElement('table');
+        table.className = 'table table-striped align-middle';
+        var thead = document.createElement('thead');
+        var headerRow = document.createElement('tr');
+        ['ERP', 'Taxa', 'Base', 'IVA', 'Conta IVA', 'Conta Geral', 'Centro de Custo', ''].forEach(function(label, index) {
+            var th = document.createElement('th');
+            if (label === '') {
+                th.className = 'text-center';
+            } else {
+                th.textContent = label;
             }
-            if (!priceVat) {
-                var priceNum = parseFloat(String(price).replace(',', '.'));
-                var ivaNum = parseFloat(String(iva).replace(',', '.'));
-                if (!isNaN(priceNum) && !isNaN(ivaNum)) {
-                    priceVat = (priceNum * (1 + ivaNum / 100)).toFixed(2);
-                }
-            }
-            html += '<tr>' +
-                '<td><input type="text" class="form-control erp-input" value="' + escapeHtml(erp) + '"><input type="hidden" class="price-vat" value="' + escapeHtml(priceVat) + '"></td>' +
-                '<td class="iva-taxa">' + escapeHtml(iva) + '</td>' +
-                '<td class="product-code">' + escapeHtml(productCode) + '</td>' +
-                '<td class="item">' + escapeHtml(item) + '</td>' +
-                '<td class="quantity">' + escapeHtml(quantity) + '</td>' +
-                '<td class="unit-price">' + escapeHtml(unitPrice) + '</td>' +
-                '<td class="price">' + escapeHtml(price) + '</td>';
-            if (showLineCostCenter) {
-                html += '<td><input type="text" class="form-control cost-center-input" value="' + escapeHtml(costCenter) + '"></td>';
-            }
-            html += '</tr>';
+            headerRow.appendChild(th);
         });
-        html += '</tbody></table>';
-        linesContainer.innerHTML = html;
+        thead.appendChild(headerRow);
+        table.appendChild(thead);
+
+        var tbody = document.createElement('tbody');
+        table.appendChild(tbody);
+        wrapper.appendChild(table);
+        linesContainer.appendChild(wrapper);
+
+        function appendRow(data) {
+            tbody.appendChild(buildLineRow(data));
+        }
+
+        if (normalized.length > 0) {
+            normalized.forEach(function(line) {
+                appendRow(line);
+            });
+        } else {
+            appendRow({});
+        }
+
+        addButton.addEventListener('click', function() {
+            appendRow({});
+        });
+
+        tbody.addEventListener('click', function(event) {
+            var btn = event.target.closest('.remove-line-btn');
+            if (!btn) {
+                return;
+            }
+            var row = btn.closest('tr');
+            if (!row) {
+                return;
+            }
+            row.remove();
+            if (!tbody.querySelector('tr')) {
+                appendRow({});
+            }
+        });
     }
 
     confirmLinesBtn.addEventListener('click', function() {
@@ -579,35 +780,75 @@ window.addEventListener('load', function() {
         }
         var rows = linesContainer.querySelectorAll('tbody tr');
         var linesToSave = [];
-        var allErpFilled = true;
+        var allLinesComplete = true;
         rows.forEach(function(row) {
             var erp = row.querySelector('.erp-input').value.trim();
-            var iva = row.querySelector('.iva-taxa').textContent.trim();
-            var productCode = row.querySelector('.product-code').textContent.trim();
-            var item = row.querySelector('.item').textContent.trim();
-            var quantity = row.querySelector('.quantity').textContent.trim();
-            var unitPrice = row.querySelector('.unit-price').textContent.trim();
-            var price = row.querySelector('.price').textContent.trim();
-            var priceVat = row.querySelector('.price-vat').value;
-            var costCenterInputEl = showLineCostCenter ? row.querySelector('.cost-center-input') : null;
+            var taxRate = row.querySelector('.tax-rate-input').value.trim();
+            var base = row.querySelector('.base-input').value.trim();
+            var ivaAmount = row.querySelector('.iva-amount-input').value.trim();
+            var ivaAccount = row.querySelector('.iva-account-input').value.trim();
+            var generalAccount = row.querySelector('.general-account-input').value.trim();
+            var costCenterInputEl = row.querySelector('.cost-center-input');
             var costCenter = costCenterInputEl ? costCenterInputEl.value.trim() : '';
-            if (!erp) {
-                allErpFilled = false;
+
+            var productCode = row.dataset.productCode || '';
+            var item = row.dataset.item || '';
+            var quantity = row.dataset.quantity || '';
+            var unitPrice = row.dataset.unitPrice || '';
+            var price = row.dataset.price || base;
+            var priceVat = row.dataset.priceVat || '';
+
+            var baseNumber = parseLocalizedNumber(base);
+            var ivaNumber = parseLocalizedNumber(ivaAmount);
+            var rateNumber = parseLocalizedNumber(taxRate);
+            if (!price && base !== '') {
+                price = base;
             }
+            if (!priceVat) {
+                if (baseNumber !== null && ivaNumber !== null) {
+                    priceVat = formatLocalizedNumber(baseNumber + ivaNumber);
+                } else if (baseNumber !== null && rateNumber !== null) {
+                    priceVat = formatLocalizedNumber(baseNumber * (1 + rateNumber / 100));
+                }
+            }
+            row.dataset.price = price;
+            row.dataset.priceVat = priceVat;
+
             var linePayload = {
                 ERP: erp,
-                IVA_TAXA: iva,
+                IVA_TAXA: taxRate,
+                TAXA: taxRate,
+                BASE: base,
+                IVA: ivaAmount,
+                CONTA_IVA: ivaAccount,
+                CONTA_GERAL: generalAccount,
                 PRODUCT_CODE: productCode,
                 ITEM: item,
                 QUANTITY: quantity,
                 UNIT_PRICE: unitPrice,
                 PRICE: price,
-                PRICE_VAT: priceVat
+                PRICE_VAT: priceVat,
+                COST_CENTER: costCenter,
+                CENTRO_CUSTO: costCenter
             };
-            if (showLineCostCenter) {
-                linePayload.COST_CENTER = costCenter;
+            if (ivaAccount) {
+                linePayload.IVA_ACCOUNT = ivaAccount;
+            }
+            if (generalAccount) {
+                linePayload.GENERAL_ACCOUNT = generalAccount;
             }
             linesToSave.push(linePayload);
+
+            var rowComplete = erp !== '' || (
+                taxRate !== '' &&
+                base !== '' &&
+                ivaAmount !== '' &&
+                ivaAccount !== '' &&
+                generalAccount !== ''
+            );
+            if (!rowComplete) {
+                allLinesComplete = false;
+            }
         });
         var body = new URLSearchParams({
             action: 'save_lines',
@@ -629,7 +870,7 @@ window.addEventListener('load', function() {
                 var analyzeBtn = document.querySelector('.analyze-lines[data-id="' + currentLinesId + '"]');
                 if (analyzeBtn) {
                     analyzeBtn.classList.remove('btn-info', 'btn-success');
-                    analyzeBtn.classList.add(allErpFilled ? 'btn-success' : 'btn-info');
+                    analyzeBtn.classList.add(allLinesComplete ? 'btn-success' : 'btn-info');
                 }
             } else {
                 showError(res.error || 'Erro ao guardar linhas');

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -25,12 +25,101 @@ function prepareImportRow(array $row): array {
     if (is_array($lines) && count($lines) > 0) {
         $allFilled = true;
         foreach ($lines as $line) {
-            $erpValue = trim((string) ($line['ERP'] ?? ''));
-            if ($erpValue === '') {
+            if (!is_array($line)) {
+                $allFilled = false;
+                break;
+            }
+            $erpValue = isset($line['ERP']) && is_scalar($line['ERP']) ? trim((string) $line['ERP']) : '';
+            if ($erpValue !== '') {
+                continue;
+            }
+
+            $taxRate = '';
+            foreach (['TAXA', 'taxa', 'IVA_TAXA', 'iva_taxa', 'IVA', 'iva', 'TAX_RATE', 'tax_rate'] as $key) {
+                if (!array_key_exists($key, $line)) {
+                    continue;
+                }
+                $value = $line[$key];
+                if (!is_scalar($value)) {
+                    continue;
+                }
+                $stringValue = trim((string) $value);
+                if ($stringValue !== '') {
+                    $taxRate = $stringValue;
+                    break;
+                }
+            }
+
+            $baseValue = '';
+            foreach (['BASE', 'base', 'BASE_IMPONIVEL', 'base_imponivel', 'PRICE', 'price', 'PRECO', 'preco', 'VALOR', 'valor'] as $key) {
+                if (!array_key_exists($key, $line)) {
+                    continue;
+                }
+                $value = $line[$key];
+                if (!is_scalar($value)) {
+                    continue;
+                }
+                $stringValue = trim((string) $value);
+                if ($stringValue !== '') {
+                    $baseValue = $stringValue;
+                    break;
+                }
+            }
+
+            $ivaValue = '';
+            foreach (['IVA', 'iva', 'IVA_TOTAL', 'iva_total', 'IVA_VALOR', 'iva_valor', 'TAX_AMOUNT', 'tax_amount'] as $key) {
+                if (!array_key_exists($key, $line)) {
+                    continue;
+                }
+                $value = $line[$key];
+                if (!is_scalar($value)) {
+                    continue;
+                }
+                $stringValue = trim((string) $value);
+                if ($stringValue !== '') {
+                    $ivaValue = $stringValue;
+                    break;
+                }
+            }
+
+            $ivaAccountValue = '';
+            foreach (['CONTA_IVA', 'conta_iva', 'IVA_ACCOUNT', 'iva_account'] as $key) {
+                if (!array_key_exists($key, $line)) {
+                    continue;
+                }
+                $value = $line[$key];
+                if (!is_scalar($value)) {
+                    continue;
+                }
+                $stringValue = trim((string) $value);
+                if ($stringValue !== '') {
+                    $ivaAccountValue = $stringValue;
+                    break;
+                }
+            }
+
+            $generalAccountValue = '';
+            foreach (['CONTA_GERAL', 'conta_geral', 'GENERAL_ACCOUNT', 'general_account'] as $key) {
+                if (!array_key_exists($key, $line)) {
+                    continue;
+                }
+                $value = $line[$key];
+                if (!is_scalar($value)) {
+                    continue;
+                }
+                $stringValue = trim((string) $value);
+                if ($stringValue !== '') {
+                    $generalAccountValue = $stringValue;
+                    break;
+                }
+            }
+
+            if ($taxRate === '' || $baseValue === '' || $ivaValue === '' || $ivaAccountValue === '' || $generalAccountValue === '') {
                 $allFilled = false;
                 break;
             }
         }
+
         if ($allFilled) {
             $row['line_btn_class'] = 'btn-success';
         }


### PR DESCRIPTION
## Summary
- add client-side helpers to render editable invoice lines with add/remove controls and persist new rate/account fields alongside existing payload
- update line completion detection to treat rows with the new accounting fields as complete when saving

## Testing
- php -l contabilidade/classificacao-importacao.php

------
https://chatgpt.com/codex/tasks/task_e_68d271233dc08320b70b46fcbd25368d