### PR TITLE
Melhorar destaque do botão de adicionar linhas

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -5103,6 +5103,17 @@ ul.project_files li a i {
     margin: 0;
 }
 
+#linesModal #addLineBtn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+#linesModal #addLineBtn[disabled] {
+    opacity: 1;
+    cursor: not-allowed;
+}
+
 #linesContainer .price {
     font-size: inherit;
     font-weight: inherit;

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -421,13 +421,14 @@ require_once __DIR__ . '/../header.php';
                 <div class="d-flex flex-wrap gap-2 w-100 justify-content-between">
 
                     <?php if ($importType === 1): ?>
-
-                    <div>
-                        <button type="button" class="btn btn-outline-primary" id="addLineBtn">
-                            <i class="fa fa-plus me-1"></i>
-                            Adicionar linha
-                        </button>
-                    </div>
+                    <button
+                        type="button"
+                        class="btn btn-outline-primary d-inline-flex align-items-center gap-2"
+                        id="addLineBtn"
+                    >
+                        <i class="fa fa-plus"></i>
+                        <span>Adicionar linha</span>
+                    </button>
                     <?php endif; ?>
 
                     <div class="ms-auto">


### PR DESCRIPTION
## Summary
- ajustar o botão "Adicionar linha" na modal para usar layout flex e manter o texto visível
- adicionar estilos específicos para apresentar o botão com alinhamento adequado e sem perder opacidade quando desativado

## Testing
- php -l contabilidade/classificacao-importacao.php

------
https://chatgpt.com/codex/tasks/task_e_68d27d4dd3e48320a2289b0bcccc328d