### PR TITLE
fix: ignore classification metadata keys

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -421,8 +421,16 @@ window.addEventListener('load', function() {
         if (source && typeof source.rates === 'object') {
             source = source.rates;
         }
+        var metadataKeys = {
+            version: true,
+            rates: true,
+            label: true,
+            labels: true,
+            title: true
+        };
         Object.keys(source).forEach(function(key) {
-            if (key === 'version' || key === 'rates') {
+            var normalizedKey = String(key).toLowerCase();
+            if (Object.prototype.hasOwnProperty.call(metadataKeys, normalizedKey)) {
                 return;
             }
             var rate = String(key);

--- a/contabilidade/functions.php
+++ b/contabilidade/functions.php
@@ -849,13 +849,15 @@ function normalizeAccountingAccounts(?string $json): array {
     }
     $sources[] = $data;
 
+    $metadataKeys = ['version', 'rates', 'label', 'labels', 'title'];
+
     foreach ($sources as $source) {
         if (!is_array($source)) {
             continue;
         }
         foreach ($source as $key => $value) {
             $keyString = (string) $key;
-            if ($keyString === 'version') {
+            if (in_array(strtolower($keyString), $metadataKeys, true)) {
                 continue;
             }
             if (!array_key_exists($keyString, $result)) {
@@ -951,9 +953,15 @@ function sanitizeAccountInput(array $input): array {
     }
     $detectedRates = array_values(array_unique(array_map('strval', $detectedRates)));
 
+    $metadataKeys = ['version', 'rates', 'label', 'labels', 'title'];
+
     $result = [];
     foreach ($detectedRates as $rate) {
-        $rateInput = $input[$rate] ?? null;
+        $normalizedRateKey = strtolower((string) $rate);
+        if (in_array($normalizedRateKey, $metadataKeys, true)) {
+            continue;
+        }
+        $rateInput = $input[$rate] ?? ($input[$normalizedRateKey] ?? null);
         $ivaAccount = '';
         $generalAccount = '';
         $label = '';

--- a/custom_fields.php
+++ b/custom_fields.php
@@ -109,7 +109,12 @@ if ($isLayout) {
         const grid = GridStack.init({float: true});
         grid.on('change', function(event, items) {
             items.forEach(item => {
-                const fieldId = item.id || (item.el ? item.el.getAttribute('gs-id') : '');
+                // GridStack emits a temporary "dummy" node without any of our
+                // metadata while dragging items. That placeholder should not be
+                // persisted, so rely solely on the DOM element's gs-id
+                // attribute (when available) instead of the library-provided
+                // identifier.
+                const fieldId = item.el ? item.el.getAttribute('gs-id') : '';
                 if (!fieldId) {
                     return;
                 }


### PR DESCRIPTION
## Summary
- ignore metadata keys like `label` and `rates` when normalising stored VAT accounts so placeholder entries are skipped
- filter those metadata keys on the classification modal so junk rows are not created for them

## Testing
- php -l contabilidade/functions.php

------
https://chatgpt.com/codex/tasks/task_e_68d430aaf2e48320865415a6e7fa7c54