### PR TITLE
Handle array field values when saving content

### DIFF
--- a/content.php
+++ b/content.php
@@ -549,9 +549,16 @@ if ($action === 'add') {
             if (empty($error)) {
                 $contentId = createContent($typeId, currentUser()['id'], $title, $body);
                 foreach ($scalarValues as $fieldId => $value) {
-                    if ($value !== null) {
-                        saveCustomValue($contentId, $fieldId, $value);
+                    if ($value === null) {
+                        continue;
                     }
+                    if (is_array($value)) {
+                        foreach ($value as $val) {
+                            saveCustomValue($contentId, $fieldId, (string)$val);
+                        }
+                        continue;
+                    }
+                    saveCustomValue($contentId, $fieldId, (string)$value);
                 }
                 foreach ($multiValues as $fieldId => $values) {
                     foreach ($values as $val) {
@@ -846,9 +853,16 @@ if ($action === 'edit') {
                 updateContent($contentId, $title, $body);
                 deleteCustomValuesForContent($contentId);
                 foreach ($scalarValues as $fieldId => $value) {
-                    if ($value !== null) {
-                        saveCustomValue($contentId, $fieldId, $value);
+                    if ($value === null) {
+                        continue;
                     }
+                    if (is_array($value)) {
+                        foreach ($value as $val) {
+                            saveCustomValue($contentId, $fieldId, (string)$val);
+                        }
+                        continue;
+                    }
+                    saveCustomValue($contentId, $fieldId, (string)$value);
                 }
                 foreach ($multiValues as $fieldId => $values) {
                     foreach ($values as $val) {


### PR DESCRIPTION
## Summary
- guard against `null` and array values when persisting scalar custom fields so only strings reach the database
- fan out array submissions into individual records to avoid PHP array-to-string conversion warnings

## Testing
- php -l content.php

------
https://chatgpt.com/codex/tasks/task_e_68d2bb2ea22c8320ae952fa0bf691aed