### PR TITLE
Add CTB import button to classification page

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -12,6 +12,19 @@ window.addEventListener('load', function() {
         }
     }
 
+    function showSuccess(message) {
+        if (window.PNotify) {
+            new PNotify({
+                title: 'Sucesso',
+                text: message,
+                type: 'success',
+                styling: 'bootstrap3'
+            });
+        } else {
+            alert(message);
+        }
+    }
+
     function fetchJson(url, options) {
         return fetch(url, options).then(function(res) {
             return res.text().then(function(text) {
@@ -51,6 +64,7 @@ window.addEventListener('load', function() {
         importType = 1;
     }
     var showLineCostCenter = importType === 1;
+    var importCtbButton = null;
     var table = $('#classify-table').DataTable({
         serverSide: true,
         processing: true,
@@ -67,6 +81,96 @@ window.addEventListener('load', function() {
             { targets: [ -1, -2 ], orderable: false, searchable: false }
         ]
     });
+
+    function updateImportButtonState() {
+        if (!importCtbButton || importType !== 1) {
+            return;
+        }
+        if (importCtbButton.data('loading')) {
+            importCtbButton.prop('disabled', true);
+            return;
+        }
+        var readyCount = $('#classify-table').find('.classify-row.btn-success').length;
+        importCtbButton.prop('disabled', readyCount === 0);
+    }
+
+    function handleImportCtbClick() {
+        if (!importCtbButton || importCtbButton.data('loading')) {
+            return;
+        }
+        var ids = [];
+        $('#classify-table').find('.classify-row.btn-success').each(function() {
+            var id = this.getAttribute('data-id');
+            if (id) {
+                ids.push(id);
+            }
+        });
+        if (ids.length === 0) {
+            showError('Não existem linhas prontas para importar.');
+            return;
+        }
+        importCtbButton.data('loading', true);
+        importCtbButton.prop('disabled', true);
+        var payload = {
+            ids: ids,
+            import_type: importType,
+            csrf_token: csrfInput ? csrfInput.value : ''
+        };
+        fetchJson('contabilidade/classificacao-importacao/import-ctb', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        })
+            .then(function(res) {
+                if (res && res.csrf_token && csrfInput) {
+                    csrfInput.value = res.csrf_token;
+                }
+                if (!res || !res.success) {
+                    var error = (res && res.error) ? res.error : 'Erro ao importar';
+                    throw new Error(error);
+                }
+                showSuccess('Importação CTB concluída com sucesso.');
+                table.ajax.reload(null, false);
+            })
+            .catch(function(err) {
+                showError(err.message || 'Erro ao importar');
+            })
+            .finally(function() {
+                if (importCtbButton) {
+                    importCtbButton.data('loading', false);
+                }
+                updateImportButtonState();
+            });
+    }
+
+    function ensureImportButton() {
+        if (importType !== 1) {
+            return;
+        }
+        var wrapper = $('#classify-table_wrapper');
+        if (!wrapper.length) {
+            return;
+        }
+        var paginate = wrapper.find('div.dataTables_paginate');
+        if (!paginate.length) {
+            return;
+        }
+        if (!importCtbButton) {
+            importCtbButton = $('<button type="button" class="btn btn-sm btn-primary me-2" id="importCtbButton">Importar Ctb</button>');
+            importCtbButton.on('click', handleImportCtbClick);
+        }
+        if (!importCtbButton.parent().length) {
+            importCtbButton.insertBefore(paginate);
+        }
+        updateImportButtonState();
+    }
+
+    table.on('draw', function() {
+        ensureImportButton();
+        updateImportButtonState();
+    });
+
+    ensureImportButton();
 
     function decodeHtmlEntities(value) {
         if (typeof value !== 'string' || value.indexOf('&') === -1) {
@@ -217,6 +321,8 @@ window.addEventListener('load', function() {
         } else {
             btn.classList.add('btn-secondary');
         }
+
+        updateImportButtonState();
 
     }
 

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -12,6 +12,11 @@ $pdo = getPDO();
 $action = $_GET['action'] ?? '';
 $importType = (int)($_GET['import_type'] ?? 1);
 
+function import_CTB(PDO $pdo, array $ids, int $importType): bool {
+    // Placeholder implementation. Replace with real import logic when available.
+    return true;
+}
+
 function prepareImportRow(array $row): array {
     $accounts = normalizeAccountingAccounts($row['account'] ?? '');
     $summaries = computeImportRateSummaries($row);
@@ -37,6 +42,67 @@ function prepareImportRow(array $row): array {
     }
 
     return $row;
+}
+
+if ($action === 'import_ctb' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    header('Content-Type: application/json; charset=utf-8');
+
+    $rawBody = file_get_contents('php://input');
+    $payload = json_decode($rawBody ?? '', true);
+
+    if (!is_array($payload)) {
+        echo json_encode([
+            'success' => false,
+            'error' => 'Pedido inválido',
+            'csrf_token' => generateCsrfToken(true)
+        ]);
+        exit;
+    }
+
+    $csrfToken = (string)($payload['csrf_token'] ?? '');
+    if ($csrfToken === '' || !validateCsrfToken($csrfToken)) {
+        echo json_encode([
+            'success' => false,
+            'error' => 'Token CSRF inválido',
+            'csrf_token' => generateCsrfToken(true)
+        ]);
+        exit;
+    }
+
+    $ids = [];
+    foreach ($payload['ids'] ?? [] as $value) {
+        if (is_numeric($value)) {
+            $id = (int)$value;
+            if ($id > 0) {
+                $ids[$id] = $id;
+            }
+        }
+    }
+    $ids = array_values($ids);
+
+    if (empty($ids)) {
+        echo json_encode([
+            'success' => false,
+            'error' => 'Nenhuma linha seleccionada para importar',
+            'csrf_token' => generateCsrfToken(true)
+        ]);
+        exit;
+    }
+
+    $requestedImportType = (int)($payload['import_type'] ?? $importType);
+    if ($requestedImportType <= 0) {
+        $requestedImportType = 1;
+    }
+
+    $success = import_CTB($pdo, $ids, $requestedImportType);
+
+    echo json_encode([
+        'success' => (bool)$success,
+        'ids' => $ids,
+        'import_type' => $requestedImportType,
+        'csrf_token' => generateCsrfToken()
+    ]);
+    exit;
 }
 
 if ($action === 'data') {

--- a/router.php
+++ b/router.php
@@ -177,6 +177,14 @@ switch (true) {
         $_GET['action'] = 'data';
         require __DIR__ . '/contabilidade/classificacao-importacao.php';
         break;
+    case in_array($path, [
+        'contabilidade/classificacao-importacao/import-ctb',
+        'contabilidade/classificacao-importacao/import_ctb',
+        'contabilidade/classificacao-importacao-import-ctb.php'
+    ], true):
+        $_GET['action'] = 'import_ctb';
+        require __DIR__ . '/contabilidade/classificacao-importacao.php';
+        break;
     case $path === 'contabilidade/classificacao-importacao':
         require __DIR__ . '/contabilidade/classificacao-importacao.php';
         break;


### PR DESCRIPTION
## Summary
- add an "Importar Ctb" button to the classificação de importação table that collects ready rows and posts them to the server
- add a placeholder PHP handler and router entry for the new CTB import endpoint

## Testing
- php -l contabilidade/classificacao-importacao.php

------
https://chatgpt.com/codex/tasks/task_e_68dbbf87dd148320b063d6793bd2c781