### PR TITLE
Fix CORS issue on CTB import by using local proxy endpoint

### DIFF
--- a/assets/js/classificacao_importacao.js
+++ b/assets/js/classificacao_importacao.js
@@ -68,11 +68,25 @@ window.addEventListener('load', function() {
         erpWebserviceUrl = window.erpWebserviceUrl;
     }
 
+    var importCtbRelativeUrl = 'contabilidade/classificacao-importacao/import-ctb';
+
     function buildImportCtbUrl() {
         if (typeof erpWebserviceUrl === 'string' && erpWebserviceUrl.trim() !== '') {
-            return erpWebserviceUrl.replace(/\/+$/, '') + '/ctb/import-ctb';
+            try {
+                var parsedUrl = new URL(erpWebserviceUrl, window.location.href);
+                if (parsedUrl.origin === window.location.origin) {
+                    return parsedUrl.href.replace(/\/+$/, '') + '/ctb/import-ctb';
+                }
+                if (typeof window.console !== 'undefined' && typeof window.console.warn === 'function') {
+                    window.console.warn('[Classificação] ERP webservice URL com origem diferente detectada. A usar endpoint local para evitar problemas de CORS.');
+                }
+            } catch (urlError) {
+                if (typeof window.console !== 'undefined' && typeof window.console.warn === 'function') {
+                    window.console.warn('[Classificação] ERP webservice URL inválida. A usar endpoint local.', urlError);
+                }
+            }
         }
-        return '';
+        return importCtbRelativeUrl;
     }
     var showLineCostCenter = importType === 1;
     var importCtbButton = $('#importCtbButton');


### PR DESCRIPTION
## Summary
- update the CTB import button to call the local classificacao-importacao endpoint instead of the remote ERP URL
- add defensive logging and fallback behaviour when the configured ERP URL is unusable to avoid browser CORS errors

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dbfc2191bc8320ba5e41d6e83002e5