### PR TITLE
Ensure Importar Ctb button visible

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -64,8 +64,7 @@ window.addEventListener('load', function() {
         importType = 1;
     }
     var showLineCostCenter = importType === 1;
-    var importCtbButton = null;
-    var importCtbWrapper = null;
+    var importCtbButton = $('#importCtbButton');
 
     var table = $('#classify-table').DataTable({
         serverSide: true,
@@ -85,7 +84,7 @@ window.addEventListener('load', function() {
     });
 
     function updateImportButtonState() {
-        if (!importCtbButton || importType !== 1) {
+        if (!importCtbButton.length || importType !== 1) {
             return;
         }
         if (importCtbButton.data('loading')) {
@@ -97,7 +96,7 @@ window.addEventListener('load', function() {
     }
 
     function handleImportCtbClick() {
-        if (!importCtbButton || importCtbButton.data('loading')) {
+        if (!importCtbButton.length || importCtbButton.data('loading')) {
             return;
         }
         var ids = [];
@@ -138,42 +137,22 @@ window.addEventListener('load', function() {
                 showError(err.message || 'Erro ao importar');
             })
             .finally(function() {
-                if (importCtbButton) {
+                if (importCtbButton.length) {
                     importCtbButton.data('loading', false);
                 }
                 updateImportButtonState();
             });
     }
 
-    function ensureImportButton() {
-        if (importType !== 1) {
-            return;
-        }
-        var wrapper = $('#classify-table_wrapper');
-        if (!wrapper.length) {
-            return;
-        }
-        var paginate = wrapper.find('div.dataTables_paginate');
-        if (!paginate.length) {
-            return;
-        }
-        if (!importCtbButton) {
-            importCtbButton = $('<button type="button" class="btn btn-sm btn-primary me-2" id="importCtbButton">Importar Ctb</button>');
-            importCtbButton.on('click', handleImportCtbClick);
-        }
-
-        if (!importCtbButton.parent().length) {
-            importCtbButton.insertBefore(paginate);
-        }
-        updateImportButtonState();
+    if (importCtbButton.length) {
+        importCtbButton.on('click', handleImportCtbClick);
     }
 
     table.on('draw', function() {
-        ensureImportButton();
         updateImportButtonState();
     });
 
-    ensureImportButton();
+    updateImportButtonState();
 
     function decodeHtmlEntities(value) {
         if (typeof value !== 'string' || value.indexOf('&') === -1) {

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -235,6 +235,11 @@ require_once __DIR__ . '/../header.php';
 <input type="hidden" id="import_type" value="<?= htmlspecialchars($importType); ?>">
 <div class="row mb-3">
     <div class="col-12">
+        <?php if ($importType === 1): ?>
+        <div class="d-flex justify-content-end mb-2">
+            <button type="button" class="btn btn-sm btn-primary" id="importCtbButton" disabled>Importar Ctb</button>
+        </div>
+        <?php endif; ?>
         <table id="classify-table" class="table table-striped">
             <thead>
                 <tr>


### PR DESCRIPTION
## Summary
- render the Importar Ctb action button directly on the classificação importação page for CTB imports so it is always visible
- update the client-side logic to bind to the static button and keep its enabled state in sync with ready rows

## Testing
- php -l contabilidade/classificacao-importacao.php

------
https://chatgpt.com/codex/tasks/task_e_68dbc3f5bd648320b3cd53fb6b671f6f