### PR TITLE
Use ERP webservice URL for CTB import

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -63,6 +63,17 @@ window.addEventListener('load', function() {
     if (isNaN(importType)) {
         importType = 1;
     }
+    var erpWebserviceUrl = '';
+    if (typeof window.erpWebserviceUrl === 'string') {
+        erpWebserviceUrl = window.erpWebserviceUrl;
+    }
+
+    function buildImportCtbUrl() {
+        if (typeof erpWebserviceUrl === 'string' && erpWebserviceUrl.trim() !== '') {
+            return erpWebserviceUrl.replace(/\/+$/, '') + '/ctb/import-ctb';
+        }
+        return '';
+    }
     var showLineCostCenter = importType === 1;
     var importCtbButton = $('#importCtbButton');
     var importCtbWrapper = $('#importCtbButtonWrapper');
@@ -181,10 +192,21 @@ window.addEventListener('load', function() {
         var payload = {
             ids: ids,
             import_type: importType,
-            csrf_token: csrfInput ? csrfInput.value : ''
+            csrf_token: csrfInput ? csrfInput.value : '',
+            act: 'import-ctb'
         };
         debugJson('Import CTB request payload', payload);
-        fetchJson('contabilidade/classificacao-importacao/import-ctb', {
+        var importUrl = buildImportCtbUrl();
+        if (!importUrl) {
+            if (typeof window.console !== 'undefined') {
+                console.error('[Classificação] URL do webservice ERP não configurada.');
+            }
+            showError('URL do webservice ERP não está configurada.');
+            importCtbButton.data('loading', false);
+            updateImportButtonState();
+            return;
+        }
+        fetchJson(importUrl, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload)

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -11,6 +11,7 @@ $useDropzone = false;
 $pdo = getPDO();
 $action = $_GET['action'] ?? '';
 $importType = (int)($_GET['import_type'] ?? 1);
+$currentErpWebserviceUrl = trim((string) getSetting('erp_webservice_url', ''));
 
 function import_CTB(PDO $pdo, array $ids, int $importType): array {
     $result = [
@@ -153,6 +154,8 @@ function prepareImportRow(array $row): array {
 
 if ($action === 'import_ctb' && $_SERVER['REQUEST_METHOD'] === 'POST') {
     header('Content-Type: application/json; charset=utf-8');
+
+    $_POST['act'] = 'import-ctb';
 
     $rawBody = file_get_contents('php://input');
     $payload = json_decode($rawBody ?? '', true);
@@ -573,6 +576,12 @@ require_once __DIR__ . '/../header.php';
         </div>
     </div>
 </div>
+<script>
+    window.erpWebserviceUrl = <?= json_encode(
+        $currentErpWebserviceUrl,
+        JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+    ); ?>;
+</script>
 <script src="assets/js/classificacao_importacao.js"></script>
 <?php require_once __DIR__ . '/../footer.php'; ?>
 


### PR DESCRIPTION
## Summary
- expose the configured ERP webservice URL to the CTB import UI
- send import requests to the ERP webservice endpoint with the required act flag
- ensure the backend request handler sets the expected act value when processing imports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbf974d9248320b12765b3152e215c