### PR TITLE
Fix Importar Ctb button visibility in DataTable toolbar

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -65,6 +65,7 @@ window.addEventListener('load', function() {
     }
     var showLineCostCenter = importType === 1;
     var importCtbButton = $('#importCtbButton');
+    var importCtbWrapper = $('#importCtbButtonWrapper');
 
     var table = $('#classify-table').DataTable({
         serverSide: true,
@@ -82,6 +83,51 @@ window.addEventListener('load', function() {
             { targets: [ -1, -2 ], orderable: false, searchable: false }
         ]
     });
+
+    function hideImportButtonWrapper() {
+        if (importCtbWrapper.length) {
+            importCtbWrapper.addClass('d-none').attr('aria-hidden', 'true');
+        }
+    }
+
+    function showImportButtonWrapper() {
+        if (importCtbWrapper.length) {
+            importCtbWrapper.removeClass('d-none').removeAttr('aria-hidden');
+        }
+    }
+
+    function moveImportButtonToFilter() {
+        if (!importCtbButton.length || importType !== 1) {
+            showImportButtonWrapper();
+            return;
+        }
+
+        var container = table.table().container();
+        if (!container) {
+            showImportButtonWrapper();
+            return;
+        }
+
+        var filter = $(container).find('div.dataTables_filter');
+        if (!filter.length) {
+            showImportButtonWrapper();
+            return;
+        }
+
+        filter.addClass('d-flex align-items-center justify-content-end flex-wrap gap-2');
+
+        var label = filter.find('label');
+        if (label.length) {
+            label.addClass('mb-0 d-flex align-items-center flex-wrap gap-2');
+            if (!label.find('#importCtbButton').length) {
+                importCtbButton.prependTo(label);
+            }
+        } else if (!filter.find('#importCtbButton').length) {
+            importCtbButton.prependTo(filter);
+        }
+
+        hideImportButtonWrapper();
+    }
 
     function updateImportButtonState() {
         if (!importCtbButton.length || importType !== 1) {
@@ -150,9 +196,11 @@ window.addEventListener('load', function() {
 
     table.on('draw', function() {
         updateImportButtonState();
+        moveImportButtonToFilter();
     });
 
     updateImportButtonState();
+    moveImportButtonToFilter();
 
     function decodeHtmlEntities(value) {
         if (typeof value !== 'string' || value.indexOf('&') === -1) {

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -236,7 +236,7 @@ require_once __DIR__ . '/../header.php';
 <div class="row mb-3">
     <div class="col-12">
         <?php if ($importType === 1): ?>
-        <div class="d-flex justify-content-end mb-2">
+        <div id="importCtbButtonWrapper" class="d-flex justify-content-end mb-2">
             <button type="button" class="btn btn-sm btn-primary" id="importCtbButton" disabled>Importar Ctb</button>
         </div>
         <?php endif; ?>


### PR DESCRIPTION
## Summary
- keep the Importar Ctb button visible in its original wrapper so it always renders even if JavaScript fails to relocate it
- update the relocation script to move the button inside the DataTable filter label, hide the wrapper only after a successful move, and restore the wrapper when the toolbar is unavailable

## Testing
- php -l contabilidade/classificacao-importacao.php

------
https://chatgpt.com/codex/tasks/task_e_68dbc64de19c83209edd1eb61d8f51a2