### PR TITLE
Atualizar envio de dados do webservice Importar CTB

### DIFF
--- a/contabilidade/IMPORTAR_CTB.md
+++ b/contabilidade/IMPORTAR_CTB.md
@@ -1,0 +1,14 @@
+# Webservice "Importar CTB"
+
+Este projeto comunica com o ERP através da função [`import_CTB`](classificacao-importacao.php). A chamada ao botão "Importar CTB" dispara um pedido HTTP `POST` para o endpoint configurado em `erp_webservice_url` e envia, no mesmo payload, os dados completos de cada documento seleccionado.
+
+O payload enviado para o ERP é construído em [`contabilidade/classificacao-importacao.php`](classificacao-importacao.php) e inclui os seguintes campos de formulário:
+
+- `tp = importMovim`
+- `act = importMovim`
+- `accao = movimentos`
+- `import_type` com o tipo de importação activo
+- `document_ids` com a lista de IDs seleccionados
+- `documents` com um JSON que contém todas as colunas de cada linha existente na tabela `accounting_imports` (incluindo, quando presente, o conteúdo estruturado de `line_items`).
+
+Ou seja, ao chamar o webservice "Importar CTB" são reenviados todos os dados disponíveis no MySQL para cada documento seleccionado, permitindo que o ERP trate a importação com base na informação integral (emitente, adquirente, totais, referências, centro de custo, contas, ficheiro associado, etc.).

--- a/contabilidade/classificacao-importacao.php
+++ b/contabilidade/classificacao-importacao.php
@@ -56,10 +56,48 @@ function import_CTB(PDO $pdo, array $ids, int $importType): array {
         $headers[] = 'X-API-KEY: ' . $token;
     }
 
+    $placeholders = implode(', ', array_fill(0, count($ids), '?'));
+    $documentSql = 'SELECT * FROM accounting_imports WHERE import_type = ? AND id IN (' . $placeholders . ') ORDER BY id';
+    $documentStmt = $pdo->prepare($documentSql);
+    $documentStmt->bindValue(1, $importType, PDO::PARAM_INT);
+    foreach ($ids as $index => $id) {
+        $documentStmt->bindValue($index + 2, $id, PDO::PARAM_INT);
+    }
+
+    $documentStmt->execute();
+    $documents = $documentStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    if (empty($documents)) {
+        $result['error'] = 'Nenhum documento encontrado para importar.';
+        logErpMessage('Importação CTB abortada: nenhum documento encontrado para os IDs ' . implode(', ', $ids));
+        return $result;
+    }
+
+    $documentsPayload = array_map(static function (array $document): array {
+        if (array_key_exists('line_items', $document)) {
+            $decodedLineItems = json_decode((string) $document['line_items'], true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $document['line_items'] = $decodedLineItems;
+            }
+        }
+
+        return $document;
+    }, $documents);
+
+    $documentsJson = json_encode($documentsPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    if ($documentsJson === false) {
+        $result['error'] = 'Falha ao preparar os documentos para envio.';
+        logErpMessage('Erro ao codificar JSON dos documentos CTB: ' . json_last_error_msg());
+        return $result;
+    }
+
     $postPayload = [
         'tp' => 'importMovim',
-        'act' => 'movimentos',
+        'act' => 'importMovim',
         'accao' => 'movimentos',
+        'import_type' => $importType,
+        'document_ids' => implode(',', $ids),
+        'documents' => $documentsJson,
     ];
 
 


### PR DESCRIPTION
## Summary
- ajustar o webservice Importar CTB para enviar o parâmetro act=importMovim
- incluir no payload JSON com todos os dados dos documentos selecionados
- atualizar a documentação para refletir o novo formato do pedido

## Testing
- php -l contabilidade/classificacao-importacao.php

------
https://chatgpt.com/codex/tasks/task_e_68dc04b6239083208e91a49bd053f550