### PR TITLE
Refresh datatable after closing modals

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -750,13 +750,23 @@ window.addEventListener('load', function() {
                 focusRateInput(rateInputs[keys[0]]);
             }
         });
+        classifyModalEl.addEventListener('hidden.bs.modal', function() {
+            table.ajax.reload(null, false);
+        });
     }
 
     var currentBtn = null;
-    var linesModal = new bootstrap.Modal(document.getElementById('linesModal'));
+    var linesModalEl = document.getElementById('linesModal');
+    var linesModal = linesModalEl ? new bootstrap.Modal(linesModalEl) : null;
     var linesContainer = document.getElementById('linesContainer');
     var confirmLinesBtn = document.getElementById('confirmLinesBtn');
     var currentLinesId = null;
+
+    if (linesModalEl) {
+        linesModalEl.addEventListener('hidden.bs.modal', function() {
+            table.ajax.reload(null, false);
+        });
+    }
 
     $('#classify-table').on('click', '.classify-row', function() {
         var btn = this;


### PR DESCRIPTION
## Summary
- reload the classification DataTable whenever the classification modal closes
- ensure the lines modal instance is created safely before using it and trigger a reload when it closes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2c9c9c69c8320bb37b2ba1eb9e273