### PR TITLE
Calcular IVA dinamicamente ao adicionar linhas

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -835,10 +835,22 @@ window.addEventListener('load', function() {
             }
         }
         if (info.base && info.iva) {
-            var hasBaseValue = info.base.value && info.base.value.trim() !== '';
-            var hasIvaValue = info.iva.value && info.iva.value.trim() !== '';
-            if (hasBaseValue && !hasIvaValue) {
-                recalculateVatForRate(rate);
+            var baseValue = info.base.value !== undefined ? String(info.base.value).trim() : '';
+            if (baseValue === '') {
+                if (info.iva.value !== '') {
+                    info.iva.value = '';
+                }
+                currentRateData[rate].iva = '';
+            } else {
+                var baseNumber = parseDecimalValue(info.base.value);
+                var percentage = getRatePercentage(rate);
+                if (baseNumber !== null && percentage !== null) {
+                    var expectedIva = formatDecimalValue(baseNumber * (percentage / 100));
+                    if (info.iva.value !== expectedIva) {
+                        info.iva.value = expectedIva;
+                    }
+                    currentRateData[rate].iva = expectedIva;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- recalculates the IVA amount when populating VAT rows by multiplying the base by the configured rate percentage
- clears the IVA field when the base value is removed to keep the totals consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba8913db08320a9c2ff34f132d227