### PR TITLE
Fix session secure cookie detection to keep sessions active

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -110,11 +110,20 @@ function startSession() {
     if (session_status() === PHP_SESSION_NONE) {
         $params = session_get_cookie_params();
 
+        $isHttps = false;
+        if (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off') {
+            $isHttps = true;
+        } elseif (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+            $isHttps = strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https';
+        } elseif (!empty($_SERVER['SERVER_PORT'])) {
+            $isHttps = (int)$_SERVER['SERVER_PORT'] === 443;
+        }
+
         $cookieParams = [
             'lifetime' => $params['lifetime'],
             'path'     => $params['path'],
             'domain'   => $params['domain'],
-            'secure'   => isset($_SERVER['HTTPS']),
+            'secure'   => $isHttps,
             'httponly' => true,
         ];
 


### PR DESCRIPTION
## Summary
- detect HTTPS correctly before flagging the session cookie as secure
- ensure the session cookie is still sent on HTTP deployments so logins persist

## Testing
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_690a1a2eea3c832084b21b85cbee7c88