### PR TITLE
Persist removal of VAT rate rows

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -184,6 +184,7 @@ window.addEventListener('load', function() {
     var currentCostCenters = {};
     var storedRowRates = {};
     var storedDefaultRates = {};
+    var removedRates = {};
     var dynamicRateCounter = 0;
     var defaultRateLabels = {
         '0': '0%',
@@ -264,6 +265,9 @@ window.addEventListener('load', function() {
         info.rate = rate;
         info.key = rate;
         rateInputs[rate] = info;
+        if (Object.prototype.hasOwnProperty.call(removedRates, rate)) {
+            delete removedRates[rate];
+        }
         if (!Object.prototype.hasOwnProperty.call(currentCostCenters, rate)) {
             currentCostCenters[rate] = '';
         }
@@ -305,11 +309,15 @@ window.addEventListener('load', function() {
             info.row.parentNode.removeChild(info.row);
         }
         delete rateInputs[rate];
-        if (!Object.prototype.hasOwnProperty.call(storedRowRates, rate)) {
-            delete currentCostCenters[rate];
-        }
-        if (defaultRates.indexOf(rate) === -1 && !Object.prototype.hasOwnProperty.call(storedRowRates, rate)) {
+        delete currentCostCenters[rate];
+        if (defaultRates.indexOf(rate) === -1 || !Object.prototype.hasOwnProperty.call(storedRowRates, rate)) {
             delete currentRateData[rate];
+        }
+        if (
+            Object.prototype.hasOwnProperty.call(storedRowRates, rate) ||
+            Object.prototype.hasOwnProperty.call(storedDefaultRates, rate)
+        ) {
+            removedRates[rate] = true;
         }
     }
 
@@ -706,6 +714,7 @@ window.addEventListener('load', function() {
         });
         rateInputs = {};
         dynamicRateCounter = 0;
+        removedRates = {};
     }
 
     function restoreSavedRates() {
@@ -787,6 +796,7 @@ window.addEventListener('load', function() {
         storedRowRates = {};
         storedDefaultRates = {};
         currentCostCenters = {};
+        removedRates = {};
 
         currentRateData = parseJsonAttribute(btn, 'data-rates') || {};
         if (!currentRateData || typeof currentRateData !== 'object') {
@@ -838,6 +848,7 @@ window.addEventListener('load', function() {
 
                 storedRowRates = (res.row_rates && typeof res.row_rates === 'object') ? res.row_rates : {};
                 storedDefaultRates = (res.rates && typeof res.rates === 'object') ? res.rates : {};
+                removedRates = {};
 
                 Object.keys(storedRowRates).forEach(function(rate) {
                     if (!currentRateData[rate]) {
@@ -928,6 +939,10 @@ window.addEventListener('load', function() {
                 };
             });
 
+            var removedPayload = Object.keys(removedRates).filter(function(rate) {
+                return removedRates[rate];
+            });
+
             var costCentersPayload = getCostCenterValues();
             var body = new URLSearchParams({
                 id: currentBtn.getAttribute('data-id') || '',
@@ -935,6 +950,7 @@ window.addEventListener('load', function() {
                 B: currentBtn.getAttribute('data-acquirer') || '',
                 D: currentBtn.getAttribute('data-doctype') || '',
                 rates: JSON.stringify(ratesPayload),
+                removed_rates: JSON.stringify(removedPayload),
                 cost_centers: JSON.stringify(costCentersPayload),
                 csrf_token: csrfInput.value
             });
@@ -992,6 +1008,10 @@ window.addEventListener('load', function() {
                     });
                 }
 
+                removedPayload.forEach(function(rate) {
+                    delete currentRateData[rate];
+                });
+
                 Object.keys(currentRateData).forEach(function(rate) {
                     if (!rateInputs[rate] && defaultRates.indexOf(rate) === -1 && !Object.prototype.hasOwnProperty.call(storedRowRates, rate)) {
                         delete currentRateData[rate];
@@ -1001,6 +1021,7 @@ window.addEventListener('load', function() {
                 currentBtn.setAttribute('data-rates', JSON.stringify(currentRateData));
                 currentBtn.setAttribute('data-cost-centers', JSON.stringify(currentCostCenters));
                 updateButtonClass(currentBtn);
+                removedRates = {};
                 if (classifyModal) {
                     classifyModal.hide();
                 }

--- a/contabilidade/save-analysis.php
+++ b/contabilidade/save-analysis.php
@@ -336,6 +336,24 @@ if ($action === 'get') {
         }
         $submittedRates = sanitizeAccountInput($ratesData);
 
+        $removedJson = $_POST['removed_rates'] ?? '[]';
+        $removedRates = json_decode($removedJson, true);
+        if (!is_array($removedRates)) {
+            $removedRates = [];
+        }
+        $removedRates = array_values(array_filter(array_map(
+            static function ($rate) {
+                if (is_string($rate) || is_numeric($rate)) {
+                    $string = trim((string) $rate);
+                    if ($string !== '') {
+                        return $string;
+                    }
+                }
+                return null;
+            },
+            $removedRates
+        )));
+
         $costCentersJson = $_POST['cost_centers'] ?? '';
         $costCentersData = [];
         if ($costCentersJson !== '') {
@@ -365,6 +383,10 @@ if ($action === 'get') {
 
         $rowAccounts = mergeAccountingAccounts($existingRow, $submittedRates);
         $classAccounts = mergeAccountingAccounts($existingClass, $submittedRates);
+
+        foreach ($removedRates as $rate) {
+            unset($rowAccounts[$rate], $classAccounts[$rate], $costCentersData[$rate]);
+        }
 
         $serializedRow = serializeAccountingAccounts($rowAccounts);
         $serializedClass = serializeAccountingAccounts($classAccounts);


### PR DESCRIPTION
## Summary
- track removed VAT rate rows in the classification modal and include them in the save payload
- clear local caches after persistence so removed VAT rows stay hidden
- drop removed VAT rates and cost centres server-side before serialising accounts

## Testing
- php -l contabilidade/save-analysis.php

------
https://chatgpt.com/codex/tasks/task_e_68d4635f59a483209ef44db603ac3e55