### PR TITLE
Move Importar Ctb button into DataTable toolbar

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -83,6 +83,31 @@ window.addEventListener('load', function() {
         ]
     });
 
+    function moveImportButtonToFilter() {
+        if (!importCtbButton.length || importType !== 1) {
+            return;
+        }
+
+        var container = table.table().container();
+        if (!container) {
+            return;
+        }
+
+        var filter = $(container).find('div.dataTables_filter');
+        if (!filter.length || filter.find('#importCtbButton').length) {
+            return;
+        }
+
+        filter.addClass('d-flex align-items-center gap-2 justify-content-end flex-wrap');
+
+        var label = filter.find('label');
+        if (label.length) {
+            label.addClass('mb-0 d-flex align-items-center gap-2');
+        }
+
+        importCtbButton.prependTo(filter);
+    }
+
     function updateImportButtonState() {
         if (!importCtbButton.length || importType !== 1) {
             return;
@@ -150,9 +175,11 @@ window.addEventListener('load', function() {
 
     table.on('draw', function() {
         updateImportButtonState();
+        moveImportButtonToFilter();
     });
 
     updateImportButtonState();
+    moveImportButtonToFilter();
 
     function decodeHtmlEntities(value) {
         if (typeof value !== 'string' || value.indexOf('&') === -1) {

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -236,7 +236,7 @@ require_once __DIR__ . '/../header.php';
 <div class="row mb-3">
     <div class="col-12">
         <?php if ($importType === 1): ?>
-        <div class="d-flex justify-content-end mb-2">
+        <div id="importCtbButtonWrapper" class="d-none">
             <button type="button" class="btn btn-sm btn-primary" id="importCtbButton" disabled>Importar Ctb</button>
         </div>
         <?php endif; ?>


### PR DESCRIPTION
## Summary
- move the Importar Ctb action button into the DataTable toolbar ahead of the Procurar search field
- adjust the template wrapper to hide the placeholder container once the button is relocated

## Testing
- php -l contabilidade/classificacao-importacao.php

------
https://chatgpt.com/codex/tasks/task_e_68dbc64de19c83209edd1eb61d8f51a2