### PR TITLE
Mostrar taxas de IVA padrão ao abrir classificação

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -731,6 +731,16 @@ window.addEventListener('load', function() {
             }
         });
 
+        defaultRates.forEach(function(rate) {
+            if (!rateInputs[rate]) {
+                addVatRowForRate(rate);
+            }
+        });
+        ensureRowsForRates(currentRateData, { allowCreate: true });
+        getRateKeys().forEach(function(rate) {
+            populateRateRow(rate);
+        });
+
         var btnCostCenters = parseJsonAttribute(btn, 'data-cost-centers');
         if (!btnCostCenters && btn.hasAttribute('data-cost-center')) {
             btnCostCenters = btn.getAttribute('data-cost-center') || '';


### PR DESCRIPTION
## Summary
- pre-create the standard VAT rate rows when opening the classification modal
- populate those rows with the document values before any manual addition is required

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d2b936db108320b2b44a08ac37c3d6