### PR TITLE
Handle array inputs when saving custom values

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1300,13 +1300,37 @@ function createContent(int $content_type_id, int $user_id, string $title, ?strin
  *
  * @param int $content_id
  * @param int $field_id
- * @param string $value
+ * @param string|array|null $value
  * @return void
  */
-function saveCustomValue(int $content_id, int $field_id, string $value): void {
+function saveCustomValue(int $content_id, int $field_id, $value): void {
+    $values = [];
+    $collect = function ($item) use (&$collect, &$values): void {
+        if ($item === null) {
+            return;
+        }
+        if (is_array($item)) {
+            foreach ($item as $subItem) {
+                $collect($subItem);
+            }
+            return;
+        }
+        if (is_scalar($item) || (is_object($item) && method_exists($item, '__toString'))) {
+            $values[] = (string)$item;
+        }
+    };
+
+    $collect($value);
+
+    if (empty($values)) {
+        return;
+    }
+
     $pdo = getPDO();
     $stmt = $pdo->prepare('INSERT INTO custom_values (content_id, field_id, value) VALUES (?, ?, ?)');
-    $stmt->execute([$content_id, $field_id, $value]);
+    foreach ($values as $scalarValue) {
+        $stmt->execute([$content_id, $field_id, $scalarValue]);
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- revert the prior adjustments in `content.php` so scalar and multi-value field handling returns to its original logic
- update `functions.php::saveCustomValue` to flatten array inputs, skip nulls, and insert each scalar value individually to prevent array-to-string conversion warnings

## Testing
- php -l content.php
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_68d2bb2ea22c8320ae952fa0bf691aed