### PR TITLE
Add dynamic VAT line support to classification modal

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -124,19 +124,202 @@ window.addEventListener('load', function() {
     var classifyModal = classifyModalEl ? new bootstrap.Modal(classifyModalEl) : null;
     var modalTitleEl = document.getElementById('classifyModalLabel');
     var form = document.getElementById('classify-form');
+    var addVatLineBtn = document.getElementById('addVatLineBtn');
+    var customRateRowTemplate = document.getElementById('customRateRowTemplate');
     var rateInputs = {};
-    var rateKeys = [];
     var currentRateData = {};
     var currentCostCenters = {};
+    var dynamicRateCounter = 0;
+    var defaultRates = ['0', '6', '13', '23'];
 
-    function forEachRate(callback) {
-        var keys = rateKeys.length ? rateKeys : Object.keys(rateInputs);
-        keys.forEach(callback);
+    function updateDynamicCounter(rate) {
+        var match = /^custom_(\d+)$/.exec(rate);
+        if (match) {
+            var num = parseInt(match[1], 10);
+            if (!isNaN(num) && num > dynamicRateCounter) {
+                dynamicRateCounter = num;
+            }
+        }
+    }
+
+    function generateCustomRateKey() {
+        dynamicRateCounter += 1;
+        return 'custom_' + dynamicRateCounter;
+    }
+
+    function getRateKeys() {
+        return Object.keys(rateInputs);
+    }
+
+    function getRateLabel(rate) {
+        var info = rateInputs[rate];
+        if (!info) {
+            return '';
+        }
+        if (info.labelInput) {
+            return info.labelInput.value.trim();
+        }
+        if (info.labelText) {
+            return info.labelText.textContent.trim();
+        }
+        if (currentRateData[rate] && typeof currentRateData[rate].label === 'string') {
+            return currentRateData[rate].label;
+        }
+        return '';
+    }
+
+    function registerRateRow(row, explicitRate) {
+        if (!row) {
+            return null;
+        }
+        var rate = explicitRate || row.getAttribute('data-rate') || '';
+        if (!rate) {
+            rate = generateCustomRateKey();
+            row.setAttribute('data-rate', rate);
+        }
+        if (rateInputs[rate]) {
+            return rateInputs[rate];
+        }
+        updateDynamicCounter(rate);
+        var info = {
+            row: row,
+            base: row.querySelector('.base-field'),
+            iva: row.querySelector('.iva-field'),
+            ivaAccount: row.querySelector('.iva-account-field'),
+            generalAccount: row.querySelector('.general-account-field'),
+            costCenter: row.querySelector('.cost-center-field') || null,
+            labelInput: row.querySelector('.rate-label-field') || null,
+            labelText: row.querySelector('.rate-label-static') || null,
+            removeBtn: row.querySelector('.remove-rate-row') || null,
+            custom: row.getAttribute('data-custom-rate') === '1'
+        };
+        rateInputs[rate] = info;
+        if (!Object.prototype.hasOwnProperty.call(currentCostCenters, rate)) {
+            currentCostCenters[rate] = '';
+        }
+        if (info.costCenter) {
+            info.costCenter.setAttribute('type', 'text');
+            info.costCenter.removeAttribute('readonly');
+            info.costCenter.removeAttribute('disabled');
+            info.costCenter.readOnly = false;
+            info.costCenter.disabled = false;
+            info.costCenter.addEventListener('input', function() {
+                currentCostCenters[rate] = info.costCenter.value;
+            });
+        }
+        if (info.labelInput) {
+            info.labelInput.addEventListener('input', function() {
+                if (!currentRateData[rate]) {
+                    currentRateData[rate] = {};
+                }
+                currentRateData[rate].label = info.labelInput.value;
+            });
+        }
+        if (info.removeBtn) {
+            info.removeBtn.addEventListener('click', function() {
+                removeRateRow(rate);
+            });
+        }
+        return info;
+    }
+
+    function removeRateRow(rate) {
+        if (defaultRates.indexOf(rate) !== -1) {
+            return;
+        }
+        var info = rateInputs[rate];
+        if (!info) {
+            return;
+        }
+        if (info.row && info.row.parentNode) {
+            info.row.parentNode.removeChild(info.row);
+        }
+        delete rateInputs[rate];
+        delete currentCostCenters[rate];
+        delete currentRateData[rate];
+    }
+
+    function createDynamicRateRow(rate, label) {
+        if (!customRateRowTemplate || !form) {
+            return null;
+        }
+        var fragment = customRateRowTemplate.content ? customRateRowTemplate.content.cloneNode(true) : null;
+        if (!fragment) {
+            return null;
+        }
+        var row = fragment.querySelector('tr');
+        var key = rate && !rateInputs[rate] ? rate : null;
+        if (!key) {
+            key = generateCustomRateKey();
+        }
+        row.setAttribute('data-rate', key);
+        row.setAttribute('data-custom-rate', '1');
+        var tbody = form.querySelector('tbody');
+        if (!tbody) {
+            return null;
+        }
+        tbody.appendChild(row);
+        var info = registerRateRow(row, key);
+        if (info && info.labelInput) {
+            info.labelInput.value = label || '';
+            info.labelInput.dispatchEvent(new Event('input'));
+            info.labelInput.focus();
+            info.labelInput.select();
+        }
+        if (!currentRateData[key]) {
+            currentRateData[key] = {};
+        }
+        return info;
+    }
+
+    function ensureRateRow(rate, data) {
+        if (!rate) {
+            return null;
+        }
+        var info = rateInputs[rate];
+        if (info) {
+            if (info.labelInput && data && typeof data.label === 'string') {
+                info.labelInput.value = data.label;
+            } else if (info.labelText && data && typeof data.label === 'string' && data.label !== '') {
+                info.labelText.textContent = data.label;
+            }
+            return info;
+        }
+        var label = data && typeof data.label === 'string' ? data.label : '';
+        return createDynamicRateRow(rate, label);
+    }
+
+    function ensureRowsForRates(value) {
+        if (!value) {
+            return;
+        }
+        if (Array.isArray(value)) {
+            value.forEach(function(entry) {
+                ensureRowsForRates(entry);
+            });
+            return;
+        }
+        if (typeof value !== 'object') {
+            return;
+        }
+        var source = value;
+        if (source && typeof source.rates === 'object') {
+            source = source.rates;
+        }
+        Object.keys(source).forEach(function(key) {
+            if (key === 'version') {
+                return;
+            }
+            var rate = String(key);
+            if (!rateInputs[rate]) {
+                ensureRateRow(rate, typeof source[key] === 'object' ? source[key] : null);
+            }
+        });
     }
 
     function createEmptyCostCenters() {
         var result = {};
-        forEachRate(function(rate) {
+        getRateKeys().forEach(function(rate) {
             result[rate] = '';
         });
         return result;
@@ -176,9 +359,9 @@ window.addEventListener('load', function() {
             if (source && typeof source.rates === 'object') {
                 source = source.rates;
             }
-            keys.forEach(function(rate) {
-                if (!Object.prototype.hasOwnProperty.call(source, rate)) {
-                    return;
+            Object.keys(source).forEach(function(rate) {
+                if (!Object.prototype.hasOwnProperty.call(normalized, rate)) {
+                    normalized[rate] = '';
                 }
                 var entry = source[rate];
                 if (entry !== null && typeof entry === 'object') {
@@ -200,8 +383,12 @@ window.addEventListener('load', function() {
     }
 
     function applyCostCenterValues(value) {
+        ensureRowsForRates(value);
         var normalized = normalizeCostCenterValues(value);
-        forEachRate(function(rate) {
+        getRateKeys().forEach(function(rate) {
+            if (!Object.prototype.hasOwnProperty.call(normalized, rate)) {
+                normalized[rate] = '';
+            }
             currentCostCenters[rate] = normalized[rate];
             var info = rateInputs[rate];
             if (info && info.costCenter && info.costCenter.value !== normalized[rate]) {
@@ -212,7 +399,7 @@ window.addEventListener('load', function() {
 
     function getCostCenterValues() {
         var values = createEmptyCostCenters();
-        forEachRate(function(rate) {
+        getRateKeys().forEach(function(rate) {
             var info = rateInputs[rate];
             if (info && info.costCenter) {
                 values[rate] = info.costCenter.value.trim();
@@ -233,37 +420,23 @@ window.addEventListener('load', function() {
     if (form) {
         var rateRows = Array.prototype.slice.call(form.querySelectorAll('tbody tr[data-rate]'));
         rateRows.forEach(function(row) {
-            var rate = row.getAttribute('data-rate');
-            rateInputs[rate] = {
-                base: row.querySelector('.base-field'),
-                iva: row.querySelector('.iva-field'),
-                ivaAccount: row.querySelector('.iva-account-field'),
-                generalAccount: row.querySelector('.general-account-field'),
-                costCenter: row.querySelector('.cost-center-field')
-            };
+            var rate = row.getAttribute('data-rate') || '';
+            registerRateRow(row, rate);
         });
-        rateKeys = Object.keys(rateInputs);
         currentCostCenters = createEmptyCostCenters();
-        rateKeys.forEach(function(rate) {
-            var info = rateInputs[rate];
-            if (!info || !info.costCenter) {
-                return;
-            }
-            var input = info.costCenter;
-            input.setAttribute('type', 'text');
-            input.removeAttribute('readonly');
-            input.removeAttribute('disabled');
-            input.readOnly = false;
-            input.disabled = false;
-            input.addEventListener('input', function() {
-                currentCostCenters[rate] = input.value;
-            });
+    }
+
+    if (addVatLineBtn) {
+        addVatLineBtn.addEventListener('click', function() {
+            createDynamicRateRow('', '');
         });
     }
+
     if (classifyModalEl) {
         classifyModalEl.addEventListener('shown.bs.modal', function() {
-            for (var i = 0; i < rateKeys.length; i += 1) {
-                var info = rateInputs[rateKeys[i]];
+            var keys = getRateKeys();
+            for (var i = 0; i < keys.length; i += 1) {
+                var info = rateInputs[keys[i]];
                 if (info && info.costCenter) {
                     info.costCenter.focus();
                     info.costCenter.select();
@@ -288,14 +461,24 @@ window.addEventListener('load', function() {
 
 
         currentRateData = parseJsonAttribute(btn, 'data-rates') || {};
+        ensureRowsForRates(currentRateData);
 
-        Object.keys(rateInputs).forEach(function(rate) {
+        getRateKeys().forEach(function(rate) {
             var info = rateInputs[rate];
+            if (!info) {
+                return;
+            }
             var data = currentRateData[rate] || {};
+            currentRateData[rate] = data;
             if (info.base) { info.base.value = data.base || ''; }
             if (info.iva) { info.iva.value = data.iva || ''; }
             if (info.ivaAccount) { info.ivaAccount.value = data.iva_account || ''; }
             if (info.generalAccount) { info.generalAccount.value = data.general_account || ''; }
+            if (info.labelInput) {
+                info.labelInput.value = typeof data.label === 'string' ? data.label : '';
+            } else if (info.labelText && data.label) {
+                info.labelText.textContent = data.label;
+            }
         });
 
         var btnCostCenters = parseJsonAttribute(btn, 'data-cost-centers');
@@ -319,8 +502,12 @@ window.addEventListener('load', function() {
                 }
 
                 var rowRates = res.row_rates || {};
-                Object.keys(rateInputs).forEach(function(rate) {
+                ensureRowsForRates(rowRates);
+                getRateKeys().forEach(function(rate) {
                     var info = rateInputs[rate];
+                    if (!info) {
+                        return;
+                    }
                     var rowData = rowRates[rate] || {};
                     if (info.ivaAccount && Object.prototype.hasOwnProperty.call(rowData, 'iva_account')) {
                         info.ivaAccount.value = rowData.iva_account || '';
@@ -328,17 +515,33 @@ window.addEventListener('load', function() {
                     if (info.generalAccount && Object.prototype.hasOwnProperty.call(rowData, 'general_account')) {
                         info.generalAccount.value = rowData.general_account || '';
                     }
+                    if (info.labelInput && Object.prototype.hasOwnProperty.call(rowData, 'label')) {
+                        info.labelInput.value = rowData.label || '';
+                    } else if (info.labelText && rowData.label) {
+                        info.labelText.textContent = rowData.label;
+                    }
                 });
 
                 var defaults = res.rates || {};
-                Object.keys(rateInputs).forEach(function(rate) {
+                ensureRowsForRates(defaults);
+                getRateKeys().forEach(function(rate) {
                     var info = rateInputs[rate];
+                    if (!info) {
+                        return;
+                    }
                     var defaultData = defaults[rate] || {};
                     if (info.ivaAccount && !info.ivaAccount.value) {
                         info.ivaAccount.value = defaultData.iva_account || '';
                     }
                     if (info.generalAccount && !info.generalAccount.value) {
                         info.generalAccount.value = defaultData.general_account || '';
+                    }
+                    if (info.labelInput && !info.labelInput.value && Object.prototype.hasOwnProperty.call(defaults, rate)) {
+                        if (Object.prototype.hasOwnProperty.call(defaultData, 'label')) {
+                            info.labelInput.value = defaultData.label || '';
+                        }
+                    } else if (info.labelText && defaultData.label) {
+                        info.labelText.textContent = defaultData.label;
                     }
                 });
 
@@ -353,7 +556,7 @@ window.addEventListener('load', function() {
                 }
 
                 currentCostCenters = getCostCenterValues();
-                Object.keys(rateInputs).forEach(function(rate) {
+                getRateKeys().forEach(function(rate) {
                     var info = rateInputs[rate];
                     if (!currentRateData[rate]) {
                         currentRateData[rate] = {};
@@ -362,6 +565,13 @@ window.addEventListener('load', function() {
                     currentRateData[rate].iva = info.iva ? info.iva.value : '';
                     currentRateData[rate].iva_account = info.ivaAccount ? info.ivaAccount.value : '';
                     currentRateData[rate].general_account = info.generalAccount ? info.generalAccount.value : '';
+                    currentRateData[rate].label = getRateLabel(rate);
+                });
+
+                Object.keys(currentRateData).forEach(function(rate) {
+                    if (!rateInputs[rate]) {
+                        delete currentRateData[rate];
+                    }
                 });
 
 
@@ -373,37 +583,39 @@ window.addEventListener('load', function() {
             });
     });
 
-    form.addEventListener('submit', function(e) {
-        e.preventDefault();
-        if (!currentBtn) {
-            return;
-        }
+    if (form) {
+        form.addEventListener('submit', function(e) {
+            e.preventDefault();
+            if (!currentBtn) {
+                return;
+            }
 
-        var ratesPayload = {};
-        Object.keys(rateInputs).forEach(function(rate) {
-            var info = rateInputs[rate];
-            ratesPayload[rate] = {
-                iva_account: info.ivaAccount ? info.ivaAccount.value.trim() : '',
-                general_account: info.generalAccount ? info.generalAccount.value.trim() : ''
-            };
-        });
+            var ratesPayload = {};
+            getRateKeys().forEach(function(rate) {
+                var info = rateInputs[rate];
+                ratesPayload[rate] = {
+                    iva_account: info.ivaAccount ? info.ivaAccount.value.trim() : '',
+                    general_account: info.generalAccount ? info.generalAccount.value.trim() : '',
+                    label: getRateLabel(rate)
+                };
+            });
 
-        var costCentersPayload = getCostCenterValues();
-        var body = new URLSearchParams({
-            id: currentBtn.getAttribute('data-id') || '',
-            A: currentBtn.getAttribute('data-emitter') || '',
-            B: currentBtn.getAttribute('data-acquirer') || '',
-            D: currentBtn.getAttribute('data-doctype') || '',
-            rates: JSON.stringify(ratesPayload),
-            cost_centers: JSON.stringify(costCentersPayload),
-            csrf_token: csrfInput.value
-        });
-        fetchJson('contabilidade/save-analysis.php?action=save', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: body.toString()
-        })
-        .then(function(res) {
+            var costCentersPayload = getCostCenterValues();
+            var body = new URLSearchParams({
+                id: currentBtn.getAttribute('data-id') || '',
+                A: currentBtn.getAttribute('data-emitter') || '',
+                B: currentBtn.getAttribute('data-acquirer') || '',
+                D: currentBtn.getAttribute('data-doctype') || '',
+                rates: JSON.stringify(ratesPayload),
+                cost_centers: JSON.stringify(costCentersPayload),
+                csrf_token: csrfInput.value
+            });
+            fetchJson('contabilidade/save-analysis.php?action=save', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body.toString()
+            })
+            .then(function(res) {
             if (res.csrf_token) {
                 csrfInput.value = res.csrf_token;
             }
@@ -420,34 +632,54 @@ window.addEventListener('load', function() {
                 currentCostCenters = getCostCenterValues();
 
                 if (res.row_rates && typeof res.row_rates === 'object') {
+                    ensureRowsForRates(res.row_rates);
                     Object.keys(res.row_rates).forEach(function(rate) {
                         var info = rateInputs[rate];
-                        if (!currentRateData[rate]) {
-                            currentRateData[rate] = {};
+                        if (!info) {
+                            return;
                         }
-                        currentRateData[rate].base = info && info.base ? info.base.value : '';
-                        currentRateData[rate].iva = info && info.iva ? info.iva.value : '';
-                        currentRateData[rate].iva_account = (res.row_rates[rate] && res.row_rates[rate].iva_account) || '';
-                        currentRateData[rate].general_account = (res.row_rates[rate] && res.row_rates[rate].general_account) || '';
-                        if (info && info.ivaAccount) {
-                            info.ivaAccount.value = currentRateData[rate].iva_account;
-                        }
-                        if (info && info.generalAccount) {
-                            info.generalAccount.value = currentRateData[rate].general_account;
-                        }
-                    });
-                } else {
-                    Object.keys(rateInputs).forEach(function(rate) {
-                        var info = rateInputs[rate];
                         if (!currentRateData[rate]) {
                             currentRateData[rate] = {};
                         }
                         currentRateData[rate].base = info.base ? info.base.value : '';
                         currentRateData[rate].iva = info.iva ? info.iva.value : '';
-                        currentRateData[rate].iva_account = ratesPayload[rate].iva_account;
-                        currentRateData[rate].general_account = ratesPayload[rate].general_account;
+                        currentRateData[rate].iva_account = (res.row_rates[rate] && res.row_rates[rate].iva_account) || '';
+                        currentRateData[rate].general_account = (res.row_rates[rate] && res.row_rates[rate].general_account) || '';
+                        if (info.ivaAccount) {
+                            info.ivaAccount.value = currentRateData[rate].iva_account;
+                        }
+                        if (info.generalAccount) {
+                            info.generalAccount.value = currentRateData[rate].general_account;
+                        }
+                        if (info.labelInput && Object.prototype.hasOwnProperty.call(res.row_rates[rate], 'label')) {
+                            info.labelInput.value = res.row_rates[rate].label || '';
+                        } else if (info.labelText && res.row_rates[rate] && res.row_rates[rate].label) {
+                            info.labelText.textContent = res.row_rates[rate].label;
+                        }
+                        currentRateData[rate].label = getRateLabel(rate);
+                    });
+                } else {
+                    getRateKeys().forEach(function(rate) {
+                        var info = rateInputs[rate];
+                        if (!info) {
+                            return;
+                        }
+                        if (!currentRateData[rate]) {
+                            currentRateData[rate] = {};
+                        }
+                        currentRateData[rate].base = info.base ? info.base.value : '';
+                        currentRateData[rate].iva = info.iva ? info.iva.value : '';
+                        currentRateData[rate].iva_account = ratesPayload[rate] ? ratesPayload[rate].iva_account : '';
+                        currentRateData[rate].general_account = ratesPayload[rate] ? ratesPayload[rate].general_account : '';
+                        currentRateData[rate].label = getRateLabel(rate);
                     });
                 }
+
+                Object.keys(currentRateData).forEach(function(rate) {
+                    if (!rateInputs[rate]) {
+                        delete currentRateData[rate];
+                    }
+                });
 
                 currentBtn.setAttribute('data-rates', JSON.stringify(currentRateData));
                 currentBtn.setAttribute('data-cost-centers', JSON.stringify(currentCostCenters));
@@ -458,11 +690,12 @@ window.addEventListener('load', function() {
             } else {
                 showError(res.error || 'Erro ao guardar');
             }
-        })
-        .catch(function(err) {
-            showError(err.message || 'Erro ao guardar');
+            })
+            .catch(function(err) {
+                showError(err.message || 'Erro ao guardar');
+            });
         });
-    });
+    }
 
     $('#classify-table').on('click', '.remove-row', function() {
         var btn = this;

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -264,6 +264,11 @@ require_once __DIR__ . '/../header.php';
             </div>
             <form id="classify-form">
                 <div class="modal-body">
+                    <div class="d-flex justify-content-end align-items-center mb-2">
+                        <button type="button" class="btn btn-sm btn-outline-primary" id="addVatLineBtn">
+                            <i class="fa fa-plus"></i> Adicionar linha de IVA
+                        </button>
+                    </div>
                     <div class="table-responsive">
                         <table class="table table-sm align-middle mb-0">
                             <thead>
@@ -276,6 +281,7 @@ require_once __DIR__ . '/../header.php';
                                     <?php if ($importType === 1): ?>
                                     <th>Centro de Custo</th>
                                     <?php endif; ?>
+                                    <th class="text-center" width="1%">Ações</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -288,8 +294,8 @@ require_once __DIR__ . '/../header.php';
                                 ];
                                 foreach ($modalRates as $rate => $label):
                                 ?>
-                                <tr data-rate="<?= $rate; ?>">
-                                    <td class="align-middle"><?= $label; ?></td>
+                                <tr data-rate="<?= $rate; ?>" data-custom-rate="0">
+                                    <td class="align-middle"><span class="rate-label-static"><?= $label; ?></span></td>
                                     <td><input type="text" class="form-control form-control-sm base-field" readonly></td>
                                     <td><input type="text" class="form-control form-control-sm iva-field" readonly></td>
                                     <td><input type="text" class="form-control form-control-sm iva-account-field" name="rates[<?= $rate; ?>][iva_account]"></td>
@@ -304,6 +310,7 @@ require_once __DIR__ . '/../header.php';
                                         >
                                     </td>
                                     <?php endif; ?>
+                                    <td class="text-center align-middle actions-cell"></td>
                                 </tr>
                                 <?php endforeach; ?>
                             </tbody>
@@ -315,9 +322,34 @@ require_once __DIR__ . '/../header.php';
                     <button type="submit" class="btn btn-primary">Guardar</button>
                 </div>
             </form>
+        </div>
+    </div>
 </div>
-</div>
-</div>
+<template id="customRateRowTemplate">
+    <tr data-custom-rate="1">
+        <td>
+            <input type="text" class="form-control form-control-sm rate-label-field" placeholder="Identificador da taxa">
+        </td>
+        <td><input type="text" class="form-control form-control-sm base-field" readonly></td>
+        <td><input type="text" class="form-control form-control-sm iva-field" readonly></td>
+        <td><input type="text" class="form-control form-control-sm iva-account-field"></td>
+        <td><input type="text" class="form-control form-control-sm general-account-field"></td>
+        <?php if ($importType === 1): ?>
+        <td>
+            <input
+                type="text"
+                class="form-control form-control-sm cost-center-field"
+                placeholder="Introduza o centro de custo"
+            >
+        </td>
+        <?php endif; ?>
+        <td class="text-center align-middle">
+            <button type="button" class="btn btn-sm btn-outline-danger remove-rate-row" title="Remover linha">
+                <i class="fa fa-trash"></i>
+            </button>
+        </td>
+    </tr>
+</template>
 <div class="modal fade" id="linesModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-xl">
         <div class="modal-content">

--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -730,18 +730,59 @@ function parseInvoiceLineTextract(string $filePath): array {
 }
 
 /**
+ * Retrieve the default VAT rates and their display labels.
+ *
+ * @return array<string,string>
+ */
+function getDefaultVatRates(): array {
+    return [
+        '0' => '0%',
+        '6' => '6%',
+        '13' => '13%',
+        '23' => '23%',
+    ];
+}
+
+/**
+ * Build a fallback label for a VAT rate when none is explicitly provided.
+ */
+function buildVatRateLabel(string $rate): string {
+    $defaults = getDefaultVatRates();
+    if (array_key_exists($rate, $defaults)) {
+        return $defaults[$rate];
+    }
+
+    $trimmed = trim($rate);
+    if ($trimmed === '') {
+        return '';
+    }
+
+    $normalized = str_replace(',', '.', $trimmed);
+    if (is_numeric($normalized)) {
+        $formatted = rtrim(rtrim($normalized, '0'), '.');
+        if ($formatted === '') {
+            $formatted = '0';
+        }
+        return $formatted . '%';
+    }
+
+    return $trimmed;
+}
+
+/**
  * Normalize stored account information into a structure keyed by VAT rate.
  *
  * @param string|null $json JSON-encoded account data.
  * @return array<string,array<string,string>>
  */
 function normalizeAccountingAccounts(?string $json): array {
-    $rates = ['0', '6', '13', '23'];
+    $defaults = getDefaultVatRates();
     $result = [];
-    foreach ($rates as $rate) {
+    foreach ($defaults as $rate => $label) {
         $result[$rate] = [
             'iva_account' => '',
             'general_account' => '',
+            'label' => $label,
         ];
     }
 
@@ -757,45 +798,71 @@ function normalizeAccountingAccounts(?string $json): array {
     $sources = [];
     if (isset($data['rates']) && is_array($data['rates'])) {
         $sources[] = $data['rates'];
-    } else {
-        $sources[] = $data;
     }
+    $sources[] = $data;
 
     foreach ($sources as $source) {
+        if (!is_array($source)) {
+            continue;
+        }
         foreach ($source as $key => $value) {
             $keyString = (string) $key;
-            if (in_array($keyString, $rates, true)) {
-                if (is_array($value)) {
-                    if (array_key_exists('iva_account', $value)) {
-                        $result[$keyString]['iva_account'] = (string) $value['iva_account'];
-                    } elseif (array_key_exists('iva', $value)) {
-                        $result[$keyString]['iva_account'] = (string) $value['iva'];
-                    }
-                    if (array_key_exists('general_account', $value)) {
-                        $result[$keyString]['general_account'] = (string) $value['general_account'];
-                    } elseif (array_key_exists('general', $value)) {
-                        $result[$keyString]['general_account'] = (string) $value['general'];
-                    }
-                } elseif (is_string($value) || is_numeric($value)) {
-                    $result[$keyString]['general_account'] = (string) $value;
-                }
+            if ($keyString === 'version') {
                 continue;
             }
-
-            switch ($keyString) {
-                case 'iva6':
-                    $result['6']['iva_account'] = (string) $value;
-                    break;
-                case 'iva13':
-                    $result['13']['iva_account'] = (string) $value;
-                    break;
-                case 'iva23':
-                    $result['23']['iva_account'] = (string) $value;
-                    break;
-                case 'novat':
-                    $result['0']['general_account'] = (string) $value;
-                    break;
+            if (!array_key_exists($keyString, $result)) {
+                $result[$keyString] = [
+                    'iva_account' => '',
+                    'general_account' => '',
+                    'label' => buildVatRateLabel($keyString),
+                ];
             }
+            if (is_array($value)) {
+                if (array_key_exists('iva_account', $value)) {
+                    $result[$keyString]['iva_account'] = (string) $value['iva_account'];
+                } elseif (array_key_exists('iva', $value)) {
+                    $result[$keyString]['iva_account'] = (string) $value['iva'];
+                }
+                if (array_key_exists('general_account', $value)) {
+                    $result[$keyString]['general_account'] = (string) $value['general_account'];
+                } elseif (array_key_exists('general', $value)) {
+                    $result[$keyString]['general_account'] = (string) $value['general'];
+                }
+                if (array_key_exists('label', $value)) {
+                    $labelValue = trim((string) $value['label']);
+                    if ($labelValue !== '') {
+                        $result[$keyString]['label'] = $labelValue;
+                    }
+                }
+            } elseif (is_string($value) || is_numeric($value)) {
+                $result[$keyString]['general_account'] = (string) $value;
+            }
+        }
+    }
+
+    $legacyMap = [
+        'iva6' => ['rate' => '6', 'field' => 'iva_account'],
+        'iva13' => ['rate' => '13', 'field' => 'iva_account'],
+        'iva23' => ['rate' => '23', 'field' => 'iva_account'],
+        'novat' => ['rate' => '0', 'field' => 'general_account'],
+    ];
+    foreach ($sources as $source) {
+        if (!is_array($source)) {
+            continue;
+        }
+        foreach ($legacyMap as $legacyKey => $info) {
+            if (!array_key_exists($legacyKey, $source)) {
+                continue;
+            }
+            $rate = $info['rate'];
+            if (!array_key_exists($rate, $result)) {
+                $result[$rate] = [
+                    'iva_account' => '',
+                    'general_account' => '',
+                    'label' => buildVatRateLabel($rate),
+                ];
+            }
+            $result[$rate][$info['field']] = (string) $source[$legacyKey];
         }
     }
 
@@ -809,17 +876,62 @@ function normalizeAccountingAccounts(?string $json): array {
  * @return array<string,array<string,string>>
  */
 function sanitizeAccountInput(array $input): array {
-    $rates = ['0', '6', '13', '23'];
+    if (isset($input['rates']) && is_array($input['rates'])) {
+        $input = $input['rates'];
+    }
+
+    $defaults = getDefaultVatRates();
+    $detectedRates = array_keys($defaults);
+    foreach ($input as $key => $_) {
+        $detectedRates[] = (string) $key;
+    }
+    $detectedRates = array_values(array_unique(array_map('strval', $detectedRates)));
+
     $result = [];
-    foreach ($rates as $rate) {
-        $rateInput = $input[$rate] ?? [];
-        if (!is_array($rateInput)) {
-            $rateInput = [];
+    foreach ($detectedRates as $rate) {
+        $rateInput = $input[$rate] ?? null;
+        $ivaAccount = '';
+        $generalAccount = '';
+        $label = '';
+
+        if (is_array($rateInput)) {
+            if (array_key_exists('iva_account', $rateInput)) {
+                $ivaAccount = trim((string) $rateInput['iva_account']);
+            } elseif (array_key_exists('iva', $rateInput)) {
+                $ivaAccount = trim((string) $rateInput['iva']);
+            }
+            if (array_key_exists('general_account', $rateInput)) {
+                $generalAccount = trim((string) $rateInput['general_account']);
+            } elseif (array_key_exists('general', $rateInput)) {
+                $generalAccount = trim((string) $rateInput['general']);
+            }
+            if (array_key_exists('label', $rateInput)) {
+                $label = trim((string) $rateInput['label']);
+            }
+        } elseif ($rateInput !== null) {
+            $generalAccount = trim((string) $rateInput);
         }
+
+        if ($rate === '6' && isset($input['iva6']) && $ivaAccount === '') {
+            $ivaAccount = trim((string) $input['iva6']);
+        } elseif ($rate === '13' && isset($input['iva13']) && $ivaAccount === '') {
+            $ivaAccount = trim((string) $input['iva13']);
+        } elseif ($rate === '23' && isset($input['iva23']) && $ivaAccount === '') {
+            $ivaAccount = trim((string) $input['iva23']);
+        }
+        if ($rate === '0' && isset($input['novat']) && $generalAccount === '') {
+            $generalAccount = trim((string) $input['novat']);
+        }
+
+        $effectiveLabel = $label !== '' ? $label : buildVatRateLabel($rate);
+
         $result[$rate] = [
-            'iva_account' => isset($rateInput['iva_account']) ? trim((string) $rateInput['iva_account']) : '',
-            'general_account' => isset($rateInput['general_account']) ? trim((string) $rateInput['general_account']) : '',
+            'iva_account' => $ivaAccount,
+            'general_account' => $generalAccount,
         ];
+        if ($effectiveLabel !== '') {
+            $result[$rate]['label'] = $effectiveLabel;
+        }
     }
 
     return $result;
@@ -836,15 +948,35 @@ function mergeAccountingAccounts(array $base, array $override): array {
     $baseSanitized = sanitizeAccountInput($base);
     $overrideSanitized = sanitizeAccountInput($override);
 
-    foreach (['0', '6', '13', '23'] as $rate) {
-        foreach (['iva_account', 'general_account'] as $field) {
-            if (array_key_exists($field, $overrideSanitized[$rate])) {
-                $baseSanitized[$rate][$field] = $overrideSanitized[$rate][$field];
+    $allRates = array_unique(array_merge(array_keys($baseSanitized), array_keys($overrideSanitized)));
+    $result = [];
+
+    foreach ($allRates as $rate) {
+        $result[$rate] = [
+            'iva_account' => $baseSanitized[$rate]['iva_account'] ?? '',
+            'general_account' => $baseSanitized[$rate]['general_account'] ?? '',
+        ];
+        if (isset($baseSanitized[$rate]['label'])) {
+            $result[$rate]['label'] = $baseSanitized[$rate]['label'];
+        }
+
+        if (array_key_exists($rate, $overrideSanitized)) {
+            foreach (['iva_account', 'general_account'] as $field) {
+                if (array_key_exists($field, $overrideSanitized[$rate])) {
+                    $result[$rate][$field] = $overrideSanitized[$rate][$field];
+                }
             }
+            if (array_key_exists('label', $overrideSanitized[$rate]) && $overrideSanitized[$rate]['label'] !== '') {
+                $result[$rate]['label'] = $overrideSanitized[$rate]['label'];
+            }
+        }
+
+        if (!array_key_exists('label', $result[$rate]) || $result[$rate]['label'] === '') {
+            $result[$rate]['label'] = buildVatRateLabel($rate);
         }
     }
 
-    return $baseSanitized;
+    return $result;
 }
 
 /**
@@ -866,9 +998,16 @@ function serializeAccountingAccounts(array $rates): string {
  *
  * @return array<string,string>
  */
-function buildEmptyCostCenterMap(): array {
+function buildEmptyCostCenterMap(array $additionalRates = []): array {
+    $baseRates = array_keys(getDefaultVatRates());
+    $allRates = [];
+    foreach (array_merge($baseRates, $additionalRates) as $rate) {
+        $allRates[] = (string) $rate;
+    }
+    $allRates = array_values(array_unique($allRates));
+
     $result = [];
-    foreach (['0', '6', '13', '23'] as $rate) {
+    foreach ($allRates as $rate) {
         $result[$rate] = '';
     }
 
@@ -886,7 +1025,19 @@ function buildEmptyCostCenterMap(): array {
  * @return array<string,string>
  */
 function sanitizeCostCenterValues($input): array {
-    $result = buildEmptyCostCenterMap();
+    $detectedRates = array_keys(getDefaultVatRates());
+
+    if (is_array($input)) {
+        $source = $input;
+        if (isset($input['rates']) && is_array($input['rates'])) {
+            $source = $input['rates'];
+        }
+        foreach ($source as $key => $_) {
+            $detectedRates[] = (string) $key;
+        }
+    }
+
+    $result = buildEmptyCostCenterMap($detectedRates);
 
     if (is_string($input) || is_numeric($input)) {
         $value = trim((string) $input);
@@ -909,12 +1060,12 @@ function sanitizeCostCenterValues($input): array {
         $input = $input['rates'];
     }
 
-    foreach ($result as $rate => $_) {
-        if (!array_key_exists($rate, $input)) {
-            continue;
+    foreach ($input as $rate => $value) {
+        $rateKey = (string) $rate;
+        if (!array_key_exists($rateKey, $result)) {
+            $result[$rateKey] = '';
         }
 
-        $value = $input[$rate];
         if (is_array($value)) {
             if (array_key_exists('cost_center', $value)) {
                 $value = $value['cost_center'];
@@ -924,9 +1075,9 @@ function sanitizeCostCenterValues($input): array {
         }
 
         if ($value === null) {
-            $result[$rate] = '';
+            $result[$rateKey] = '';
         } else {
-            $result[$rate] = trim((string) $value);
+            $result[$rateKey] = trim((string) $value);
         }
     }
 
@@ -1076,12 +1227,24 @@ function buildRatePayload(array $summaries, array $accounts): array {
     $payload = [];
     $requirements = [];
 
-    foreach ($summaries as $rate => $info) {
+    $allRates = array_unique(array_merge(array_keys($summaries), array_keys($accounts)));
+    foreach ($allRates as $rate) {
+        $info = $summaries[$rate] ?? [];
+        $accountInfo = $accounts[$rate] ?? [];
+        $label = '';
+        if (is_array($accountInfo) && array_key_exists('label', $accountInfo)) {
+            $label = trim((string) $accountInfo['label']);
+        }
+        if ($label === '') {
+            $label = buildVatRateLabel((string) $rate);
+        }
+
         $payload[$rate] = [
+            'label' => $label,
             'base' => $info['base_display'] ?? '',
             'iva' => $info['iva_display'] ?? '',
-            'iva_account' => $accounts[$rate]['iva_account'] ?? '',
-            'general_account' => $accounts[$rate]['general_account'] ?? '',
+            'iva_account' => $accountInfo['iva_account'] ?? '',
+            'general_account' => $accountInfo['general_account'] ?? '',
         ];
         $requirements[$rate] = [
             'general' => !empty($info['require_general']),


### PR DESCRIPTION
## Summary
- add an "Adicionar linha de IVA" control and reusable template to the Classificar modal so users can insert or remove custom VAT rows
- refactor the classification front-end logic to manage dynamic VAT rows, including labels and cost centre propagation when loading or saving classifications
- update backend helpers to preserve dynamic VAT rate metadata when normalising accounts, merging overrides and serialising cost centres

## Testing
- php -l contabilidade/functions.php
- php -l contabilidade/classificacao-importacao.php

------
https://chatgpt.com/codex/tasks/task_e_68d2b068d00c8320a9f69b8320bb461b