### PR TITLE
Fix label extraction when saving VAT rate rows

### DIFF
--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -887,7 +887,7 @@ function normalizeAccountingAccounts(?string $json): array {
                 }
 
                 if (array_key_exists('label', $value)) {
-                    $labelValue = extractStringValue($value['label'], ['label', 'text']);
+                    $labelValue = extractStringValue($value['label'], ['value', 'label', 'text']);
                     if ($labelValue !== null && $labelValue !== '') {
                         $result[$keyString]['label'] = $labelValue;
                     }
@@ -980,7 +980,7 @@ function sanitizeAccountInput(array $input): array {
             }
 
             if (array_key_exists('label', $rateInput)) {
-                $labelCandidate = extractStringValue($rateInput['label'], ['label', 'text']);
+                $labelCandidate = extractStringValue($rateInput['label'], ['value', 'label', 'text']);
                 if ($labelCandidate !== null) {
                     $label = $labelCandidate;
                 }


### PR DESCRIPTION
## Summary
- ensure normalizeAccountingAccounts prefers value entries when extracting stored rate labels
- prioritize value keys when sanitizing submitted VAT rate data so human labels persist instead of the literal string "label"

## Testing
- php -l contabilidade/functions.php

------
https://chatgpt.com/codex/tasks/task_e_68d2caf7665083208ebacaf2a70acc22